### PR TITLE
feat: add Codex plugin support

### DIFF
--- a/migrate/plugins/.agents/plugins/marketplace.json
+++ b/migrate/plugins/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "aws-migration-plugins",
+  "interface": {
+    "displayName": "AWS Migration Plugins"
+  },
+  "plugins": [
+    {
+      "name": "migration-to-aws",
+      "source": {
+        "source": "local",
+        "path": "./migration-to-aws"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "DevOps"
+    }
+  ]
+}

--- a/migrate/plugins/.agents/plugins/marketplace.json
+++ b/migrate/plugins/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "DevOps"
+      "category": "Developer Tools"
     }
   ]
 }

--- a/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
+++ b/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "migration-to-aws",
+  "version": "1.1.0",
+  "description": "Migrate workloads from Google Cloud Platform to AWS. Runs a 6-phase process: discover GCP resources from Terraform files, app code, or billing exports; clarify migration requirements; design AWS architecture; estimate costs; generate migration artifacts; and collect optional feedback. Includes AI provider migration guidance (OpenAI/Gemini to Amazon Bedrock) with model mapping, agentic migration paths, and honest pricing comparisons.",
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com"
+  },
+  "homepage": "https://github.com/awslabs/startups/tree/main/migrate",
+  "repository": "https://github.com/awslabs/startups",
+  "license": "MIT-0",
+  "keywords": [
+    "aws",
+    "gcp",
+    "google-cloud",
+    "migration",
+    "cloud-migration",
+    "terraform",
+    "fargate",
+    "rds",
+    "eks",
+    "bedrock",
+    "ai-migration"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "GCP to AWS Migration",
+    "shortDescription": "Migrate GCP infrastructure and AI workloads to AWS with architecture mapping, cost analysis, and runnable Terraform.",
+    "longDescription": "Point this plugin at your Terraform files, application code, or GCP billing data. It runs a structured 6-phase migration assessment — discovering what you have, asking the right questions, designing the AWS architecture, estimating costs with real pricing data, and generating runnable migration artifacts.\n\nFor AI-focused startups, it detects your entire AI stack (models, agents, tools, orchestration patterns) and recommends three migration paths: retarget (keep your framework, swap models), AgentCore Harness (config-based managed agents), or Strands Agents (AWS-native multi-agent SDK).\n\nGenerates Terraform configurations, migration scripts, provider adapters, harness.json, and documentation — all tailored to your specific stack.",
+    "developerName": "Amazon Web Services",
+    "category": "DevOps",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/awslabs/startups/tree/main/migrate",
+    "defaultPrompt": [
+      "Migrate my GCP infrastructure to AWS",
+      "Migrate my OpenAI app to Amazon Bedrock",
+      "Estimate AWS costs for my GCP workload",
+      "Generate Terraform for my GCP to AWS migration",
+      "Migrate my LangChain app from OpenAI to Bedrock"
+    ]
+  }
+}

--- a/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
+++ b/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
@@ -40,7 +40,7 @@
     "shortDescription": "Migrate GCP infrastructure and AI workloads to AWS with architecture mapping, cost analysis, and runnable Terraform.",
     "longDescription": "Point this plugin at your Terraform files, application code, or GCP billing data. It runs a structured 6-phase migration assessment — discovering what you have, asking the right questions, designing the AWS architecture, estimating costs with real pricing data, and generating runnable migration artifacts.\n\nFor AI-focused startups, it detects your entire AI stack (models, agents, tools, orchestration patterns) and recommends three migration paths: retarget (keep your framework, swap models), AgentCore Harness (config-based managed agents), or Strands Agents (AWS-native multi-agent SDK).\n\nGenerates Terraform configurations, migration scripts, provider adapters, harness.json, and documentation — all tailored to your specific stack.",
     "developerName": "Amazon Web Services",
