### PR TITLE
docs: rebalance migrate/README.md — equal weight for infra and AI migrations

### DIFF
--- a/migrate/README.md
+++ b/migrate/README.md
@@ -1,18 +1,25 @@
 # Migration to AWS
 
-AI agent skills for migrating workloads to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) and [Cursor](https://www.cursor.com/).
+AI agent skills for migrating workloads from GCP to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://openai.com/codex), and [Cursor](https://www.cursor.com/).
 
 ## What This Does
 
-Point this plugin at your codebase, Terraform files, or GCP billing data. It runs a structured 6-phase migration assessment — discovering what you have, asking the right questions, designing the AWS architecture, estimating costs with real pricing data, and generating runnable migration artifacts.
+Point this plugin at your Terraform files, application code, or GCP billing data. It runs a structured 6-phase assessment — discovering what you have, asking the right questions, designing the AWS architecture, estimating costs with real pricing data, and generating runnable migration artifacts.
 
-**For AI-focused startups**, it goes further:
+**For infrastructure migrations:**
+
+- **Maps your GCP resources to AWS equivalents** — Cloud Run → Fargate, Cloud SQL → Aurora, GKE → EKS, Cloud Storage → S3, VPC → VPC, and more
+- **Generates production-ready Terraform** — `vpc.tf`, `compute.tf`, `database.tf`, `security.tf`, `baseline.tf` with security controls (GuardDuty, CloudTrail, IMDSv2, ECR scanning), and a full `terraform/README.md`
+- **Selects the right database migration tool** — pg_dump for small databases, pgcopydb for parallel copy at scale, AWS DMS for zero-downtime migrations — based on your actual database size
+- **Produces numbered migration scripts** — prerequisites validation, data migration, container image migration (GCR → ECR), secrets migration (GCP Secret Manager → AWS Secrets Manager), and post-migration validation
+- **Estimates costs across three tiers** — Premium, Balanced, and Optimized — using real-time AWS pricing, compared against your current GCP spend
+
+**For AI and agentic migrations:**
 
 - **Detects your entire AI stack** — not just "you use GPT-4o" but your agents, tools, orchestration patterns, memory layers, and multi-model pipelines
 - **Recommends three migration paths** for agentic workloads: retarget (keep your framework, swap models), AgentCore Harness (config-based managed agents), or Strands Agents (AWS-native multi-agent SDK)
-- **Surfaces options you wouldn't find on your own** — like Strands Agents (open-source, powers AgentCore internally) and AgentCore Harness (declare an agent in 3 API calls)
-- **Generates runnable artifacts** — `harness.json`, deployment scripts, incremental migration scripts, provider adapters — tailored to your specific models, tools, and architecture
-- **Gives honest pricing comparisons** — finds you the best Bedrock option for your workload with current pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
+- **Gives honest pricing comparisons** — finds the best Bedrock option for your workload with current pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
+- **Generates runnable AI artifacts** — `harness.json`, provider adapters, deployment scripts, incremental migration scripts — tailored to your specific models, tools, and architecture
 
 ## Installation
 
@@ -20,10 +27,17 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ```bash
 # Add the marketplace
-/plugin marketplace add awslabs/startups
+/plugin marketplace add awslabs/startups --sparse migrate/plugins
 
 # Install the plugin
-/plugin install migration-to-aws@startups-for-aws
+/plugin install migration-to-aws@startups
+```
+
+### Codex
+
+```bash
+codex plugin marketplace add awslabs/startups --sparse migrate/plugins
+codex plugin install migration-to-aws
 ```
 
 ### Cursor
@@ -55,44 +69,60 @@ The skill creates a `.migration/<MMDD-HHMM>/` directory in the current working d
 
 ## What It Detects
 
-| Category             | Examples                                                                                              |
-| -------------------- | ----------------------------------------------------------------------------------------------------- |
-| Infrastructure       | Cloud Run, Cloud SQL, GKE, Cloud Functions, Pub/Sub, Cloud Storage, VPC, DNS                          |
-| AI Models            | OpenAI (GPT-4o, GPT-5.4, o-series, embeddings, image, speech), Gemini (Pro, Flash), Anthropic, Cohere |
-| Agentic Frameworks   | LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, Strands, custom agent loops                            |
-| Integration Patterns | Direct SDK, LangChain, LlamaIndex, LiteLLM, OpenRouter, MCP servers                                   |
-| Agent Architecture   | Single agent, hierarchical, swarm, graph, sequential orchestration                                    |
-| Tools & Memory       | Tool definitions with transport/auth classification, memory backends (Redis, Postgres, vector stores) |
+| Category | GCP → AWS |
+|---|---|
+| Containers | Cloud Run → Fargate, GKE → EKS |
+| Serverless | Cloud Functions → Lambda |
+| Databases | Cloud SQL (PostgreSQL/MySQL) → Aurora, Cloud SQL (SQL Server) → RDS, Firestore → DynamoDB, Memorystore → ElastiCache, Spanner → Aurora DSQL |
+| Storage | Cloud Storage → S3, Filestore → EFS |
+| Networking | VPC → VPC, Cloud Load Balancing → ALB/NLB, Cloud DNS → Route 53, Cloud Armor → WAF + Shield |
+| Secrets | Secret Manager → Secrets Manager |
+| AI Models | OpenAI (GPT-4o, GPT-5.x, o-series), Gemini (Pro, Flash), embeddings, image, speech → Amazon Bedrock |
+| Agentic Frameworks | LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, Strands, custom agent loops |
+| Integration Patterns | Direct SDK, LangChain, LlamaIndex, LiteLLM, OpenRouter, MCP servers |
+| Agent Architecture | Single agent, hierarchical, swarm, graph, sequential orchestration |
+| Tools & Memory | Tool definitions with transport/auth classification, memory backends (Redis, Postgres, vector stores) |
 
 ## What You Get That a Base LLM Can't
 
-| Capability               | Base LLM                          | This Plugin                                                                                                                                           |
-| ------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Model recommendation     | Generic "use Bedrock"             | Your specific models mapped with pricing, honest assessment per model, stay-or-migrate recommendation                                                 |
-| Agentic migration        | "Swap ChatOpenAI for ChatBedrock" | Detects your framework, agents, tools, orchestration pattern. Recommends retarget vs Harness vs Strands with effort ranges.                           |
-| Multi-model coordination | Generic advice                    | Warns about re-embedding requirements, cascade pair testing, tiered strategies — based on your actual model usage                                     |
-| Framework gotchas        | Not covered                       | Documents real issues: LangGraph checkpointer incompatibility, CrewAI hierarchical process failures with smaller models, async thread pool exhaustion |
-| Regional validation      | Outdated region lists             | Live `get_regional_availability` MCP call — catches "AgentCore Harness isn't in your target region" before you commit                                 |
-| Cost estimation          | Stale pricing                     | Three-tier pricing: cached current rates, live AWS Pricing API, fallback. Shows ±5-10% accuracy.                                                      |
-| Generated code           | Generic templates                 | Your model IDs, your tool names, your system prompts, your region — in runnable scripts                                                               |
-| Incremental migration    | Not suggested                     | Run existing OpenAI models on AgentCore infrastructure today, A/B test with Bedrock per-invocation, swap when confident                               |
+**Infrastructure:**
+
+| Capability | Base LLM | This Plugin |
+|---|---|---|
+| Terraform generation | Generic templates | Your actual GCP config translated — instance classes, storage sizes, region, VPC CIDRs, security groups |
+| Security baseline | Not included | `baseline.tf` always emitted: GuardDuty, CloudTrail, IMDSv2, ECR scanning, EBS encryption, budget alerts |
+| Database migration tooling | "Use DMS" | Selects pg_dump / pgcopydb / DMS based on your actual database size; generates the right script |
+| Cost estimation | Stale guesses | Three-tier pricing (Premium/Balanced/Optimized) using live AWS Pricing API, compared to your GCP bill |
+| Migration plan | Generic checklist | Phased timeline with Go/No-Go gates, rollback procedures, and data integrity checks |
+
+**AI/Agentic:**
+
+| Capability | Base LLM | This Plugin |
+|---|---|---|
+| Model recommendation | Generic "use Bedrock" | Your specific models mapped with pricing, honest stay-or-migrate recommendation per model |
+| Agentic migration | "Swap ChatOpenAI for ChatBedrock" | Detects your framework, agents, tools, orchestration pattern; recommends retarget vs Harness vs Strands with effort ranges |
+| Multi-model coordination | Generic advice | Warns about re-embedding requirements, cascade pair testing, tiered strategies — based on your actual model usage |
+| Framework gotchas | Not covered | LangGraph checkpointer incompatibility, CrewAI hierarchical failures with smaller models, async thread pool exhaustion |
+| Regional validation | Outdated region lists | Live `get_regional_availability` MCP call — catches "AgentCore Harness isn't in your target region" before you commit |
+| Generated code | Generic templates | Your model IDs, your tool names, your system prompts, your region — in runnable scripts |
+| Incremental migration | Not suggested | Run existing OpenAI models on AgentCore infrastructure today, A/B test with Bedrock per-invocation, swap when confident |
 
 ## Agent Skill Triggers
 
-| Agent Skill    | Triggers                                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------------- |
-| **gcp-to-aws** | "migrate GCP to AWS", "move from GCP", "GCP migration plan", "estimate AWS costs", "migrate my AI app to AWS" |
+| Agent Skill | Triggers |
+|---|---|
+| **gcp-to-aws** | "migrate GCP to AWS", "move from GCP", "GCP migration plan", "migrate Cloud SQL to Aurora", "move Cloud Run to Fargate", "estimate AWS costs for my GCP infrastructure", "migrate my OpenAI app to Bedrock", "migrate my LangChain agents to AWS" |
 
 ## MCP Servers
 
-| Server           | Purpose                                                         |
-| ---------------- | --------------------------------------------------------------- |
+| Server | Purpose |
+|---|---|
 | **awsknowledge** | AWS documentation, regional availability, architecture guidance |
-| **awspricing**   | Real-time AWS service pricing for cost estimates                |
+| **awspricing** | Real-time AWS service pricing for cost estimates |
 
 ## Requirements
 
-- Claude Code >=2.1.29 or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
+- Claude Code >=2.1.29, Codex (latest), or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
 - AWS CLI configured with appropriate credentials
 - At least one input source: Terraform files, application code, or GCP billing data
 - **For AI/agentic migration:** Application source code is required (billing/IaC alone cannot detect agent architecture)
@@ -101,7 +131,7 @@ The skill creates a `.migration/<MMDD-HHMM>/` directory in the current working d
 
 ```
 migrate/
-├── plugins/          # Claude Code and Cursor plugins
+├── plugins/          # Claude Code, Codex, and Cursor plugins
 └── docs/             # Documentation
 ```
 


### PR DESCRIPTION
The previous README led with a generic infrastructure sentence then spent 5 bullets on AI/agentic migration, making it look like an AI-only tool. Most users will be doing infrastructure migrations.

## Changes

**What This Does** — parallel sections for infrastructure and AI, neither dominates. Infrastructure section now has 5 concrete bullets (Terraform generation, security baseline, database tooling selection, migration scripts, cost estimation) matching the depth of the AI section.

**What It Detects** — expanded from a service name list to a GCP → AWS mapping table showing actual equivalents: Cloud Run → Fargate, Cloud SQL → Aurora, Spanner → Aurora DSQL, Filestore → EFS, Cloud Armor → WAF + Shield, etc.

**What You Get** — split into two tables (Infrastructure and AI/Agentic) so infra engineers immediately see their value without scrolling past AI content.

**Agent Skill Triggers** — added infrastructure-specific phrases: 'migrate Cloud SQL to Aurora', 'move Cloud Run to Fargate', 'estimate AWS costs for my GCP infrastructure'.

**Installation** — added Codex instructions; fixed stale Claude Code install path.

**Requirements** — added Codex to supported clients list.