### PR TITLE
fix: compute defaults, AI guardrails, Mantle limits, and gpt-oss path

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/compute.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/compute.md
@@ -41,8 +41,7 @@
 
 - **Kubernetes orchestration explicitly required** (`kubernetes = "eks-managed"` or `"eks-or-ecs"` in `preferences.json`) → EKS
 - **Default / no explicit K8s preference** (`kubernetes = "ecs-fargate"` or absent):
-  - If `gcp-resource-inventory.json` contains `google_container_cluster` → EKS (IaC signal shows K8s workload)
-  - Otherwise → **Fargate** (no K8s signal; lower-ops default)
+  - → **Fargate** (absent kubernetes preference resolves to Fargate, not EKS — teams that want EKS answer A or B in Clarify)
 
 ## 6-Criteria Rubric
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-ai.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-ai.md
@@ -297,6 +297,7 @@ Before presenting Category G questions, show:
 
 **Auto-detect signals** — recommend default based on `agentic_profile.framework`:
 
+- `gateway_type` is `"llm_router"` (LiteLLM or OpenRouter detected) → Default to **A (retarget)**. These users are already abstracted from the model provider — migration is a config change (swap model IDs), not a code rewrite. Set `migration_approach: "retarget"` automatically and skip Q23 unless the user explicitly asks to evaluate Harness or Strands.
 - `langgraph`, `crewai`, `autogen` → Default to A (retarget). These frameworks support Bedrock as a model provider with minimal code changes.
 - `openai_agents` → Surface all options. OpenAI Agents SDK is tightly coupled to OpenAI API; retarget is harder. Note partial retarget (HTTP-compatible routing to Bedrock) as a bridge.
 - `strands` → Already AWS-native. Recommend B (Harness) for managed deployment or note "already on target framework."

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-ai.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-ai.md
@@ -307,7 +307,7 @@ _Skip when:_ Auto-detection fully resolves AND user has no preference signal. Us
 > Your agent system can migrate to AWS in different ways, each with different effort and risk:
 >
 > A) **Retarget** — Keep your current framework ([framework name]), swap the model layer to Bedrock. Fastest path, lowest risk. Your orchestration code stays the same.
-> B) **AgentCore Harness** — Declare your agent as configuration (model + tools + prompt). Get managed runtime, memory, identity, and observability. Good for simpler agents or incremental migration.
+> B) **AgentCore Harness** — Declare your agent as configuration (model + tools + prompt). Get managed runtime, memory, identity, and observability. Good for simpler agents or incremental migration. _(Preview — 4 regions: us-east-1, us-west-2, eu-central-1, ap-southeast-2)_
 > C) **Strands native** — Rewrite orchestration using AWS Strands SDK on AgentCore. Most AWS-integrated, highest effort. Best for teams wanting full AWS-native multi-agent capabilities.
 > D) **I'm not sure** — Help me decide based on my workload.
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-compute.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-compute.md
@@ -75,11 +75,11 @@ E -> same as default — see IaC-signal default rule below
 
 **Default (IaC-signal driven):**
 
-- If `gcp-resource-inventory.json` contains `google_container_cluster` resources → Default **B** (`kubernetes: "eks-or-ecs"`). Discovery shows the team is running Kubernetes; defaulting to Fargate produces a wrong first-pass architecture for users who skip questions.
+- If `gcp-resource-inventory.json` contains `google_container_cluster` resources → Default **C** (`kubernetes: "ecs-fargate"`). Teams that answer "I don't know" are better served by Fargate's lower operational overhead; EKS remains available via explicit answers A and B.
 - If no `google_container_cluster` in inventory (Cloud Run, Cloud Functions, or billing-only) → Default **C** (`kubernetes: "ecs-fargate"`). No Kubernetes signal; Fargate is the lower-ops starting point.
 - If inventory is absent (billing-only mode) → Default **C** (`kubernetes: "ecs-fargate"`).
 
