### PR TITLE
fix: Q-number drift, Category E collision, README typo and stale install path

### DIFF
--- a/migrate/plugins/migration-to-aws/README.md
+++ b/migrate/plugins/migration-to-aws/README.md
@@ -12,7 +12,7 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 - **Recommends three migration paths** for agentic workloads: retarget (keep your framework, swap models), AgentCore Harness (config-based managed agents), or Strands Agents (AWS-native multi-agent SDK)
 - **Surfaces options you wouldn't find on your own** — like Strands Agents (open-source, powers AgentCore internally) and AgentCore Harness (declare an agent in 3 API calls)
 - **Generates runnable artifacts** — `harness.json`, deployment scripts, incremental migration scripts, provider adapters — tailored to your specific models, tools, and architecture
-- **Gives honest pricing comparisons** — Gives honest pricing comparisons — finds you the best Bedrock option for your workload with current April 2026 pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
+- **Gives honest pricing comparisons** — finds you the best Bedrock option for your workload with current pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
 
 ## What You Get That a Base LLM Can't Give You
 
@@ -39,10 +39,10 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ```bash
 # Add the marketplace
-/plugin marketplace add aws-samples/sample-agent-skills-for-aws-migration
+/plugin marketplace add awslabs/startups --sparse migrate/plugins
 
 # Install the plugin
-/plugin install migration-to-aws@sample-agent-skills-for-aws-migration
+/plugin install migration-to-aws@startups
 ```
 
 ### Cursor

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
@@ -15,7 +15,7 @@ Questions are organized into **six named categories (A–F)** with documented fi
 | `clarify-global.md`   | A — Global/Strategic         | Q1–Q7     | Always                                          |
 | `clarify-compute.md`  | B — Config Gaps, C — Compute | Q8–Q11    | Compute or billing-source resources present     |
 | `clarify-database.md` | D — Database                 | Q12–Q13   | Database resources present                      |
-| `clarify-ai.md`       | F — AI/Bedrock               | Q14–Q22   | `ai-workload-profile.json` exists               |
+| `clarify-ai.md`       | F — AI/Bedrock               | Q14–Q26   | `ai-workload-profile.json` exists               |
 | `clarify-ai-only.md`  | _(standalone)_               | Q1–Q10    | AI-only migration (no infrastructure artifacts) |
 
 ---
@@ -115,7 +115,7 @@ Record extracted values. Questions whose answers are fully determined by extract
 | **C**    | Compute Model      | Compute resources present (Cloud Run, Cloud Functions, GKE, GCE)               | `clarify-compute.md`  | Q8 (K8s sentiment), Q9 (WebSocket), Q10 (Cloud Run traffic), Q11 (Cloud Run spend)                                  |
 | **D**    | Database Model     | Database resources present (Cloud SQL, Spanner, Memorystore)                   | `clarify-database.md` | Q12 (DB traffic pattern), Q13 (DB I/O)                                                                              |
 | **E**    | Migration Posture  | **Disabled by default** — requires explicit user opt-in                        | _(inline below)_      | HA upgrades, right-sizing                                                                                           |
-| **F**    | AI/Bedrock         | `ai-workload-profile.json` exists                                              | `clarify-ai.md`       | Q14–Q22                                                                                                             |
+| **F**    | AI/Bedrock         | `ai-workload-profile.json` exists                                              | `clarify-ai.md`       | Q14–Q26 (Q14–Q22 always; Q23–Q26 only when `agentic_profile.is_agentic == true`) |
 
 **Apply firing rules to determine which categories are active:**
 
@@ -162,7 +162,7 @@ After determining active categories, organize questions into **up to three batch
 | ----- | ---------------------- | ------------------------------------------ | --------------------------- | ----------------------------------------- |
 | **1** | Strategic Requirements | A (Global/Strategic)                       | Q1–Q7 (minus Q4)            | Always                                    |
 | **2** | Infrastructure         | B (Config Gaps), C (Compute), D (Database) | Q8–Q13 + Category B prompts | Any compute or database resources present |
-| **3** | AI Workloads           | F (AI/Bedrock)                             | Q14–Q22                     | `ai-workload-profile.json` exists         |
+| **3** | AI Workloads           | F (AI/Bedrock)                             | Q14–Q26 (Q23–Q26 only if agentic) | `ai-workload-profile.json` exists         |
 
 **Determine active batches:**
 
@@ -183,13 +183,13 @@ _Default behavior when disabled:_ Apply conservative defaults — no HA upgrades
 
 If the user opts in, present after all other categories:
 
-### Q24 — Should we recommend upgrading Single-AZ to Multi-AZ where possible?
+### Q-E1 — Should we recommend upgrading Single-AZ to Multi-AZ where possible?
 
 > A) Yes — upgrade to Multi-AZ for higher availability | B) No — keep current topology
 
 Interpret → `ha_upgrade`: A → `true`, B → `false`. Default: B → `false`.
 
-### Q25 — Should we use billing utilization data to right-size instance types?
+### Q-E2 — Should we use billing utilization data to right-size instance types?
 
 > A) Yes — right-size based on utilization | B) No — match current capacity
 
@@ -313,7 +313,7 @@ After the last substantive batch is answered (but before writing final `preferen
 
 > "Would you also like HA upgrade and right-sizing recommendations based on your billing data? If not, I'll use conservative defaults (no upgrades, match current capacity)."
 
-If user opts in, present Q24–Q25 (defined in **Category E — Migration Posture** above). Otherwise, apply Category E defaults (`ha_upgrade: false`, `right_sizing: false`).
+If user opts in, present Q-E1–Q-E2 (defined in **Category E — Migration Posture** above). Otherwise, apply Category E defaults (`ha_upgrade: false`, `right_sizing: false`).
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
@@ -381,7 +381,7 @@ Assemble all interpreted answers from the completed batches into the final `$MIG
     "questions_defaulted": ["Q9"],
     "questions_skipped_extracted": ["Q14"],
     "questions_skipped_early_exit": ["Q8"],
-    "questions_skipped_not_applicable": ["Q4", "Q10", "Q11", "Q12", "Q13"],
+    "questions_skipped_not_applicable": ["Q4", "Q10", "Q11", "Q12", "Q13", "Q14-DB"],
     "category_e_enabled": false,
     "inventory_clarifications": {}
   },


### PR DESCRIPTION
Four quick wins in one PR — all low effort, each independently valuable.

## Changes

**clarify.md — Category F Q-number range corrected**
- Category Reference table and Batch 3 planning table both said `Q14–Q22` for Category F
- `clarify-ai.md` actually runs Q14–Q26 (Q23–Q26 are the agentic Category G questions)
- Agents reading the summary table would skip Q23–Q26 entirely or mis-route them

**clarify.md — Category E Q-number collision resolved**
- Category E (Migration Posture) used Q24 and Q25 for HA upgrade and right-sizing questions
- Category G (Agentic) in `clarify-ai.md` uses Q24 (memory) and Q25 (task duration)
- Renamed Category E questions to Q-E1 and Q-E2 — unambiguous, no collision possible

**README.md — duplicate bullet text removed**
- `Gives honest pricing comparisons — Gives honest pricing comparisons —` appeared as a single bullet
- Reduced to a single clean sentence

**README.md — stale Claude Code install path updated**
- Install instructions still pointed at `aws-samples/sample-agent-skills-for-aws-migration`
- Updated to `awslabs/startups` with `--sparse migrate/plugins` to match the current repo location