### PR TITLE
docs: rewrite root README with jobs-to-be-done framing and both plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,111 @@
 # AWS Startups
 
-AI agent plugins, tools, and resources for startup builders on AWS.
+AI agent plugins for startup builders on AWS — works with Claude Code, Codex, Cursor, Kiro, GitHub Copilot, and 50+ other AI coding agents.
+
+---
+
+## Which plugin do you need?
+
+| I want to... | Use this |
+|---|---|
+| Understand AWS programs, credits, and partner offers | [advisor-for-startups](#advisor-for-startups) |
+| Get architectural guidance and sample code for building on AWS | [advisor-for-startups](#advisor-for-startups) |
+| Move my infrastructure from GCP to AWS | [migration-to-aws](#migration-to-aws) |
+| Migrate my OpenAI or Gemini app to Amazon Bedrock | [migration-to-aws](#migration-to-aws) |
+| Move my LangChain, CrewAI, or AutoGen agents to AWS | [migration-to-aws](#migration-to-aws) |
+| Compare AWS vs GCP costs for my stack | [migration-to-aws](#migration-to-aws) |
+| Get runnable Terraform for my AWS architecture | [migration-to-aws](#migration-to-aws) |
+
+---
 
 ## Plugins
 
-| Plugin                           | Description                                                                                                                                   | Status    |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| **[migration-to-aws](migrate/)** | Migrate GCP/Azure infrastructure and AI workloads to AWS with resource discovery, architecture mapping, cost analysis, and execution planning | Available |
+### advisor-for-startups
 
-## Installation
+**Three skills that help you get started on AWS:**
+
+- **`knowledge-base-for-startups`** — AWS Startups knowledge base: FAQ, credits guide, programs, partner offers, sample architectures, and 277 learn articles. All searchable and offline after install.
+- **`prompt-library-for-startups`** — 30 AWS-curated prompts plus 4 downloadable agents (Migration, Multi-Account Transition Advisor, Bill Shock Preventer, Service Quota).
+- **`start-building-for-startups`** — interactive discovery workflow that gathers your requirements and writes an AWS architectural scaffold directly into your codebase.
+
+The three skills are cross-aware — `start-building-for-startups` consults the knowledge base and prompt library mid-flow.
+
+**Install** (works with 50+ agents including Kiro, Claude Code, Cursor, Codex, GitHub Copilot):
+
+```bash
+# Install all three skills into your agent
+npx skills add https://github.com/awslabs/startups/tree/main/advisor/plugins/advisor-for-startups --skill '*' --agent <agent>
+
+# Examples
+npx skills add https://github.com/awslabs/startups/tree/main/advisor/plugins/advisor-for-startups --skill '*' --agent kiro-cli
+npx skills add https://github.com/awslabs/startups/tree/main/advisor/plugins/advisor-for-startups --skill '*' --agent claude-code
+npx skills add https://github.com/awslabs/startups/tree/main/advisor/plugins/advisor-for-startups --skill '*' --agent codex
+npx skills add https://github.com/awslabs/startups/tree/main/advisor/plugins/advisor-for-startups --skill '*' --agent cursor
+```
+
+> **Always pass `--agent`.** Omitting it writes skills to `.agents/skills/` which most agents won't discover. See the [full agent list](https://github.com/vercel-labs/skills#supported-agents) for all 50+ supported values.
+
+Full documentation: [advisor/README.md](advisor/README.md)
+
+---
+
+### migration-to-aws
+
+**Migrate from GCP to AWS — including your entire AI stack.**
+
+Moves infrastructure (Cloud Run → Fargate, Cloud SQL → Aurora, GKE → EKS), OpenAI/Gemini workloads to Amazon Bedrock, and agentic systems (LangChain, CrewAI, AutoGen, OpenAI Agents SDK) to AWS-native frameworks. Generates runnable Terraform, migration scripts, provider adapters, and deployment artifacts. Gives honest model-by-model pricing comparisons so you know exactly when Bedrock saves money and when it doesn't.
+
+**What it does:**
+
+Runs a 6-phase assessment against your Terraform files, application code, or GCP billing data:
+
+1. **Discover** — maps your GCP resources, AI models, agent frameworks, and billing
+2. **Clarify** — asks targeted questions to understand your priorities and constraints
+3. **Design** — maps GCP services to AWS equivalents; selects the right Bedrock model for your workload with honest pricing comparisons
+4. **Estimate** — calculates monthly AWS costs using real-time pricing; compares against your current spend
+5. **Generate** — produces runnable Terraform, migration scripts, provider adapters, `harness.json`, and a full migration guide
+6. **Feedback** _(optional)_ — anonymized usage data to improve the tool
+
+**Install:**
 
 ### Claude Code
 
 ```bash
-# Add the marketplace
-/plugin marketplace add awslabs/startups
+/plugin marketplace add awslabs/startups --sparse migrate/plugins
+/plugin install migration-to-aws@startups
+```
 
-# Install a plugin
-/plugin install migration-to-aws@startups-for-aws
+### Codex
+
+```bash
+codex plugin marketplace add awslabs/startups --sparse migrate/plugins
+codex plugin install migration-to-aws
 ```
 
 ### Cursor
 
-> **Coming soon** — Plugins are not yet published on the Cursor Marketplace.
+> Coming soon on the Cursor Marketplace. Clone the repo and point Cursor at `migrate/plugins/migration-to-aws/` to use it locally today.
 
-## Repository Structure
+Full documentation: [migrate/plugins/migration-to-aws/README.md](migrate/plugins/migration-to-aws/README.md)
 
-Each top-level folder is owned by a team and contains their plugins, tools, or resources:
+---
+
+## Repository structure
 
 ```
 awslabs/startups/
-├── .claude-plugin/marketplace.json   # Plugin marketplace (lists all plugins)
-├── migrate/                          # Migration tools and plugins
+├── advisor/                          # AWS Startups advisor skills
+│   └── plugins/
+│       └── advisor-for-startups/    # Knowledge base, prompt library, build workflow
+├── migrate/                          # Migration plugins
+│   └── plugins/
+│       └── migration-to-aws/        # GCP → AWS migration plugin
 └── ...                               # Future team folders
 ```
 
-## Adding a Plugin
-
-To add a new plugin to the marketplace:
-
-1. Create your plugin under your team's folder (e.g., `migrate/plugins/my-plugin/`)
-1. Include a `.claude-plugin/plugin.json` manifest in your plugin directory
-1. Add an entry to the root `.claude-plugin/marketplace.json`:
-
-```json
-{
-  "name": "my-plugin",
-  "source": "./my-team-folder/plugins/my-plugin",
-  "version": "1.0.0",
-  "description": "What your plugin does"
-}
-```
-
-1. Submit a PR — requires approval from `@awslabs/startups-admins` (for marketplace changes) and your team's CODEOWNERS (for plugin content)
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines, the first-time publishing process, and documentation requirements.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and the plugin publishing process.
 
 ## Security
 
@@ -64,4 +113,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for security is
 
 ## License
 
-This project is licensed under the Apache-2.0 License. See [LICENSE](LICENSE) for details.
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
The current root README is a thin table with a one-line description and contributor instructions. A startup landing here has no idea what's available or which plugin to use.

## Changes

**Decision table at the top** — maps startup jobs-to-be-done to the right plugin. A founder should know in 10 seconds whether they need advisor-for-startups or migration-to-aws.

**advisor-for-startups section** — was completely missing from the root README despite being a full plugin with three skills. Now includes:
- Description of all three skills (knowledge-base, prompt-library, start-building)
- Install commands for Kiro, Claude Code, Codex, Cursor, and the full 50+ agent list
- Warning about the `--agent` flag gotcha
- Link to advisor/README.md for full docs

**migration-to-aws section** — replaces the one-line table entry with:
- Value proposition leading with AI/agent migration (not just infrastructure)
- 6-phase description
- Install instructions for Claude Code, Codex, and Cursor
- Fixed stale Claude Code install path (`aws-samples` → `awslabs/startups`)
- Added Codex install instructions (was missing entirely)
- Removed 'Azure' from description (plugin only supports GCP)

**Repo structure diagram** — updated to show both advisor and migrate trees.

**Contributor instructions** — moved to the bottom where they belong.