-**Rationale:** The default follows what discovery found, not a blanket product preference. Teams running GKE who answer E ("I don't know") are more likely to want EKS than Fargate — they already operate Kubernetes. Teams migrating from Cloud Run who answer E have no Kubernetes investment to preserve and are better served by Fargate. EKS and Fargate remain fully available via explicit answers A–C regardless of default.
+**Rationale:** Teams that answer E ("I don't know") have not expressed a Kubernetes preference. Defaulting to Fargate gives them a simpler, lower-ops starting point regardless of what discovery found. Teams who actively want EKS will answer A or B explicitly. EKS remains fully available via explicit answers A and B.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/design/design-ai.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/design/design-ai.md
@@ -226,6 +226,10 @@ For each detected `integration.pattern` and `ai_source`, generate before/after m
 
 **Mantle (OpenAI-compatible endpoints):** If `ai_source = "openai"` and `integration.pattern = "direct_sdk"`, prefer the Mantle path as the primary migration option. Mantle provides OpenAI-compatible Chat Completions and Responses APIs on Bedrock — the existing OpenAI SDK code works with zero changes, only environment variable updates. Check [Mantle regional availability](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) — if the target region does not have Mantle, fall back to the boto3 Converse API path. Record `migration_path: "mantle"` or `migration_path: "converse"` in `aws-design-ai.json` → `ai_architecture.code_migration`.
 
+**Mantle throughput caveat (medium/high volume):** Mantle runs on a shared 10,000 RPM account limit. For workloads with `ai_token_volume = "medium"` or `"high"`, add a note in the design summary: "Mantle is subject to a shared 10K RPM account limit. At medium/high volume, monitor for 429s and consider migrating to `bedrock-runtime` (Converse API) for dedicated throughput." See `references/shared/ai-migration-guardrails.md` for the full risk table.
+
+**gpt-oss migration path:** If `ai_source = "openai"` and the user wants to preserve OpenAI model architecture while consolidating on AWS, offer `gpt-oss` on Bedrock as a fourth migration path alongside Mantle, Converse API, and framework swap. Record `migration_path: "gpt-oss"` in `aws-design-ai.json` → `ai_architecture.code_migration`. The gpt-oss path uses the Converse API with the gpt-oss Bedrock model ID — it is not an OpenAI-compatible endpoint. Note the Claude 4.7+ output TPM cap (2M) if the user is migrating from a high-output OpenAI workload.
+
 Generate concrete code examples using actual model IDs from the selected Bedrock models. Only include patterns matching the detected integration.
 
 **OpenRouter-specific guidance** (if `gateway_type == "llm_router"` AND `detection_signals` contains OpenRouter evidence):

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/design/design-ai.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/design/design-ai.md
@@ -135,6 +135,7 @@ If `models[]` contains more than one model, check for coordination patterns and 
 
 1. **Embeddings + generation model detected** — If `models[]` contains both an embeddings model (capabilities_used includes `"embeddings"`) AND a text generation model:
    > ⚠️ "Migrating the embedding model (e.g., text-embedding-3-small → Titan Embeddings v2) requires re-embedding all documents in your vector store. Plan for re-indexing time and temporary storage. Test retrieval quality with the new embeddings before switching generation model."
+   > ⚠️ "Verify vector index dimension compatibility before cutover. OpenAI text-embedding-3-small outputs 1536 dimensions; Titan Embeddings v2 is configurable (256, 512, or 1024). A mismatch will cause insert failures at the vector store layer — your index must be rebuilt at the target dimension before any data is written."
 
 2. **Models at different price tiers** — If `models[]` contains both a mini/nano/lite model AND a flagship model (infer from model_id naming: `*-mini`, `*-nano`, `*-lite` vs flagship):
    > ⚠️ "These models appear to work as a cascade or routing pattern (cheap model for classification/filtering, expensive model for generation). Test the Bedrock replacement pair together — validate that the cheaper model's classification accuracy is preserved with its Bedrock equivalent before testing the expensive model."

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/discover/discover-app-code.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/discover/discover-app-code.md
@@ -130,6 +130,8 @@ Scan source code and dependency manifests for agentic framework patterns. These 
 | 3B.3 AutoGen           | `from autogen` imports, `AssistantAgent(`, `GroupChat(`, `ConversableAgent(`                                                                                   | 95%        |
 | 3B.4 OpenAI Agents SDK | `from openai.agents` or `from agents import`, `openai.beta.assistants`, `Runner(`                                                                              | 95%        |
 | 3B.5 Strands Agents    | `from strands` imports, `Agent(` with `tools=`, `Swarm(`, `GraphBuilder(`                                                                                      | 95%        |
