### PR TITLE
feat: add database size clarify question to drive migration tooling selection

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/database.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/database.md
@@ -20,6 +20,7 @@
 - **High availability required** → RDS Multi-AZ or Aurora (preferred)
 - **Dev/test sizing** → RDS Aurora Serverless v2 (min 0.5 ACU, ~$43–58/mo depending on I/O mode)
 - **Production, always-on** → RDS Aurora Provisioned (or Serverless v2 if fluctuating)
+- **Migration tooling** — Read `preferences.json` → `design_constraints.db_size.value` (set by Q14-DB in Clarify) to select the right tool: `"<10GB"` → pg_dump/pg_restore; `"10-100GB"` or `"100-500GB"` → pgcopydb; `">500GB"` → AWS DMS strongly recommended; `"unknown"` → default to pgcopydb
 
 ### Firestore
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-database.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-database.md
@@ -102,3 +102,41 @@ E -> same as default (B) — assume medium I/O
 ```
 
 Default: B — `db_io_workload: "medium"`.
+
+---
+
+## Q14 — Approximately how large is your primary database?
+
+_Fire when:_ Cloud SQL (PostgreSQL or MySQL) present in inventory. Skip when: no Cloud SQL, or engine is SQL Server (DMS is always recommended for SQL Server regardless of size).
+
+**Rationale:** Database size is the primary driver of migration tooling selection. pg_dump/pg_restore is sufficient for small databases but becomes impractically slow above ~10GB within a typical maintenance window. pgcopydb's parallel copy cuts migration time by 3–5x for medium databases. Very large databases (>500GB) require DMS for continuous replication regardless of whether a maintenance window exists — a single-pass export/import at that scale carries too much risk.
+
+**Auto-detect signal:** If `gcp_config.disk_size_gb` is present on `google_sql_database_instance`, use it as the default answer and confirm with the user rather than asking from scratch.
+
+> Database size determines which migration tool we recommend — this directly affects your migration window length and risk.
+>
+> A) < 10 GB — small, pg_dump/pg_restore completes in minutes
+> B) 10 GB – 100 GB — medium, pgcopydb recommended for parallel copy
+> C) 100 GB – 500 GB — large, pgcopydb required; plan for multi-hour window
+> D) > 500 GB — very large, AWS DMS strongly recommended regardless of window
+> E) I don't know
+
+| Answer          | Tooling Recommendation                                                                                                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| < 10 GB         | **pg_dump/pg_restore** — fast, simple, no extra tooling required                                                                                                       |
+| 10 GB – 100 GB  | **pgcopydb** — parallel table copy + index rebuild; 3–5x faster than pg_dump; requires `wal_level=logical` on Cloud SQL if CDC mode used                               |
+| 100 GB – 500 GB | **pgcopydb** required — pg_dump at this size risks exceeding maintenance window; plan for 4–12 hour window depending on table count and index complexity                |
+| > 500 GB        | **AWS DMS strongly recommended** — single-pass export/import at this scale is high-risk; DMS provides continuous replication with minimal cutover window (minutes, not hours) |
+| I don't know    | Default to pgcopydb (safer than pg_dump at unknown scale); flag for user to verify before migration                                                                     |
+
+Interpret:
+
+```
+A -> db_size: "<10GB"    — pg_dump/pg_restore recommended
+B -> db_size: "10-100GB" — pgcopydb recommended
+C -> db_size: "100-500GB" — pgcopydb required; flag extended window
+D -> db_size: ">500GB"   — AWS DMS strongly recommended; flag in migration plan
+E -> db_size: "unknown"  — default to pgcopydb; flag for verification
+```
+
+Default: E — `db_size: "unknown"` (default to pgcopydb; safer than pg_dump at unknown scale).

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-database.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-database.md
@@ -105,7 +105,7 @@ Default: B — `db_io_workload: "medium"`.
 
 ---
 
-## Q14 — Approximately how large is your primary database?
+## Q14-DB — Approximately how large is your primary database?
 
 _Fire when:_ Cloud SQL (PostgreSQL or MySQL) present in inventory. Skip when: no Cloud SQL, or engine is SQL Server (DMS is always recommended for SQL Server regardless of size).
 
@@ -132,11 +132,11 @@ _Fire when:_ Cloud SQL (PostgreSQL or MySQL) present in inventory. Skip when: no
 Interpret:
 
 ```
