### PR TITLE
Bump aws-startup-advisor version to release architect-for-startups

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "aws-startup-advisor",
       "source": "./advisor/plugins/aws-startup-advisor",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "description": "Three sibling skills for startups building on AWS: knowledge-base-for-startups (Activate FAQ, credits, programs, partner offers, sample architectures, learn articles), prompt-library-for-startups (copy-paste prompts + downloadable installable agents), and start-building-for-startups (interactive discovery workflow that scaffolds an AWS architecture)"
     },
     {

--- a/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
   "author": {
     "name": "Amazon Web Services"

--- a/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-startup-advisor",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
   "author": {
     "name": "Amazon Web Services",

--- a/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "author": {
     "name": "Amazon Web Services"
   },


### PR DESCRIPTION
## Description

Bumps version for startup advisor plugin

## Type of Change

- [ ] New plugin/power/tool
- [ ] Bug fix
- [x] Enhancement to existing content
- [ ] Documentation update
- [ ] Guardrail/CI update

## Team Folder

<!-- Which top-level folder does this PR affect? -->

- [ ] `advisor/`
- [ ] `migrate/`
- [X] Other: root

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [x] I have run `mise run build` locally and it passes
- [x] I have updated documentation if needed
- [ ] My changes are scoped to my team's folder only