+| 3B.5a Pydantic AI      | `from pydantic_ai import Agent`, `from pydantic_ai.models` imports, `Agent(model=`, `.run_sync(`, `.run(`                                                        | 95%        |
+| 3B.5b Agno             | `from agno.agent import Agent`, `from agno.models` imports, `Agent(model=`, `Team(`, `.print_response(`                                                          | 95%        |
 | 3B.6 Custom agent loop | `while` loop body containing BOTH an LLM call (completions/generate) AND tool execution (function dispatch from model output) AND result parsing back to model | 80%        |
 | 3B.7 Tool definitions  | `@tool` decorators, `function_declarations=`, `tools=[{...schema...}]`, tool schema objects with `name`+`description`+`parameters`                             | 90%        |
 | 3B.8 MCP integration   | `from mcp.server` or `from mcp.client`, `mcp.json` config files, `MCPClient(`                                                                                  | 90%        |
@@ -142,6 +144,8 @@ Also check dependency manifests for agentic framework dependencies:
 - `pyautogen` or `autogen` (AutoGen)
 - `openai` with agents imports (OpenAI Agents SDK — same package, different import path)
 - `strands-agents` (Strands Agents SDK)
+- `pydantic-ai` (Pydantic AI)
+- `agno` (Agno)
 - `mcp` (Model Context Protocol SDK)
 
 ---
@@ -150,7 +154,7 @@ Also check dependency manifests for agentic framework dependencies:
 
 Determine whether the codebase contains agentic workflows. Execute these rules in order:
 
-1. If ANY framework signal from 3B.1–3B.5 detected → set `is_agentic: true`, set `framework` to the detected framework name
+1. If ANY framework signal from 3B.1–3B.5b detected → set `is_agentic: true`, set `framework` to the detected framework name
 2. If NO framework signal BUT 3B.6 (custom agent loop) detected → set `is_agentic: true`, set `framework: "custom"`
 3. If 3B.7 (tool definitions) detected WITH an LLM call in a loop pattern → set `is_agentic: true`, set `framework: "custom"`
 4. If ONLY 3B.8 (MCP integration) detected WITHOUT an agent loop → set `is_agentic: false` (MCP alone does not imply agent orchestration)
@@ -501,7 +505,7 @@ After generating the output file, the parent `discover.md` handles the phase sta
 - If `is_agentic: true`: `agentic_profile` section exists with all required fields
 - If `is_agentic: true`: `agentic_profile.agent_count` equals length of `agentic_profile.agents[]`
 - If `is_agentic: true`: `agentic_profile.tool_count` equals length of `tool_manifest[]` (deduplicated)
-- If `is_agentic: true`: `agentic_profile.framework` is one of: `"langgraph"`, `"crewai"`, `"autogen"`, `"openai_agents"`, `"strands"`, `"custom"`, `"none"`
+- If `is_agentic: true`: `agentic_profile.framework` is one of: `"langgraph"`, `"crewai"`, `"autogen"`, `"openai_agents"`, `"strands"`, `"pydantic_ai"`, `"agno"`, `"custom"`, `"none"`
 - If `is_agentic: true`: `agentic_profile.orchestration_pattern` is one of: `"single"`, `"hierarchical"`, `"swarm"`, `"graph"`, `"sequential"`, `"unknown"`
 - If `is_agentic: true`: every `agent_id` in `tool_manifest[].used_by_agents` exists in `agentic_profile.agents[].agent_id`
 - If `is_agentic: true`: `tool_manifest[].transport` is one of: `"function"`, `"api"`, `"mcp"`, `"unknown"`

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-ai.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-ai.md
@@ -45,6 +45,7 @@ If any required file is missing: **STOP**. Output: "Missing required artifact: [
 Check `preferences.json` → `ai_constraints.ai_framework.value` and `aws-design-ai.json` → `ai_architecture.code_migration.migration_path`:
 
 - `migration_path` = `"mantle"` → Generate Mantle setup (Step 1M) + setup (Step 3) + test harness (Step 2). Skip provider adapter (Step 1).