-A -> db_size: "<10GB"    — pg_dump/pg_restore recommended
-B -> db_size: "10-100GB" — pgcopydb recommended
-C -> db_size: "100-500GB" — pgcopydb required; flag extended window
-D -> db_size: ">500GB"   — AWS DMS strongly recommended; flag in migration plan
-E -> db_size: "unknown"  — default to pgcopydb; flag for verification
+A -> design_constraints.db_size: { value: "<10GB", chosen_by: "user" }    — pg_dump/pg_restore recommended
+B -> design_constraints.db_size: { value: "10-100GB", chosen_by: "user" } — pgcopydb recommended
+C -> design_constraints.db_size: { value: "100-500GB", chosen_by: "user" } — pgcopydb required; flag extended window
+D -> design_constraints.db_size: { value: ">500GB", chosen_by: "user" }   — AWS DMS strongly recommended; flag in migration plan
+E -> design_constraints.db_size: { value: "unknown", chosen_by: "default" } — default to pgcopydb; flag for verification
 ```
 
-Default: E — `db_size: "unknown"` (default to pgcopydb; safer than pg_dump at unknown scale).
+Default: E — `design_constraints.db_size: { value: "unknown", chosen_by: "default" }` (default to pgcopydb; safer than pg_dump at unknown scale).

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-global.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-global.md
@@ -243,8 +243,10 @@ Default: B — `availability: "multi-az"`.
 
 **Database migration tooling notes:**
 
-- For PostgreSQL databases <10GB: **pg_dump/pg_restore** is sufficient.
-- For larger PostgreSQL databases (>10GB): **pgcopydb** offers parallel table copying and index rebuilding, significantly reducing migration time within the same maintenance window.
+- Read `preferences.json.db_size` (set by Q14 in `clarify-database.md`) to select the right tool. If absent, fall back to the size thresholds below.
+- For PostgreSQL databases `db_size: "<10GB"` or unknown-small: **pg_dump/pg_restore** is sufficient.
+- For PostgreSQL databases `db_size: "10-100GB"` or `"100-500GB"`: **pgcopydb** offers parallel table copying and index rebuilding, significantly reducing migration time within the same maintenance window.
+- For PostgreSQL databases `db_size: ">500GB"`: **AWS DMS strongly recommended** regardless of maintenance window — single-pass export/import at this scale is high-risk.
 - pgcopydb's CDC mode requires `wal_level=logical` on Cloud SQL, which must be enabled explicitly.
 
 > The maintenance window determines your migration cutover strategy and which database migration tooling we recommend. Zero-downtime migrations require significantly more complex infrastructure.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-global.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify-global.md
@@ -243,7 +243,7 @@ Default: B — `availability: "multi-az"`.
 
 **Database migration tooling notes:**
 
-- Read `preferences.json.db_size` (set by Q14 in `clarify-database.md`) to select the right tool. If absent, fall back to the size thresholds below.
+- Read `preferences.json` → `design_constraints.db_size.value` (set by Q14-DB in `clarify-database.md`) to select the right tool. If absent, fall back to the size thresholds below.
 - For PostgreSQL databases `db_size: "<10GB"` or unknown-small: **pg_dump/pg_restore** is sufficient.
 - For PostgreSQL databases `db_size: "10-100GB"` or `"100-500GB"`: **pgcopydb** offers parallel table copying and index rebuilding, significantly reducing migration time within the same maintenance window.
 - For PostgreSQL databases `db_size: ">500GB"`: **AWS DMS strongly recommended** regardless of maintenance window — single-pass export/import at this scale is high-risk.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
@@ -14,7 +14,7 @@ Questions are organized into **six named categories (A–F)** with documented fi
 | --------------------- | ---------------------------- | --------- | ----------------------------------------------- |
 | `clarify-global.md`   | A — Global/Strategic         | Q1–Q7     | Always                                          |
 | `clarify-compute.md`  | B — Config Gaps, C — Compute | Q8–Q11    | Compute or billing-source resources present     |
-| `clarify-database.md` | D — Database                 | Q12–Q13   | Database resources present                      |
+| `clarify-database.md` | D — Database                 | Q12–Q14-DB | Database resources present                      |
 | `clarify-ai.md`       | F — AI/Bedrock               | Q14–Q22   | `ai-workload-profile.json` exists               |
 | `clarify-ai-only.md`  | _(standalone)_               | Q1–Q10    | AI-only migration (no infrastructure artifacts) |
 
@@ -99,6 +99,7 @@ Before generating questions, scan the inventory to extract values that are alrea
 4. **Billing-only mode** — If `billing-profile.json` exists and `gcp-resource-inventory.json` does NOT exist, check `billing-profile.json → services[]` for Category B question matching.
 5. **AI framework detection** — If `ai-workload-profile.json` exists, check `integration.gateway_type` and `integration.frameworks` for auto-detection of Q14 answer.
 6. **BigQuery / analytics warehouse** — Set `bigquery_present` to **true** if **any** of: (a) a resource in `gcp-resource-inventory.json` has `gcp_type` (or equivalent type field) starting with `google_bigquery_`; (b) `billing-profile.json` lists a service/SKU that clearly indicates **BigQuery** (e.g., service name or SKU contains `BigQuery`). Otherwise `bigquery_present` is **false**.
+7. **Database size auto-detect** — If `gcp-resource-inventory.json` exists and any `google_sql_database_instance` resource has `gcp_config.disk_size_gb`, record that value as the default for Q14-DB and confirm with the user rather than asking from scratch. Set `chosen_by: "extracted"` if confirmed unchanged.
 
 Record extracted values. Questions whose answers are fully determined by extraction will be skipped and the extracted value used directly with `chosen_by: "extracted"`.
 
@@ -113,7 +114,7 @@ Record extracted values. Questions whose answers are fully determined by extract
 | **A**    | Global/Strategic   | **Always fires**                                                               | `clarify-global.md`   | Q1 (location), Q2 (compliance), Q3 (GCP spend), Q4 (funding stage), Q5 (multi-cloud), Q6 (uptime), Q7 (maintenance) |
 | **B**    | Configuration Gaps | `billing-profile.json` exists AND `gcp-resource-inventory.json` does NOT exist | `clarify-compute.md`  | Cloud SQL HA, Cloud Run count, Memorystore memory, Functions gen                                                    |
 | **C**    | Compute Model      | Compute resources present (Cloud Run, Cloud Functions, GKE, GCE)               | `clarify-compute.md`  | Q8 (K8s sentiment), Q9 (WebSocket), Q10 (Cloud Run traffic), Q11 (Cloud Run spend)                                  |
-| **D**    | Database Model     | Database resources present (Cloud SQL, Spanner, Memorystore)                   | `clarify-database.md` | Q12 (DB traffic pattern), Q13 (DB I/O)                                                                              |
+| **D**    | Database Model     | Database resources present (Cloud SQL, Spanner, Memorystore)                   | `clarify-database.md` | Q12 (DB traffic pattern), Q13 (DB I/O), Q14-DB (DB size)                                                            |
 | **E**    | Migration Posture  | **Disabled by default** — requires explicit user opt-in                        | _(inline below)_      | HA upgrades, right-sizing                                                                                           |
 | **F**    | AI/Bedrock         | `ai-workload-profile.json` exists                                              | `clarify-ai.md`       | Q14–Q22                                                                                                             |
 
@@ -152,6 +153,7 @@ Apply these before presenting questions:
 - **Q5 = "Yes, multi-cloud required"** — Immediately record `compute: "eks"`. Skip Q8 (Kubernetes sentiment) — all container workloads resolve to EKS.
 - **Q10/Q11 N/A** — Cloud Run not present, auto-skip.
 - **Q12/Q13 N/A** — Cloud SQL not present, auto-skip.
+- **Q14-DB auto-detect** — If `gcp_config.disk_size_gb` is present on any `google_sql_database_instance`, use it as the default for Q14-DB with `chosen_by: "extracted"` if the user confirms it unchanged.
 - **Q14 auto-detected** — If `integration.gateway_type` is non-null OR `integration.frameworks` is non-empty in `ai-workload-profile.json`, skip Q14. Set `ai_framework` from the detected values with `chosen_by: "extracted"`.
 
 ### Batch Planning
@@ -161,7 +163,7 @@ After determining active categories, organize questions into **up to three batch
 | Batch | Name                   | Categories                                 | Questions                   | Fires When                                |
 | ----- | ---------------------- | ------------------------------------------ | --------------------------- | ----------------------------------------- |
 | **1** | Strategic Requirements | A (Global/Strategic)                       | Q1–Q7 (minus Q4)            | Always                                    |
-| **2** | Infrastructure         | B (Config Gaps), C (Compute), D (Database) | Q8–Q13 + Category B prompts | Any compute or database resources present |
+| **2** | Infrastructure         | B (Config Gaps), C (Compute), D (Database) | Q8–Q14-DB + Category B prompts | Any compute or database resources present |
 | **3** | AI Workloads           | F (AI/Bedrock)                             | Q14–Q22                     | `ai-workload-profile.json` exists         |
 
 **Determine active batches:**
@@ -394,7 +396,8 @@ Assemble all interpreted answers from the completed batches into the final `$MIG
     "cutover_strategy": { "value": "maintenance-window-weekly", "chosen_by": "user" },
     "kubernetes": { "value": "eks-or-ecs", "chosen_by": "user" },
     "database_traffic": { "value": "steady", "chosen_by": "user" },