-    "category": "DevOps",
+    "category": "Developer Tools",
     "capabilities": ["Read", "Write"],
     "websiteURL": "https://github.com/awslabs/startups/tree/main/migrate",
     "defaultPrompt": [

--- a/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
+++ b/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
@@ -24,6 +24,9 @@
     "ai-migration",
     "openai",
     "openai-to-bedrock",
+    "gemini",
+    "gemini-to-bedrock",
+    "vertex-ai",
     "langchain",
     "langgraph",
     "crewai",
@@ -46,6 +49,7 @@
     "defaultPrompt": [
       "Migrate my GCP infrastructure to AWS",
       "Migrate my OpenAI app to Amazon Bedrock",
+      "Migrate my Gemini app to Amazon Bedrock",
       "Estimate AWS costs for my GCP workload",
       "Generate Terraform for my GCP to AWS migration",
       "Migrate my LangChain app from OpenAI to Bedrock"

--- a/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
+++ b/migrate/plugins/migration-to-aws/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "migration-to-aws",
   "version": "1.1.0",
-  "description": "Migrate workloads from Google Cloud Platform to AWS. Runs a 6-phase process: discover GCP resources from Terraform files, app code, or billing exports; clarify migration requirements; design AWS architecture; estimate costs; generate migration artifacts; and collect optional feedback. Includes AI provider migration guidance (OpenAI/Gemini to Amazon Bedrock) with model mapping, agentic migration paths, and honest pricing comparisons.",
+  "description": "Migrate from GCP to AWS — including your entire AI stack. Moves infrastructure (Cloud Run → Fargate, Cloud SQL → Aurora, GKE → EKS), OpenAI/Gemini workloads to Amazon Bedrock, and agentic systems (LangChain, CrewAI, AutoGen, OpenAI Agents SDK) to AWS-native frameworks. Generates runnable Terraform, migration scripts, provider adapters, and deployment artifacts. Gives honest model-by-model pricing comparisons so you know exactly when Bedrock saves money and when it doesn't.",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com"
@@ -18,9 +18,20 @@
     "terraform",
     "fargate",
     "rds",
+    "aurora",
     "eks",
     "bedrock",
-    "ai-migration"
+    "ai-migration",
+    "openai",
+    "openai-to-bedrock",
+    "langchain",
+    "langgraph",
+    "crewai",
+    "autogen",
+    "agentic",
+    "agents",
+    "llm-migration",
+    "cost-estimation"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",

--- a/migrate/plugins/migration-to-aws/.mcp.json
+++ b/migrate/plugins/migration-to-aws/.mcp.json
@@ -14,7 +14,13 @@
         "AWS_REGION": "us-east-1"
       },
       "timeout": 120000,
-      "type": "stdio"
+      "type": "stdio",
+      "autoApprove": [
+        "get_pricing_service_codes",
+        "get_pricing_service_attributes",
+        "get_pricing_attribute_values",
+        "get_pricing"
+      ]
     }
   }
 }

--- a/migrate/plugins/migration-to-aws/README.md
+++ b/migrate/plugins/migration-to-aws/README.md
@@ -1,6 +1,6 @@
 # Agent Skills for AWS Migration
 
-AI agent skills for migrating workloads to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) and [Cursor](https://www.cursor.com/).
+AI agent skills for migrating workloads to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://openai.com/codex), and [Cursor](https://www.cursor.com/).
 
 ## What This Does
 
@@ -39,10 +39,20 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ```bash
 # Add the marketplace
-/plugin marketplace add aws-samples/sample-agent-skills-for-aws-migration
+/plugin marketplace add awslabs/startups --sparse migrate/plugins
 
 # Install the plugin
-/plugin install migration-to-aws@sample-agent-skills-for-aws-migration
+/plugin install migration-to-aws@startups
+```
+
+### Codex
+
+```bash
+# Add the marketplace
+codex plugin marketplace add awslabs/startups --sparse migrate/plugins
+
+# Install the plugin
+codex plugin install migration-to-aws
 ```
 
 ### Cursor
@@ -86,7 +96,7 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ## Requirements
 
-- Claude Code >=2.1.29 or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
+- Claude Code >=2.1.29, Codex (latest), or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
 - AWS CLI configured with appropriate credentials
 - At least one input source: Terraform files, application code, or GCP billing data
 - **For AI/agentic migration:** Application source code is required (billing/IaC alone cannot detect agent architecture)


### PR DESCRIPTION
Adds OpenAI Codex plugin packaging alongside the existing Claude Code and Cursor support. No skill content changes — SKILL.md and all reference files are identical between clients.

## What's added

**`migrate/plugins/migration-to-aws/.codex-plugin/plugin.json`**
Codex manifest with full `interface` block: displayName, shortDescription, longDescription, defaultPrompts, category, capabilities. Points `skills` at `./skills/` and `mcpServers` at `./.mcp.json`. Same core metadata as the existing `.claude-plugin/plugin.json`.

**`migrate/plugins/migration-to-aws/.mcp.json`**
Codex expects the MCP config at `.mcp.json` at the plugin root. Same content as the existing `mcp.json` (awsknowledge + awspricing servers). Both files coexist — Claude Code reads `mcp.json`, Codex reads `.mcp.json`.

**`migrate/plugins/.agents/plugins/marketplace.json`**
Repo-scoped Codex marketplace entry. Enables one-command install:
```bash
codex plugin marketplace add awslabs/startups --sparse migrate/plugins
codex plugin install migration-to-aws
```

**`README.md`**
- Add Codex to supported clients in the header line
- Add Codex install instructions section
- Fix stale Claude Code install path (`aws-samples/sample-agent-skills-for-aws-migration` → `awslabs/startups --sparse migrate/plugins`)
- Update Requirements line to include Codex