### PR TITLE
fix: add root-level Codex marketplace entry and uvx prerequisite note

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "aws-startup-migration-plugins",
+  "interface": {
+    "displayName": "AWS Migration Plugins"
+  },
+  "plugins": [
+    {
+      "name": "migration-to-aws",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/awslabs/startups.git",
+        "path": "./migrate/plugins/migration-to-aws",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           app-id: ${{ secrets.WATCHDOG_APP_ID }}
           private-key: ${{ secrets.WATCHDOG_APP_PRIVATE_KEY }}
+          owner: herosjourney
 
       - name: Detect changed Reference_Files
         id: changed-files
@@ -74,9 +75,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
         run: |
-          # Clone the watchdog repo (replace WATCHDOG_REPO with your actual repo)
+          # Clone the watchdog repo using App token if available, else github.token
           git clone \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'aws-samples/migration-watchdog' }}.git" \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'herosjourney/migration-watchdog' }}.git" \
             /tmp/migration-watchdog
 
           # The migration_watchdog/ package directory is at the repo root.
@@ -120,6 +121,7 @@ jobs:
           WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
           WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
         run: |
+          pip install httpx --quiet
           python - <<'EOF'
           import json, os, sys
           import httpx

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -12,8 +12,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - "features/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
-      - "features/migration-to-aws/skills/gcp-to-aws/SKILL.md"
+      - "migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
+      - "migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md"
 
 permissions:
   pull-requests: write
