### PR TITLE
Update description/version to 1.3.2 and fix migration agent links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,8 +14,8 @@
     {
       "name": "aws-startup-advisor",
       "source": "./advisor/plugins/aws-startup-advisor",
-      "version": "1.3.1",
-      "description": "AWS Startup Advisor delivers personalized architecture, cost, and security guidance with expertise from AWS Startup Solutions Architects."
+      "version": "1.3.2",
+      "description": "AI-powered build guidance from AWS Solutions Architects, built for startups at any stage."
     }
   ]
 }

--- a/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
-  "version": "1.3.1",
-  "description": "AWS Startup Advisor delivers personalized architecture, cost, and security guidance with expertise from AWS Startup Solutions Architects.",
+  "version": "1.3.2",
+  "description": "AI-powered build guidance from AWS Solutions Architects, built for startups at any stage.",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
-  "description": "AWS Startup Advisor delivers personalized architecture, cost, and security guidance with expertise from AWS Startup Solutions Architects.",
-  "version": "1.3.1",
+  "description": "AI-powered build guidance from AWS Solutions Architects, built for startups at any stage.",
+  "version": "1.3.2",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/SKILL.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/SKILL.md
@@ -44,7 +44,7 @@ When the user asks for a prompt:
 
 The 4 entries in the **Downloadable agents** section of `references/prompt-library.md` are **installable agents**, not copy-paste prompts:
 
-- **AWS Migration Agent** — Terraform-based discovery + migration of GCP / OpenAI / Gemini workloads to AWS. Repo: https://github.com/aws-samples/sample-agent-skills-for-aws-migration
+- **AWS Migration Agent** — Terraform-based discovery + migration of GCP / OpenAI / Gemini workloads to AWS. Now the `migration-to-aws` plugin: https://github.com/awslabs/startups/tree/main/migrate
 - **AWS Multi-Account Transition Advisor** — guides single-account → multi-account (AWS Organizations + OUs).
 - **AWS Bill Shock Preventer** — proactive cost-spike detection and alerting.
 - **AWS Service Quota Agent** — auditing and requesting quota increases.

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library.md
@@ -65,8 +65,13 @@ Tags: Cloud-Migration Intermediate
 
 AI agent skills for migrating workloads to AWS, built for Claude Code and Cursor.
 
-Agent Details: This agent helps you migrate Google Cloud Platform (GCP) infrastructure and AI models such as OpenAI and Gemini to AWS through Terraform resource discovery, architecture mapping, cost estimation, and execution planning.
-You can download the agent from here: https://github.com/aws-samples/sample-agent-skills-for-aws-migration
+Agent Details: This agent helps you migrate Google Cloud Platform (GCP) infrastructure and AI models such as OpenAI and Gemini to AWS through Terraform resource discovery, architecture mapping, cost estimation, and execution planning. It has moved into the `awslabs/startups` repo as the `migration-to-aws` plugin: https://github.com/awslabs/startups/tree/main/migrate
+
+Install it with your AI coding tool:
+
+- **Claude Code:** `/plugin marketplace add awslabs/startups --sparse migrate/plugins` then `/plugin install migration-to-aws@startups`
+- **Codex:** `codex plugin marketplace add awslabs/startups --sparse migrate/plugins` then `codex plugin install migration-to-aws`
+- **Other tools:** install from the marketplace at https://github.com/awslabs/startups/tree/main/migrate
 
 ### [AWS Multi-Account Transition Advisor](https://aws.amazon.com/startups/prompt-library/multi-account-transition-advisor)
 


### PR DESCRIPTION
## Description

* Bumps aws-startup-advisor to v1.3.2 with new description ("AI-powered build guidance from AWS Solutions Architects, built for startups at any stage.") across .claude-plugin/plugin.json, .cursor-plugin/plugin.json, and the public marketplace.json entry.
* replaces the relocated AWS Migration Agent links (aws-samples/sample-agent-skills-for-aws-migration → awslabs/startups/tree/main/migrate) in prompt-library-for-startups SKILL.md and prompt-library.md, and swaps "download from here" for the migration-to-aws plugin's per-tool marketplace install commands (Claude Code, Codex, generic fallback).

## Type of Change

- [ ] New plugin/power/tool
- [ ] Bug fix
- [x] Enhancement to existing content
- [x] Documentation update
- [ ] Guardrail/CI update

## Team Folder

<!-- Which top-level folder does this PR affect? -->

- [ ] `migrate/`
- [x] Other: `advisor/`

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [x] I have run `mise run build` locally and it passes
- [x] I have updated documentation if needed
- [x] My changes are scoped to my team's folder only
