### PR TITLE
feat: add CODEOWNERS rules for protected metadata files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,12 @@ dprint.json              @awslabs/startups-admins
 .semgrep.yaml            @awslabs/startups-admins
 .markdownlint-cli2.yaml  @awslabs/startups-admins
 
+# Protected metadata files - admin approval for identity changes
+**/OWNERS.yaml           @awslabs/startups-admins
+**/OWNERS.yml            @awslabs/startups-admins
+**/.claude-plugin/       @awslabs/startups-admins
+**/.cursor-plugin/       @awslabs/startups-admins
+**/SKILL.md              @awslabs/startups-admins
+
 # Team folders
 /migrate/                @awslabs/startups-migrate


### PR DESCRIPTION
Require @awslabs/startups-admins approval for changes to:
- OWNERS.yaml/yml at any path
- .claude-plugin/ and .cursor-plugin/ directories
- SKILL.md files

Works as a second layer of defense alongside the PR guardrails workflow.

## Description

<!-- Brief description of the changes -->

## Type of Change

- [ ] New plugin/power/tool
- [ ] Bug fix
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Guardrail/CI update

## Team Folder

<!-- Which top-level folder does this PR affect? -->

- [ ] `migrate/`
- [ ] Other: ___

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My changes do not include hardcoded secrets, credentials, or internal-only content
- [ ] I have run `mise run build` locally and it passes
- [ ] I have updated documentation if needed
- [ ] My changes are scoped to my team's folder only