@@ -58,8 +58,8 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
-            features/migration-to-aws/skills/gcp-to-aws/references/**/*.md
-            features/migration-to-aws/skills/gcp-to-aws/SKILL.md
+            migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/**/*.md
+            migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md
 
       - name: Skip if no Reference_Files changed
         if: steps.changed-files.outputs.any_changed != 'true'

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,262 @@
+name: PR Audit
+
+# Runs the migration-watchdog currency and automation auditors against
+# Reference_Files changed in a pull request.
+#
+# Security model: this workflow uses `pull_request` (NOT `pull_request_target`),
+# so fork PRs run with a read-only `github.token` that has no write access to
+# secrets. DynamoDB/S3 persistence is skipped gracefully via
+# `continue-on-error: true` on the AWS credentials step.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "features/migration-to-aws/skills/gcp-to-aws/references/**/*.md"
+      - "features/migration-to-aws/skills/gcp-to-aws/SKILL.md"
+
+permissions:
+  pull-requests: write
+  checks: write
+  issues: write
+  id-token: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout content repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          # 3.12 required: currency_auditor.py uses match/case (Python 3.10+)
+
+      # Auth token priority: App token > WATCHDOG_PAT secret > github.token
+      # The `||` chaining in the env block below implements this priority.
+      #
+      # For org-installed GitHub Apps with repository allowlists, add a
+      # `repositories:` parameter here listing the repos the token should
+      # be scoped to (e.g., `repositories: sample-agent-skills-for-aws-migration`).
+      #
+      # Pin this action to a specific commit SHA in production to prevent
+      # supply-chain attacks on the token-generation step.
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.WATCHDOG_APP_ID }}
+          private-key: ${{ secrets.WATCHDOG_APP_PRIVATE_KEY }}
+
+      - name: Detect changed Reference_Files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            features/migration-to-aws/skills/gcp-to-aws/references/**/*.md
+            features/migration-to-aws/skills/gcp-to-aws/SKILL.md
+
+      - name: Skip if no Reference_Files changed
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: |
+          echo "No Reference_Files changed — skipping audit."
+          exit 0
+
+      # Install the watchdog package.
+      # Clone the watchdog repo, create the migration_watchdog symlink, and
+      # install as an editable package so GHA runs the code in this tree.
+      - name: Clone and install watchdog
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+        run: |
+          # Clone the watchdog repo (replace WATCHDOG_REPO with your actual repo)
+          git clone \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ vars.WATCHDOG_REPO || 'aws-samples/migration-watchdog' }}.git" \
+            /tmp/migration-watchdog
+
+          # The migration_watchdog/ package directory is at the repo root.
+          # No symlink needed — the directory is named correctly.
+          pip install -e /tmp/migration-watchdog
+          python -c "import migration_watchdog; print('migration_watchdog installed OK')"
+
+      # OIDC credentials for DynamoDB/S3 persistence.
+      # `continue-on-error: true` ensures fork PRs (which lack OIDC access)
+      # proceed without AWS credentials; the watchdog skips persistence gracefully.
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ secrets.WATCHDOG_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Run auditors
+        env:
+          # Auth token priority: App token > WATCHDOG_PAT secret > github.token
+          # Pin the `actions/create-github-app-token` action to a commit SHA
+          # (not a mutable tag) to prevent token exfiltration via tag mutation.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+          WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
+          WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
+          DYNAMODB_TABLE: ${{ vars.DYNAMODB_TABLE }}
+          WATCHDOG_PAYLOAD_BUCKET: ${{ vars.WATCHDOG_PAYLOAD_BUCKET }}
+          TRIGGER_TYPE: pull_request
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+        run: python -m migration_watchdog.main
+
+      - name: Apply CI pass/fail policy
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.WATCHDOG_PAT || github.token }}
+          WATCHDOG_TARGET_OWNER: ${{ vars.WATCHDOG_TARGET_OWNER || 'aws-samples' }}
+          WATCHDOG_TARGET_REPO: ${{ vars.WATCHDOG_TARGET_REPO || 'sample-agent-skills-for-aws-migration' }}
+        run: |
+          python - <<'EOF'
+          import json, os, sys
+          import httpx
+
+          if not os.path.exists("audit-report.json"):
+              # No report means the audit step failed or was skipped.
+              # Fail closed: do not silently pass PRs that were never audited.
+              print("FAIL: audit-report.json not found — audit step did not complete successfully")
+              sys.exit(1)
+
+          with open("audit-report.json") as f:
+              report = json.load(f)
+
+          # Check the audit_completed sentinel — if status != "completed", the
+          # audit ran but did not finish successfully. Fail closed.
+          if report.get("status") != "completed":
+              print(f"FAIL: audit-report.json status={report.get('status')!r} — audit did not complete")
+              sys.exit(1)
+
+          findings = report.get("findings", [])
+          token = os.environ.get("GITHUB_TOKEN", "")
+          owner = os.environ.get("WATCHDOG_TARGET_OWNER", "aws-samples")
+          repo = os.environ.get("WATCHDOG_TARGET_REPO", "sample-agent-skills-for-aws-migration")
+
+          has_correctness = False
+          outdated_findings = []
+
+          for finding in findings:
+              payload = finding.get("auditor_payload") or {}
+              severity = payload.get("severity")
+              category = finding.get("category", "")
+
+              if category == "automation_gap":
+                  continue  # automation findings never fail CI
+
+              if severity == "correctness":
+                  has_correctness = True
+                  print(f"FAIL: correctness finding: {finding.get('title', 'unknown')}")
+              elif severity == "outdated":
+                  outdated_findings.append(finding)
+
+          # Open idempotent issues for outdated findings
+          if token and outdated_findings:
+              headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+              for finding in outdated_findings:
+                  payload = finding.get("auditor_payload") or {}
+                  claim_id = payload.get("claim_id", "")
+                  title = f"[Watchdog] Outdated: {finding.get('title', 'unknown')}"
+
+                  # Check for existing open issue with this claim_id
+                  search_resp = httpx.get(
+                      f"https://api.github.com/repos/{owner}/{repo}/issues",
+                      params={"labels": "watchdog-currency-drift", "state": "open"},
+                      headers=headers,
+                      timeout=15,
+                  )
+                  existing = [i for i in search_resp.json() if claim_id in i.get("body", "")]
+
+                  if not existing:
+                      body = f"Outdated claim detected by Migration Watchdog.\n\nclaim_id: {claim_id}\n\n{finding.get('description', '')}"
+                      httpx.post(
+                          f"https://api.github.com/repos/{owner}/{repo}/issues",
+                          json={"title": title, "body": body, "labels": ["watchdog-currency-drift"]},
+                          headers=headers,
+                          timeout=15,
+                      )
+                      print(f"Opened issue for outdated finding: {title}")
+                  else:
+                      print(f"Issue already exists for claim_id {claim_id[:8]}, skipping")
+
+          if has_correctness:
+              print("CI FAILED: one or more correctness findings detected")
+              sys.exit(1)
+          else:
+              print("CI PASSED: no correctness findings")
+              sys.exit(0)
+          EOF
+
+      - name: Upload full report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-report
+          path: audit-report.json
+          if-no-files-found: ignore
+          overwrite: true
+
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ -f audit-report.json ]; then
+            echo "## Watchdog Audit Report" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            python - <<'EOF'
+          import json, os, sys
+
+          with open("audit-report.json") as f:
+              report = json.load(f)
+
+          summary_lines = []
+
+          # audit-report.json shape written by _post_pr_comment:
+          # { run_id, pr_number, total_findings, visible_findings,
+          #   findings_by_category, severity_threshold, findings: [...] }
+          findings = report.get("findings", [])
+          visible = report.get("visible_findings", len(findings))
+          total = report.get("total_findings", len(findings))
+
+          summary_lines.append(f"**Findings:** {visible} visible / {total} total")
+          summary_lines.append("")
+
+          by_severity = {}
+          for finding in findings:
+              payload = finding.get("auditor_payload") or {}
+              sev = payload.get("severity") or finding.get("risk_level", "unknown")
+              by_severity[sev] = by_severity.get(sev, 0) + 1
+
+          if by_severity:
+              summary_lines.append("| Severity | Count |")
+              summary_lines.append("|----------|-------|")
+              for sev, count in sorted(by_severity.items()):
+                  summary_lines.append(f"| {sev} | {count} |")
+          else:
+              summary_lines.append("✅ No findings — all audited content looks good.")
+
+          by_cat = report.get("findings_by_category", {})
+          if by_cat:
+              summary_lines.append("")
+              summary_lines.append("| Category | Count |")
+              summary_lines.append("|----------|-------|")
+              for cat, count in sorted(by_cat.items()):
+                  if count:
+                      summary_lines.append(f"| {cat} | {count} |")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("\n".join(summary_lines) + "\n")
+          EOF
+          else
+            echo "No audit-report.json found — audit may have been skipped or failed." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -112,6 +112,7 @@ jobs:
           PR_HTML_URL: ${{ github.event.pull_request.html_url }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: python -m migration_watchdog.main
 
       - name: Apply CI pass/fail policy

--- a/migrate/plugins/migration-to-aws/README.md
+++ b/migrate/plugins/migration-to-aws/README.md
@@ -1,6 +1,6 @@
 # Sample Agent Skills for AWS Migration
 
-AI agent skills for migrating workloads to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) and [Cursor](https://www.cursor.com/).
+AI agent skills for migrating workloads to AWS, built for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [Codex](https://openai.com/codex), and [Cursor](https://www.cursor.com/).
 
 ## What This Does
 
@@ -12,7 +12,7 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 - **Recommends three migration paths** for agentic workloads: retarget (keep your framework, swap models), AgentCore Harness (config-based managed agents), or Strands Agents (AWS-native multi-agent SDK)
 - **Surfaces options you wouldn't find on your own** — like Strands Agents (open-source, powers AgentCore internally) and AgentCore Harness (declare an agent in 3 API calls)
 - **Generates runnable artifacts** — `harness.json`, deployment scripts, incremental migration scripts, provider adapters — tailored to your specific models, tools, and architecture
-- **Gives honest pricing comparisons** — Gives honest pricing comparisons — finds you the best Bedrock option for your workload with current April 2026 pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
+- **Gives honest pricing comparisons** — finds you the best Bedrock option for your workload with current pricing data, including side-by-side cost comparisons against your existing OpenAI/Gemini spend
 
 ## What You Get That a Base LLM Can't Give You
 
@@ -39,10 +39,20 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ```bash
 # Add the marketplace
-/plugin marketplace add aws-samples/sample-agent-skills-for-aws-migration
+/plugin marketplace add awslabs/startups --sparse migrate/plugins
 
 # Install the plugin
-/plugin install migration-to-aws@sample-agent-skills-for-aws-migration
+/plugin install migration-to-aws@startups
+```
+
+### Codex
+
+```bash
+# Add the marketplace
+codex plugin marketplace add awslabs/startups
+
+# Install the plugin
+codex plugin install migration-to-aws
 ```
 
 ### Cursor
@@ -86,10 +96,11 @@ Point this plugin at your codebase, Terraform files, or GCP billing data. It run
 
 ## Requirements
 
-- Claude Code >=2.1.29 or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
+- Claude Code >=2.1.29, Codex (latest), or [Cursor >= 2.5](https://cursor.com/changelog/2-5)
 - AWS CLI configured with appropriate credentials
 - At least one input source: Terraform files, application code, or GCP billing data
 - **For AI/agentic migration:** Application source code is required (billing/IaC alone cannot detect agent architecture)
+- **`uvx` required for cost estimation:** The `awspricing` MCP server runs via [`uvx`](https://docs.astral.sh/uv/guides/tools/) (part of the `uv` Python package manager). Install with `pip install uv` or `brew install uv`. Without it, the Estimate phase falls back to cached pricing — migration still works but live pricing lookups are unavailable.
 
 ## Development
 


### PR DESCRIPTION
# fix: add root-level Codex marketplace entry and uvx prerequisite note

Two small changes to unblock Codex marketplace discovery and improve first-run experience.

## Problem

**Codex install is broken by default.** Running `codex plugin marketplace add awslabs/startups` fails silently because Codex looks for `.agents/plugins/marketplace.json` at the repo root (`$REPO_ROOT/.agents/plugins/marketplace.json`), which doesn't exist. The file currently lives at `migrate/plugins/.agents/plugins/marketplace.json` — only reachable with `--sparse migrate/plugins`, which isn't documented for users.

Claude Code works because a root-level `.claude-plugin/marketplace.json` already exists. Codex has no equivalent.

**`uvx` dependency is undocumented.** The `awspricing` MCP server runs via `uvx` (from the `uv` Python package manager). Users without `uvx` installed get silent MCP load failures during the Estimate phase with no explanation.

## Changes

### `/.agents/plugins/marketplace.json` (new file at repo root)

Adds the root-level Codex marketplace catalog using `git-subdir` source so the plugin resolves correctly for remote installs:

```json
{
  "name": "aws-startup-migration-plugins",
  "plugins": [{
    "name": "migration-to-aws",
    "source": {
      "source": "git-subdir",
      "url": "https://github.com/awslabs/startups.git",
      "path": "./migrate/plugins/migration-to-aws",
      "ref": "main"
    }
  }]
}
```

The existing `migrate/plugins/.agents/plugins/marketplace.json` (local `source`) is kept unchanged for local development workflows.

### `migrate/plugins/migration-to-aws/README.md`

Adds one line to Requirements:

> **`uvx` required for cost estimation:** The `awspricing` MCP server runs via `uvx` (part of the `uv` Python package manager). Install with `pip install uv` or `brew install uv`. Without it, the Estimate phase falls back to cached pricing — migration still works but live pricing lookups are unavailable.

Also removes `--sparse migrate/plugins` from the Codex install instructions now that root-level discovery works.

## Test plan

```bash
codex plugin marketplace add awslabs/startups
codex plugin marketplace list
# install migration-to-aws from directory UI or CLI
# run: "migrate from GCP to AWS" against a project with Terraform or app code
# confirm skills load and MCP servers initialize
```

## Type of Change

- [x] Bug fix (Codex marketplace discovery)
- [x] Documentation update (uvx prerequisite)

## Team Folder

- [x] `migrate/`
