### PR TITLE
feat: Clarify fast-path — 3 questions for simple infra stacks

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           app-id: ${{ secrets.WATCHDOG_APP_ID }}
           private-key: ${{ secrets.WATCHDOG_APP_PRIVATE_KEY }}
+          owner: herosjourney
 
       - name: Detect changed Reference_Files
         id: changed-files
@@ -74,9 +75,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
         run: |
-          # Clone the watchdog repo (replace WATCHDOG_REPO with your actual repo)
+          # Clone the watchdog repo using App token if available, else github.token
           git clone \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'aws-samples/migration-watchdog' }}.git" \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'herosjourney/migration-watchdog' }}.git" \
             /tmp/migration-watchdog
 
           # The migration_watchdog/ package directory is at the repo root.
@@ -120,6 +121,7 @@ jobs:
           WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
           WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
         run: |
+          pip install httpx --quiet
           python - <<'EOF'
           import json, os, sys
           import httpx

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -12,8 +12,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - "features/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
-      - "features/migration-to-aws/skills/gcp-to-aws/SKILL.md"
+      - "migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
+      - "migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md"
 
 permissions:
   pull-requests: write
@@ -58,8 +58,8 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
-            features/migration-to-aws/skills/gcp-to-aws/references/**/*.md
-            features/migration-to-aws/skills/gcp-to-aws/SKILL.md
+            migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/**/*.md
+            migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md
 
       - name: Skip if no Reference_Files changed
         if: steps.changed-files.outputs.any_changed != 'true'

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,262 @@
+name: PR Audit
+
+# Runs the migration-watchdog currency and automation auditors against
+# Reference_Files changed in a pull request.
+#
+# Security model: this workflow uses `pull_request` (NOT `pull_request_target`),
+# so fork PRs run with a read-only `github.token` that has no write access to
+# secrets. DynamoDB/S3 persistence is skipped gracefully via
+# `continue-on-error: true` on the AWS credentials step.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "features/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
+      - "features/migration-to-aws/skills/gcp-to-aws/SKILL.md"
+
+permissions:
+  pull-requests: write
+  checks: write
+  issues: write
+  id-token: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout content repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          # 3.12 required: currency_auditor.py uses match/case (Python 3.10+)
+
+      # Auth token priority: App token > WATCHDOG_PAT secret > github.token
+      # The `||` chaining in the env block below implements this priority.
+      #
+      # For org-installed GitHub Apps with repository allowlists, add a
+      # `repositories:` parameter here listing the repos the token should
+      # be scoped to (e.g., `repositories: sample-agent-skills-for-aws-migration`).
+      #
+      # Pin this action to a specific commit SHA in production to prevent
+      # supply-chain attacks on the token-generation step.
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.WATCHDOG_APP_ID }}
+          private-key: ${{ secrets.WATCHDOG_APP_PRIVATE_KEY }}
+
+      - name: Detect changed Reference_Files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            features/migration-to-aws/skills/gcp-to-aws/references/**/*.md
+            features/migration-to-aws/skills/gcp-to-aws/SKILL.md
+
+      - name: Skip if no Reference_Files changed
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No Reference_Files changed — skipping audit."
+          exit 0
+
+      # Install the watchdog package.
+      # Clone the watchdog repo, create the migration_watchdog symlink, and
+      # install as an editable package so GHA runs the code in this tree.
+      - name: Clone and install watchdog
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+        run: |
+          # Clone the watchdog repo (replace WATCHDOG_REPO with your actual repo)
+          git clone \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'aws-samples/migration-watchdog' }}.git" \
+            /tmp/migration-watchdog
+
+          # The migration_watchdog/ package directory is at the repo root.
+          # No symlink needed — the directory is named correctly.
+          pip install -e /tmp/migration-watchdog
+          python -c "import migration_watchdog; print('migration_watchdog installed OK')"
+
+      # OIDC credentials for DynamoDB/S3 persistence.
+      # `continue-on-error: true` ensures fork PRs (which lack OIDC access)
+      # proceed without AWS credentials; the watchdog skips persistence gracefully.
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ secrets.WATCHDOG_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Run auditors
+        env:
+          # Auth token priority: App token > WATCHDOG_PAT secret > github.token
+          # Pin the `actions/create-github-app-token` action to a commit SHA
+          # (not a mutable tag) to prevent token exfiltration via tag mutation.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+          WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
+          WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
+          DYNAMODB_TABLE: ${{ vars.DYNAMODB_TABLE }}
+          WATCHDOG_PAYLOAD_BUCKET: ${{ vars.WATCHDOG_PAYLOAD_BUCKET }}
+          TRIGGER_TYPE: pull_request
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+        run: python -m migration_watchdog.main
+
+      - name: Apply CI pass/fail policy
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+          WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
+          WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
+        run: |
+          python - <<'EOF'
+          import json, os, sys
+          import httpx
+
+          if not os.path.exists("audit-report.json"):
+              # No report means the audit step failed or was skipped.
+              # Fail closed: do not silently pass PRs that were never audited.
+              print("FAIL: audit-report.json not found — audit step did not complete successfully")
+              sys.exit(1)
+
+          with open("audit-report.json") as f:
+              report = json.load(f)
+
+          # Check the audit_completed sentinel — if status != "completed", the
+          # audit ran but did not finish successfully. Fail closed.
+          if report.get("status") != "completed":
+              print(f"FAIL: audit-report.json status={report.get('status')!r} — audit did not complete")
+              sys.exit(1)
+
+          findings = report.get("findings", [])
+          token = os.environ.get("GITHUB_TOKEN", "")
+          owner = os.environ.get("WATCHDOG_TARGET_OWNER", "aws-samples")
+          repo = os.environ.get("WATCHDOG_TARGET_REPO", "sample-agent-skills-for-aws-migration")
+
+          has_correctness = False
+          outdated_findings = []
+
+          for finding in findings:
+              payload = finding.get("auditor_payload") or {}
+              severity = payload.get("severity")
+              category = finding.get("category", "")
+
+              if category == "automation_gap":
+                  continue  # automation findings never fail CI
+
+              if severity == "correctness":
+                  has_correctness = True
+                  print(f"FAIL: correctness finding: {finding.get('title', 'unknown')}")
+              elif severity == "outdated":
+                  outdated_findings.append(finding)
+
+          # Open idempotent issues for outdated findings
+          if token and outdated_findings:
+              headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+              for finding in outdated_findings:
+                  payload = finding.get("auditor_payload") or {}
+                  claim_id = payload.get("claim_id", "")
+                  title = f"[Watchdog] Outdated: {finding.get('title', 'unknown')}"
+
+                  # Check for existing open issue with this claim_id
+                  search_resp = httpx.get(
+                      f"https://api.github.com/repos/{owner}/{repo}/issues",
+                      params={"labels": "watchdog-currency-drift", "state": "open"},
+                      headers=headers,
+                      timeout=15,
+                  )
+                  existing = [i for i in search_resp.json() if claim_id in i.get("body", "")]
+
+                  if not existing:
+                      body = f"Outdated claim detected by Migration Watchdog.\n\nclaim_id: {claim_id}\n\n{finding.get('description', '')}"
+                      httpx.post(
+                          f"https://api.github.com/repos/{owner}/{repo}/issues",
+                          json={"title": title, "body": body, "labels": ["watchdog-currency-drift"]},
+                          headers=headers,
+                          timeout=15,
+                      )
+                      print(f"Opened issue for outdated finding: {title}")
+                  else:
+                      print(f"Issue already exists for claim_id {claim_id[:8]}, skipping")
+
+          if has_correctness:
+              print("CI FAILED: one or more correctness findings detected")
+              sys.exit(1)
+          else:
+              print("CI PASSED: no correctness findings")
+              sys.exit(0)
+          EOF
+
+      - name: Upload full report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-report
+          path: audit-report.json
+          if-no-files-found: ignore
+          overwrite: true
+
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ -f audit-report.json ]; then
+            echo "## Watchdog Audit Report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            python - <<'EOF'
+          import json, os, sys
+
+          with open("audit-report.json") as f:
+              report = json.load(f)
+
+          summary_lines = []
+
+          # audit-report.json shape written by _post_pr_comment:
+          # { run_id, pr_number, total_findings, visible_findings,
+          #   findings_by_category, severity_threshold, findings: [...] }
+          findings = report.get("findings", [])
+          visible = report.get("visible_findings", len(findings))
+          total = report.get("total_findings", len(findings))
+
+          summary_lines.append(f"**Findings:** {visible} visible / {total} total")
+          summary_lines.append("")
+
+          by_severity = {}
+          for finding in findings:
+              payload = finding.get("auditor_payload") or {}
+              sev = payload.get("severity") or finding.get("risk_level", "unknown")
+              by_severity[sev] = by_severity.get(sev, 0) + 1
+
+          if by_severity:
+              summary_lines.append("| Severity | Count |")
+              summary_lines.append("|----------|-------|")
+              for sev, count in sorted(by_severity.items()):
+                  summary_lines.append(f"| {sev} | {count} |")
+          else:
+              summary_lines.append("✅ No findings — all audited content looks good.")
+
+          by_cat = report.get("findings_by_category", {})
+          if by_cat:
+              summary_lines.append("")
+              summary_lines.append("| Category | Count |")
+              summary_lines.append("|----------|-------|")
+              for cat, count in sorted(by_cat.items()):
+                  if count:
+                      summary_lines.append(f"| {cat} | {count} |")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("\n".join(summary_lines) + "\n")
+          EOF
+          else
+            echo "No audit-report.json found — audit may have been skipped or failed." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -112,6 +112,7 @@ jobs:
           PR_HTML_URL: ${{ github.event.pull_request.html_url }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: python -m migration_watchdog.main
 
       - name: Apply CI pass/fail policy

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/clarify/clarify.md
@@ -89,6 +89,44 @@ Present a discovery summary:
 
 ---
 
+## Step 1.5: Fast-Path Gate (Simple Infra Only)
+
+**After presenting the Discovery Summary**, check `$MIGRATION_DIR/migration-preview.json` for fast-path eligibility:
+
+```
+IF migration-preview.json exists
+   AND eligible_for_clarify_fast_path == true
+THEN offer fast-path
+ELSE skip to Step 2 (full Clarify)
+```
+
+**If eligible**, present this offer before any questions:
+
+> "Your stack looks straightforward — [primary_resource_count] resource(s), no database, no AI detected.
+>
+> Want to use smart defaults and answer just 3 questions instead of up to 22?
+>
+> **[Yes — 3 questions]** / **[No — ask me everything]**"
+
+**If user chooses Yes (fast-path):**
+
+1. Ask only these three questions (load exact wording from their respective category files):
+   - **Q1** (target region) — from `clarify-global.md`
+   - **Q2** (compliance) — from `clarify-global.md`, presented as a one-liner: "Any compliance requirements? (A) None (B) SOC2 (C) PCI (D) HIPAA (E) FedRAMP (F) GDPR/CCPA"
+   - **Q7** (maintenance window / cutover strategy) — from `clarify-global.md`
+
+2. Apply documented defaults for ALL other questions. Record each in `metadata.questions_defaulted`.
+
+3. Still run the BigQuery advisory if `bigquery_present` is true (Step 4 mandatory callout).
+
+4. Write `preferences.json` with `metadata.clarify_mode: "fast_path"` and proceed to Step 5. Skip Steps 2–4 entirely.
+
+**Agentic hard block:** Even if `migration-preview.json` is absent or `eligible_for_clarify_fast_path` is true, if `ai-workload-profile.json` exists with `agentic_profile.is_agentic == true`, **never offer fast-path**. Agentic workloads require Q23–Q26 (Category G) which are mandatory once PR #16 is merged.
+
+**If user chooses No, or fast-path is not eligible:** Continue to Step 2 (full Clarify).
+
+---
+
 ## Step 2: Extract Known Information
 
 Before generating questions, scan the inventory to extract values that are already known:
@@ -383,6 +421,7 @@ Assemble all interpreted answers from the completed batches into the final `$MIG
     "questions_skipped_early_exit": ["Q8"],
     "questions_skipped_not_applicable": ["Q4", "Q10", "Q11", "Q12", "Q13"],
     "category_e_enabled": false,
+    "clarify_mode": "full",
     "inventory_clarifications": {}
   },
   "design_constraints": {
@@ -479,6 +518,7 @@ Before handing off to Design:
 - [ ] `ai_constraints.ai_framework` is an array (Q14 is multi-select)
 - [ ] Output is valid JSON
 - [ ] `preferences-draft.json` has been deleted (if it existed)
+- [ ] `metadata.clarify_mode` is set to `"fast_path"` or `"full"`
 
 ---
 


### PR DESCRIPTION
Reduces Clarify friction for simple infra stacks. Depends on PR #25 (migration preview) for the `eligible_for_clarify_fast_path` signal.

## Problem

A startup with one Cloud Run service and no database still goes through the same 3-batch, up-to-22-question Clarify workflow as a startup with 12 services, 3 databases, and an agentic AI stack. For simple stacks, the defaults are almost always correct — the only things that genuinely matter are where to deploy, compliance requirements, and when to cut over.

## Changes

**clarify.md** — Step 1.5 (new section between Discovery Summary and Step 2)
- Reads `migration-preview.json` → `eligible_for_clarify_fast_path` (written by PR #25)
- Presents opt-in offer: "3 questions instead of up to 22"
- Fast-path asks only Q1 (region), Q2 (compliance), Q7 (cutover window)
- All other questions get documented defaults, recorded in `metadata.questions_defaulted`
- BigQuery advisory still fires if `bigquery_present` is true
- Writes `metadata.clarify_mode: "fast_path"` to `preferences.json`
- Skips Steps 2–4 entirely on fast-path

## Eligibility criteria (from discover-preview.md in PR #25)

- primary_resource_count <= 3
- No google_sql_*, google_spanner_*, google_redis_*
- No google_bigquery_*
- is_agentic != true
- billing absent OR total_monthly_spend < 1000
- has_ai_profile == false (any AI profile routes to full Clarify)

## Key design decisions

- **Q2 (compliance) is mandatory** — missing compliance on a simple stack that later needs SOC2 is a real failure mode. 3 questions not 2.
- **Agentic hard block** — even if eligibility check passes, is_agentic == true always blocks fast-path. Q23–Q26 are mandatory for agentic workloads.
- **Any AI profile blocks fast-path** — non-agentic AI still routes to full Clarify for Bedrock model selection questions.
- **Opt-in, not opt-out** — user must explicitly choose "Yes — 3 questions". Default is full Clarify.
- **clarify_mode is auditable** — Design/Generate can reference it; useful for future doc shortening and telemetry.

## Merge order

- Merge PR #25 first — this PR reads migration-preview.json which PR #25 writes. Without it, Step 1.5 skips gracefully.
- Merge PR #16 before testing agentic stacks — the agentic hard block references Q23–Q26 which are broken on main until #16 merges.

## Type of Change

- [x] Enhancement to existing content

## Team Folder

- [x] `migrate/`