+- `migration_path` = `"gpt-oss"` → Generate provider adapter (Step 1) targeting the gpt-oss model on Bedrock via the Converse API + setup (Step 3) + test harness (Step 2). Use the Bedrock model ID from `aws-design-ai.json` → `ai_architecture.bedrock_models[].aws_model_id` (the gpt-oss model ID). Do NOT generate a Mantle script — gpt-oss uses the Converse API directly.
 - `"direct"` or absent → Generate provider adapter (Step 1) + setup (Step 3) + test harness (Step 2)
 - `"llm_router"`, `"api_gateway"`, `"voice_platform"`, or `"framework"` → Skip Step 1, generate gateway config (Step 3B) instead
 
@@ -61,9 +62,24 @@ Generate `ai-migration/migrate_to_mantle.sh` — a shell script that configures 
 - Dry-run by default (`--execute` flag to apply)
 - Print the environment variables to set: `OPENAI_BASE_URL=https://bedrock-mantle.{region}.api.aws/v1`, `OPENAI_API_KEY=<bedrock-api-key>`
 - Print the model string change: current model ID → Bedrock model ID from `aws-design-ai.json`
+- **Add a warning comment** about `max_tokens`: OpenAI SDK users migrating via Mantle carry over their existing `max_tokens` value unchanged. If the existing value is 4096 (OpenAI default), this reduces Bedrock concurrency by 5–8x on TPM quota. Instruct users to audit `max_tokens` before production and include the workload-type lookup table (see Step 1M max_tokens guidance above).
 - Include a quick verification call using the OpenAI SDK against the Mantle endpoint
 - Note: "No code changes required. Your existing OpenAI SDK calls work unchanged."
 - Reference [Mantle documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) for API key generation
+- **Set `max_tokens` default to 1024** in the generated migration script with an explanatory comment. Do NOT inherit the caller's existing `max_tokens` value (often 4096 from OpenAI defaults) — this reduces concurrency by 5–8x on Bedrock's TPM quota. Include a workload-type lookup table as a comment so users tune before production:
+
+  ```bash
+  # max_tokens guidance — tune before production:
+  # | Workload type                              | Suggested max_tokens |
+  # |--------------------------------------------|----------------------|
+  # | Classification / extraction / routing      | 256–512              |
+  # | Chat / Q&A / summarization                 | 512–1024 (default)   |
+  # | Long-form generation / reports             | 2048–4096            |
+  # | Tool outputs / multi-step reasoning        | 2048–8192            |
+  # | Code generation                            | 2048–4096            |
+  # TODO: Review and adjust max_tokens for your workload before deploying to production.
+  MAX_TOKENS=1024  # Starting point — see table above
+  ```
 
 Skip Step 1 (provider adapter) when this step runs — the OpenAI SDK is the adapter.
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/ai-migration-guardrails.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/ai-migration-guardrails.md
@@ -8,14 +8,14 @@ Shared warnings and constraints for all agentic migration paths. Loaded once by 
 
 AgentCore services have different regional footprints. Always validate via `get_regional_availability` from the `awsknowledge` MCP server before recommending.
 
-**As of April 2026:**
+**As of May 2026:**
 
 | Service                     | Availability | Regions                                                                                                              |
 | --------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