-    "db_io_workload": { "value": "medium", "chosen_by": "user" }
+    "db_io_workload": { "value": "medium", "chosen_by": "user" },
+    "db_size": { "value": "10-100GB", "chosen_by": "user" }
   },
   "ai_constraints": {
     "ai_framework": { "value": ["direct"], "chosen_by": "extracted" },
@@ -449,6 +452,7 @@ After writing `preferences.json`, delete `$MIGRATION_DIR/preferences-draft.json`
 | Q11 — Cloud Run spend   | B ($100–$500)        | `cloud_run_monthly_spend: "$100-$500"`            |
 | Q12 — DB traffic        | A (steady)           | `database_traffic: "steady"`                      |
 | Q13 — DB I/O            | B (medium)           | `db_io_workload: "medium"`                        |
+| Q14-DB — DB size        | E (unknown)          | `db_size: "unknown"` → default to pgcopydb        |
 | Q14 — AI framework      | _(auto-detect)_      | `ai_framework` from code detection                |
 | Q15 — AI spend          | B ($500–$2K)         | `ai_monthly_spend: "$500-$2K"`                    |
 | Q16 — AI priority       | E (balanced)         | `ai_priority: "balanced"`                         |

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-scripts.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-scripts.md
@@ -81,12 +81,24 @@ Based on database and storage resources in `aws-design.json`:
 
 **Cloud SQL to RDS/Aurora** — include only if `has_databases`:
 
+Read `preferences.json.db_size` to select the migration tool:
+- `"<10GB"` → use **pg_dump/pg_restore**
+- `"10-100GB"` or `"100-500GB"` → use **pgcopydb** (parallel copy; requires `wal_level=logical` on Cloud SQL)
+- `">500GB"` → use **AWS DMS** (continuous replication; generate DMS task config instead of a shell export script)
+- `"unknown"` → default to **pgcopydb** with a TODO comment to verify size before running
+
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
 # Cloud SQL → RDS data migration
 # Usage: ./02-migrate-data.sh [--execute]
+#
+# Tool selection based on database size (preferences.json db_size):
+#   <10GB:      pg_dump/pg_restore
+#   10-500GB:   pgcopydb (parallel copy, 3-5x faster than pg_dump)
+#   >500GB:     AWS DMS recommended — see README-DMS.md if generated
+#   unknown:    pgcopydb (safer default at unknown scale)
 
 DRY_RUN=true
 [[ "${1:-}" == "--execute" ]] && DRY_RUN=false

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-scripts.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-scripts.md
@@ -81,11 +81,13 @@ Based on database and storage resources in `aws-design.json`:
 
 **Cloud SQL to RDS/Aurora** — include only if `has_databases`:
 
-Read `preferences.json.db_size` to select the migration tool:
+Read `preferences.json` → `design_constraints.db_size.value` to select the migration tool:
 - `"<10GB"` → use **pg_dump/pg_restore**
 - `"10-100GB"` or `"100-500GB"` → use **pgcopydb** (parallel copy; requires `wal_level=logical` on Cloud SQL)
 - `">500GB"` → use **AWS DMS** (continuous replication; generate DMS task config instead of a shell export script)
 - `"unknown"` → default to **pgcopydb** with a TODO comment to verify size before running
+
+Generate the script with conditional branches based on `db_size`:
 
 ```bash
 #!/usr/bin/env bash
@@ -94,11 +96,12 @@ set -euo pipefail
 # Cloud SQL → RDS data migration
 # Usage: ./02-migrate-data.sh [--execute]
 #
-# Tool selection based on database size (preferences.json db_size):
+# Tool selection based on database size (preferences.json design_constraints.db_size.value):
 #   <10GB:      pg_dump/pg_restore
 #   10-500GB:   pgcopydb (parallel copy, 3-5x faster than pg_dump)
 #   >500GB:     AWS DMS recommended — see README-DMS.md if generated
 #   unknown:    pgcopydb (safer default at unknown scale)
+# TODO: Verify database size before running — wrong tool choice can exceed your maintenance window.
 
 DRY_RUN=true
 [[ "${1:-}" == "--execute" ]] && DRY_RUN=false
@@ -106,27 +109,95 @@ DRY_RUN=true
 echo "=== Database Migration: Cloud SQL → RDS ==="
 echo "Mode: $([ "$DRY_RUN" = true ] && echo 'DRY RUN' || echo 'EXECUTE')"
 
-# TODO: Configure source and target connection details
 SOURCE_HOST="<cloud-sql-ip>"      # TODO: Set Cloud SQL IP
 TARGET_HOST="<rds-endpoint>"       # From terraform output database_endpoint
 DATABASE_NAME="<database>"         # TODO: Set database name
+```
 
+Then emit ONE of the following tool-specific blocks based on `db_size`:
+
+**If `db_size` is `"<10GB"`** — emit pg_dump block:
+
+```bash
+# Tool: pg_dump/pg_restore (database < 10GB)
 if [ "$DRY_RUN" = true ]; then
-  echo "[DRY RUN] Would export from Cloud SQL: $SOURCE_HOST"
-  echo "[DRY RUN] Would import to RDS: $TARGET_HOST"
-  echo "[DRY RUN] Database: $DATABASE_NAME"
+  echo "[DRY RUN] Would export from Cloud SQL using pg_dump: $DATABASE_NAME"
+  echo "[DRY RUN] Would import to RDS using pg_restore: $TARGET_HOST"
 else
-  # Export from Cloud SQL
-  echo "Exporting from Cloud SQL..."
-  gcloud sql export sql "$SOURCE_HOST" "gs://migration-bucket/export.sql" \
-    --database="$DATABASE_NAME"
-
-  # Import to RDS
-  echo "Importing to RDS..."
-  # TODO: Use pg_restore, mysql, or appropriate tool for your database engine
-  # psql -h "$TARGET_HOST" -U admin -d "$DATABASE_NAME" < export.sql
+  echo "Exporting from Cloud SQL with pg_dump..."
+  PGPASSWORD="$SOURCE_DB_PASSWORD" pg_dump \
+    -h "$SOURCE_HOST" -U postgres -d "$DATABASE_NAME" \
+    -Fc -f /tmp/migration_dump.pgc
+  echo "Importing to RDS with pg_restore..."
+  PGPASSWORD="$TARGET_DB_PASSWORD" pg_restore \
+    -h "$TARGET_HOST" -U postgres -d "$DATABASE_NAME" \
+    -Fc /tmp/migration_dump.pgc
+  rm -f /tmp/migration_dump.pgc
 fi
+```
 
+**If `db_size` is `"10-100GB"` or `"100-500GB"`** — emit pgcopydb block:
+
+```bash
+# Tool: pgcopydb (database 10GB–500GB — parallel copy, 3-5x faster than pg_dump)
+# Requires: pgcopydb installed, wal_level=logical on Cloud SQL source
+# See: https://pgcopydb.readthedocs.io/
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] Would copy database using pgcopydb: $DATABASE_NAME"
+  echo "[DRY RUN] Source: $SOURCE_HOST → Target: $TARGET_HOST"
+else
+  echo "Copying database with pgcopydb (parallel)..."
+  pgcopydb copy db \
+    --source "postgresql://postgres:${SOURCE_DB_PASSWORD}@${SOURCE_HOST}/${DATABASE_NAME}" \
+    --target "postgresql://postgres:${TARGET_DB_PASSWORD}@${TARGET_HOST}/${DATABASE_NAME}" \
+    --table-jobs 4 \
+    --index-jobs 4
+fi
+```
+
+**If `db_size` is `">500GB"`** — emit DMS guidance block instead of a shell script:
+
+```bash
+# Tool: AWS DMS (database > 500GB — continuous replication recommended)
+# Single-pass export/import at this scale is high-risk and likely to exceed any maintenance window.
+# AWS DMS provides continuous replication with a minimal cutover window (minutes, not hours).
+#
+# Steps:
+# 1. Create a DMS replication instance in the target VPC
+# 2. Create source endpoint (Cloud SQL PostgreSQL) and target endpoint (Aurora PostgreSQL)
+# 3. Create a full-load + CDC replication task
+# 4. Run full load, then let CDC catch up to < 1 second lag
+# 5. Cut over DNS during the minimal lag window
+#
+# TODO: Configure DMS endpoints and task — see AWS DMS documentation:
+# https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html
+echo "Database size > 500GB: AWS DMS is strongly recommended."
+echo "See README-DMS.md for setup instructions."
+echo "This script does not perform the migration directly at this scale."
+```
+
+**If `db_size` is `"unknown"`** — emit pgcopydb block with prominent TODO:
+
+```bash
+# Tool: pgcopydb (database size unknown — safer default than pg_dump at unknown scale)
+# TODO: Verify your database size before running. If > 500GB, use AWS DMS instead.
+# Requires: pgcopydb installed, wal_level=logical on Cloud SQL source
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] Would copy database using pgcopydb: $DATABASE_NAME"
+  echo "[DRY RUN] TODO: Verify database size before executing"
+else
+  echo "Copying database with pgcopydb..."
+  pgcopydb copy db \
+    --source "postgresql://postgres:${SOURCE_DB_PASSWORD}@${SOURCE_HOST}/${DATABASE_NAME}" \
+    --target "postgresql://postgres:${TARGET_DB_PASSWORD}@${TARGET_HOST}/${DATABASE_NAME}" \
+    --table-jobs 4 \
+    --index-jobs 4
+fi
+```
+
+Close the script with the verification block:
+
+```bash
 # Verification
 echo "=== Verification ==="
 echo "TODO: Compare row counts between source and target"


### PR DESCRIPTION
## Problem

The plugin already has excellent guidance on pg_dump vs pgcopydb vs DMS in Q7 (`clarify-global.md`), but it can never apply it correctly because it never asks how large the database is. The tooling threshold (`<10GB` → pg_dump, `>10GB` → pgcopydb) was hardcoded in prose — the plugin had no way to actually use it when generating migration scripts. A team with a 500GB PostgreSQL database got the same migration script as a team with a 2GB database.

The wrong tooling choice can turn a 2-hour migration window into a 14-hour one, or worse — a failed migration that requires rollback.

## Changes

**clarify-database.md** — new Q14: database size
- Fires when Cloud SQL (PostgreSQL or MySQL) is present; skips for SQL Server (DMS always recommended regardless of size)
- Auto-detects from `gcp_config.disk_size_gb` when available in IaC — confirms with user rather than asking from scratch
- Five answers: < 10GB / 10–100GB / 100–500GB / > 500GB / I don't know
- Writes `db_size` to `preferences.json`
- Includes tooling recommendation table per size tier

**clarify-global.md** — Q7 tooling notes updated
- Now reads `preferences.json.db_size` set by Q14 — tooling selection is data-driven
- Adds the missing `> 500GB → AWS DMS strongly recommended` path (previously not covered at all)
- Falls back to size thresholds if `db_size` is absent

**generate-artifacts-scripts.md** — migration script generation updated
- Cloud SQL script generation now selects pg_dump / pgcopydb / DMS based on `db_size` from `preferences.json`
- Generated script includes a tool selection comment block explaining why a particular tool was chosen
- DMS path (`> 500GB`) notes to generate a DMS task config instead of a shell export script