-| AgentCore Runtime (GA)      | 9 regions    | us-east-1, us-east-2, us-west-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, eu-central-1, eu-west-1, ap-south-1 |
+| AgentCore Runtime (GA)      | 15 regions   | us-east-1, us-east-2, us-west-2, us-west-1, ap-southeast-1, ap-southeast-2, ap-northeast-1, ap-northeast-2, ap-south-1, eu-central-1, eu-west-1, eu-west-2, eu-north-1, sa-east-1, ca-central-1 |
 | AgentCore Harness (Preview) | 4 regions    | us-west-2, us-east-1, ap-southeast-2, eu-central-1                                                                   |
-| AgentCore Memory (GA)       | 9 regions    | Same as Runtime                                                                                                      |
-| AgentCore Gateway (GA)      | 9 regions    | Same as Runtime                                                                                                      |
+| AgentCore Memory (GA)       | 15 regions   | Same as Runtime                                                                                                      |
+| AgentCore Gateway (GA)      | 15 regions   | Same as Runtime                                                                                                      |
 
 **IMPORTANT:** These lists go stale. The `get_regional_availability` MCP call is the source of truth. Use the table above only as a fallback if the MCP call fails.
 
@@ -24,6 +24,43 @@ AgentCore services have different regional footprints. Always validate via `get_
 1. Flag prominently in `aws-design-ai.json` → `regional_warnings[]`
 2. Suggest nearest available region as alternative
 3. Note in user summary: "[Service] is not yet available in [target region]. Nearest available: [alternative]."
+
+---
+
+## Bedrock Mantle Throughput Limits (Shared Account)
+
+Bedrock Mantle provides OpenAI-compatible endpoints on Bedrock. It runs on a **shared account limit of 10,000 RPM** across all Mantle users in a region — this is not a per-customer quota.
+
+**Risk table:**
+
+| Workload Volume | Risk Level | Guidance |
+| --------------- | ---------- | -------- |
+| Low (< 100 RPM) | Low | Mantle is a good fit; shared limit is not a concern |
+| Medium (100–1,000 RPM) | Medium | Monitor for 429s at peak; have a fallback ready |
+| High (> 1,000 RPM) | High | Use `bedrock-runtime` (Converse API) directly — not subject to the shared Mantle RPM cap |
+
+**When to use `bedrock-runtime` instead of Mantle:**
+- Production workloads with sustained high request rates
+- Latency-sensitive workloads where shared-limit throttling is unacceptable
+- Workloads that need per-customer quota increases via Service Quotas
+
+**Source:** [AWS Bedrock Mantle scaling throughput best practices](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
+
+---
+
+## Bedrock Mantle TPM Limits (Claude Models)
+
+Claude models on Mantle have an additional **output TPM cap** that differs by model generation:
+
+| Model Family | Output TPM Cap | Notes |
+| ------------ | -------------- | ----- |
+| Claude 4.7+ | 2,000,000 output TPM | Per-model cap applies |
+| All other Claude models | No per-model output TPM limit | Standard account TPM limits apply |
+
+**Impact for migration decisions:**
+- For Claude migrations at medium/high volume: the 2M output TPM cap on Claude 4.7+ is the binding constraint, not the 10K RPM limit
+- For gpt-oss migrations (OpenAI model architecture on Bedrock): check whether the target model is Claude 4.7+ and flag the output TPM cap in the design
+- When output-heavy workloads (long JSON, tool outputs, multi-step reasoning) are detected, flag this cap prominently and recommend `bedrock-runtime` for production
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-fallback.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-fallback.md
@@ -1,0 +1,37 @@
+# Pricing Fallback
+
+> Loaded by `ai-migration-guardrails.md` as the tertiary pricing source when both
+> `pricing-cache.md` (primary) and the `awspricing` MCP server (secondary) are unavailable.
+
+## When This File Is Used
+
+Use this fallback **only** when:
+
+1. `pricing-cache.md` is stale (>30 days since `Last updated`) **and**
+2. The `awspricing` MCP `get_pricing` call fails or times out
+
+## Fallback Behavior
+
+When this fallback is active:
+
+1. Set `pricing_source: "unavailable"` on all AI model cost estimates in `estimation-ai.json`
+2. Surface a visible warning to the user:
+
+   > ⚠️ **Pricing data unavailable.** The pricing cache is stale and the live pricing API could not be reached. AI cost estimates in this report are omitted. Re-run the Estimate phase when connectivity is restored, or check [aws.amazon.com/bedrock/pricing](https://aws.amazon.com/bedrock/pricing) manually.
+
+3. Do **not** fabricate or guess token prices — emit `null` for all per-token cost fields
+4. Infrastructure pricing (Fargate, RDS, S3, etc.) from `pricing-cache.md` may still be used — infrastructure prices change rarely and the cache remains reliable beyond 30 days
+
+## MCP Retry Path
+
+Before falling back to this file, attempt the MCP call with one retry:
+
+```
+get_pricing(service="bedrock", model_id="<model>", region="<target_region>")
+```
+
+If the retry also fails, proceed with `pricing_source: "unavailable"` as above.
+
+## Do Not Guess
+
+Never emit fabricated prices. A missing cost estimate is better than a wrong one.


### PR DESCRIPTION
Port of aws-samples/sample-agent-skills-for-aws-migration#35, plus additional AI reliability and detection improvements.

## Changes

**clarify-compute.md** — Q8 default changed from `eks-or-ecs` to `ecs-fargate`
- Teams that answer "I don't know" are better served by Fargate's lower operational overhead
- EKS remains available via explicit answers A and B

**compute.md** — GKE rubric signal updated
- Absent kubernetes preference now resolves to Fargate, not EKS
- Aligns with the Q8 default change above

**clarify-ai.md** — Q23 Harness option + LiteLLM/OpenRouter default
- Now shows preview status and 4-region limitation inline so users see it before committing to that path
- Regions: us-east-1, us-west-2, eu-central-1, ap-southeast-2
- **LiteLLM/OpenRouter users now default to retarget path** — gateway_type `llm_router` detected → auto-select retarget (config change only, no code rewrite); Q23 skipped unless user explicitly opts in

**ai-migration-guardrails.md**
- Update AgentCore Runtime region count from 9 to 15 (May 2026 expansion)
- Add Bedrock Mantle 10K RPM shared account limit section with risk table and guidance on when to use `bedrock-runtime` instead
- Add Claude 4.7+ 2M output TPM cap distinction (asymmetry matters for gpt-oss vs Claude migration decisions)

**generate-artifacts-ai.md**
- Bedrock provider class now defaults `max_tokens` to 1024 with explanatory comment and workload-type lookup table — prevents teams from inheriting OpenAI's 4096 default and reducing concurrency by 5–8x
- Add `gpt-oss` dispatch case to Step 0 so `migration_path: gpt-oss` routes to provider adapter with correct model IDs
- Add `max_tokens` warning for Mantle path — OpenAI SDK users migrating via Mantle carry over their existing value unchanged

**design-ai.md**
- Add Mantle throughput caveat for medium/high volume workloads (10K RPM shared limit)
- Add gpt-oss on Bedrock as a fourth migration path for OpenAI users who want to preserve model architecture while consolidating on AWS
- **Embedding dimension mismatch warning** — added to re-embedding block: OpenAI text-embedding-3-small (1536 dims) vs Titan v2 (configurable 256/512/1024) causes vector store insert failures if index is not rebuilt at the target dimension before cutover

**discover-app-code.md** — Pydantic AI + Agno detection
- Added 3B.5a (Pydantic AI) and 3B.5b (Agno) to the agentic framework detection table
- Added `pydantic-ai` and `agno` to dependency manifest scan list
- Added `pydantic_ai` and `agno` to the framework enum in the output validation checklist
- Routes to same Clarify Q23 framework options (retarget vs Harness vs Strands) as existing frameworks

**references/shared/pricing-fallback.md** — new file
- Resolves broken reference in `ai-migration-guardrails.md` (tertiary pricing source pointed to a non-existent file)
- Defines `pricing_source: "unavailable"` behavior, MCP retry path, and explicit "do not guess prices" rule