### PR TITLE
Extract heroku-to-aws design lookup tables to structured JSON

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/dyno-fargate-sizing.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/dyno-fargate-sizing.json
@@ -1,0 +1,83 @@
+{
+  "_comment": "Dyno type -> Fargate sizing. DIRECT LOOKUP: read fargate_cpu/fargate_memory columns; do NOT recompute them. heroku_cpu_share/heroku_memory_mb are PROVENANCE ONLY (why this row meets-or-exceeds the source) — never derive the fargate values from them. fargate_cpu in CPU units (1024 = 1 vCPU); fargate_memory in MiB. All rows are valid Fargate CPU/memory pairings.",
+  "_match": "exact, case-insensitive, on formation config.dyno_type",
+  "_on_not_found": "reject the formation; produce NO Fargate entry; append warning 'Unsupported dyno type: {dyno_type}. Cannot map to Fargate. Please contact support or provide manual sizing.'; continue",
+  "_desired_count": {
+    "from": "formation config.quantity",
+    "min": 0,
+    "max": 100,
+    "on_out_of_range": "clamp to nearest boundary AND append a warning naming the clamp"
+  },
+  "_load_balancer": "true iff process_type == 'web' (also emits a separate ALB service entry); false otherwise",
+  "rows": {
+    "standard-1x": { "heroku_cpu_share": "1x", "heroku_memory_mb": 512, "fargate_cpu": 256, "fargate_memory": 512 },
+    "standard-2x": { "heroku_cpu_share": "2x", "heroku_memory_mb": 1024, "fargate_cpu": 512, "fargate_memory": 1024 },
+    "performance-m": {
+      "heroku_cpu_share": "6x",
+      "heroku_memory_mb": 2560,
+      "fargate_cpu": 1024,
+      "fargate_memory": 2048
+    },
+    "performance-l": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 14336,
+      "fargate_cpu": 4096,
+      "fargate_memory": 16384
+    },
+    "performance-l-ram": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 30720,
+      "fargate_cpu": 4096,
+      "fargate_memory": 30720
+    },
+    "performance-xl": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 63488,
+      "fargate_cpu": 8192,
+      "fargate_memory": 65536
+    },
+    "performance-2xl": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 129024,
+      "fargate_cpu": 16384,
+      "fargate_memory": 122880
+    },
+    "private-s": { "heroku_cpu_share": "1x", "heroku_memory_mb": 1024, "fargate_cpu": 512, "fargate_memory": 1024 },
+    "private-m": { "heroku_cpu_share": "6x", "heroku_memory_mb": 2560, "fargate_cpu": 1024, "fargate_memory": 2048 },
+    "private-l": { "heroku_cpu_share": "12x", "heroku_memory_mb": 14336, "fargate_cpu": 4096, "fargate_memory": 16384 },
+    "private-l-ram": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 30720,
+      "fargate_cpu": 4096,
+      "fargate_memory": 30720
+    },
+    "private-xl": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 63488,
+      "fargate_cpu": 8192,
+      "fargate_memory": 65536
+    },
+    "private-2xl": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 129024,
+      "fargate_cpu": 16384,
+      "fargate_memory": 122880
+    },
+    "shield-s": { "heroku_cpu_share": "1x", "heroku_memory_mb": 1024, "fargate_cpu": 512, "fargate_memory": 1024 },
+    "shield-m": { "heroku_cpu_share": "6x", "heroku_memory_mb": 2560, "fargate_cpu": 1024, "fargate_memory": 2048 },
+    "shield-l": { "heroku_cpu_share": "12x", "heroku_memory_mb": 14336, "fargate_cpu": 4096, "fargate_memory": 16384 },
+    "shield-l-ram": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 30720,
+      "fargate_cpu": 4096,
+      "fargate_memory": 30720
+    },
+    "shield-xl": { "heroku_cpu_share": "12x", "heroku_memory_mb": 63488, "fargate_cpu": 8192, "fargate_memory": 65536 },
+    "shield-2xl": {
+      "heroku_cpu_share": "12x",
+      "heroku_memory_mb": 129024,
+      "fargate_cpu": 16384,
+      "fargate_memory": 122880
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/fast-path-addons.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/fast-path-addons.json
@@ -1,0 +1,47 @@
+{
+  "_comment": "Fast-path add-on -> AWS service mapping for non-core add-ons (anything that is NOT heroku-postgresql/heroku-redis/heroku-kafka). DIRECT LOOKUP on a normalized name. All matches get confidence 'deterministic'.",
+  "_match": "EXACT, case-insensitive, full-string match on the NORMALIZED add-on name against a rows key. Partial matches are INVALID (e.g. 'paper' does NOT match 'papertrail'; 'New Relic APM' does NOT match 'new relic').",
+  "_normalize": "from config.addon_service: strip a leading 'heroku-' prefix; replace hyphens with spaces; lowercase. Then apply the prefix aliases below before matching.",
+  "_prefix_aliases": {
+    "bonsai": "bonsai elasticsearch",
+    "scout": "scout apm",
+    "newrelic": "new relic",
+    "new-relic": "new relic"
+  },
+  "_on_not_found": "route to the specialist gate: append a deferred[] entry {addon_name, addon_plan, provider, reason: 'Not found in Fast_Path_Table', recommendation: 'Engage AWS account team for replacement selection'}; produce NO service entry; continue",
+  "rows": {
+    "papertrail": { "type": "single", "aws_services": ["CloudWatch Logs"], "notes": "Log aggregation and search" },
+    "sendgrid": { "type": "single", "aws_services": ["Amazon SES"], "notes": "Transactional and marketing email" },
+    "heroku scheduler": {
+      "type": "single",
+      "aws_services": ["EventBridge Scheduler"],
+      "notes": "Cron-style scheduled jobs"
+    },
+    "memcachier": {
+      "type": "single",
+      "aws_services": ["ElastiCache Memcached"],
+      "notes": "In-memory caching (Memcached protocol)"
+    },
+    "bucketeer": { "type": "single", "aws_services": ["S3"], "notes": "Object/file storage" },
+    "cloudamqp": { "type": "single", "aws_services": ["Amazon MQ"], "notes": "RabbitMQ-compatible message broker" },
+    "bonsai elasticsearch": {
+      "type": "single",
+      "aws_services": ["Amazon OpenSearch"],
+      "notes": "Full-text search and analytics"
+    },
+    "scout apm": { "type": "composite", "aws_services": ["CloudWatch", "X-Ray"], "notes": "APM + distributed tracing" },
+    "rollbar": { "type": "single", "aws_services": ["CloudWatch"], "notes": "Error tracking via structured logs" },
+    "new relic": {
+      "type": "composite",
+      "aws_services": ["CloudWatch", "X-Ray"],
+      "notes": "Full-stack observability + distributed tracing"
+    },
+    "twilio": { "type": "single", "aws_services": ["Amazon SNS (SMS)"], "notes": "SMS messaging" },
+    "cloudinary": {
+      "type": "composite",
+      "aws_services": ["S3", "CloudFront"],
+      "notes": "Media storage + CDN delivery"
+    },
+    "sentry": { "type": "single", "aws_services": ["CloudWatch"], "notes": "Error tracking via structured logs" }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/kafka-msk-sizing.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/kafka-msk-sizing.json
@@ -1,0 +1,113 @@
+{
+  "_comment": "Heroku Kafka plan -> MSK sizing. DIRECT LOOKUP: read broker_instance_type / storage_per_broker_gb / max_topics / max_partitions. throughput/storage are PROVENANCE ONLY.",
+  "_match": "exact, case-insensitive, on addon config.plan",
+  "_on_not_found": "defer to specialist gate; append warning 'Unrecognized heroku-kafka plan tier: {plan}. Cannot determine MSK broker instance type. Deferring to specialist engagement.'; continue",
+  "_broker_count_and_azs": {
+    "basic": { "broker_count": 2, "availability_zones": 2 },
+    "standard|extended|private": { "broker_count": 3, "availability_zones": 3 },
+    "_floor": "never fewer than 2 brokers or 2 AZs"
+  },
+  "_topology_preservation": "max_topics from config.topics else row; max_partitions from config.partitions else row; replication_factor from config.replication_factor else default (3 for standard/extended/private, 2 for basic)",
+  "rows": {
+    "basic-0": {
+      "tier": "basic",
+      "max_topics": 20,
+      "max_partitions": 40,
+      "storage": "4 GB",
+      "throughput": "5 MB/s",
+      "broker_instance_type": "kafka.t3.small",
+      "storage_per_broker_gb": 10,
+      "default_replication_factor": 2
+    },
+    "standard-0": {
+      "tier": "standard",
+      "max_topics": 40,
+      "max_partitions": 160,
+      "storage": "50 GB",
+      "throughput": "20 MB/s",
+      "broker_instance_type": "kafka.m5.large",
+      "storage_per_broker_gb": 100,
+      "default_replication_factor": 3
+    },
+    "standard-1": {
+      "tier": "standard",
+      "max_topics": 100,
+      "max_partitions": 400,
+      "storage": "200 GB",
+      "throughput": "50 MB/s",
+      "broker_instance_type": "kafka.m5.xlarge",
+      "storage_per_broker_gb": 250,
+      "default_replication_factor": 3
+    },
+    "standard-2": {
+      "tier": "standard",
+      "max_topics": 200,
+      "max_partitions": 1600,
+      "storage": "1 TB",
+      "throughput": "100 MB/s",
+      "broker_instance_type": "kafka.m5.2xlarge",
+      "storage_per_broker_gb": 500,
+      "default_replication_factor": 3
+    },
+    "extended-0": {
+      "tier": "extended",
+      "max_topics": 200,
+      "max_partitions": 2000,
+      "storage": "2 TB",
+      "throughput": "150 MB/s",
+      "broker_instance_type": "kafka.m5.4xlarge",
+      "storage_per_broker_gb": 1024,
+      "default_replication_factor": 3
+    },
+    "extended-1": {
+      "tier": "extended",
+      "max_topics": 400,
+      "max_partitions": 4000,
+      "storage": "4 TB",
+      "throughput": "200 MB/s",
+      "broker_instance_type": "kafka.m5.8xlarge",
+      "storage_per_broker_gb": 2048,
+      "default_replication_factor": 3
+    },
+    "extended-2": {
+      "tier": "extended",
+      "max_topics": 600,
+      "max_partitions": 8000,
+      "storage": "8 TB",
+      "throughput": "300 MB/s",
+      "broker_instance_type": "kafka.m5.12xlarge",
+      "storage_per_broker_gb": 4096,
+      "default_replication_factor": 3
+    },
+    "private-extended-0": {
+      "tier": "private",
+      "max_topics": 200,
+      "max_partitions": 2000,
+      "storage": "2 TB",
+      "throughput": "150 MB/s",
+      "broker_instance_type": "kafka.m5.4xlarge",
+      "storage_per_broker_gb": 1024,
+      "default_replication_factor": 3
+    },
+    "private-extended-1": {
+      "tier": "private",
+      "max_topics": 400,
+      "max_partitions": 4000,
+      "storage": "4 TB",
+      "throughput": "200 MB/s",
+      "broker_instance_type": "kafka.m5.8xlarge",
+      "storage_per_broker_gb": 2048,
+      "default_replication_factor": 3
+    },
+    "private-extended-2": {
+      "tier": "private",
+      "max_topics": 600,
+      "max_partitions": 8000,
+      "storage": "8 TB",
+      "throughput": "300 MB/s",
+      "broker_instance_type": "kafka.m5.12xlarge",
+      "storage_per_broker_gb": 4096,
+      "default_replication_factor": 3
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/postgres-rds-sizing.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/postgres-rds-sizing.json
@@ -1,0 +1,340 @@
+{
+  "_comment": "Heroku Postgres plan -> RDS/Aurora sizing. DIRECT LOOKUP: read the recommended instance class column for the selected engine. ram/storage_gb/connections/ha/src_connection_pooling are PROVENANCE ONLY (why the row was chosen / source plan facts) — do not recompute the instance class from them, and do NOT use src_connection_pooling for rds_proxy. storage_gb is the minimum storage to allocate (configure >= this).",
+  "_match": "exact, case-insensitive, on addon config.plan",
+  "_on_not_found": "defer to specialist gate; append warning 'Unrecognized heroku-postgresql plan tier: {plan}. Cannot determine AWS sizing. Deferring to specialist engagement.'; continue",
+  "_engine_selection": {
+    "single-az": "RDS PostgreSQL (use rds_instance_class)",
+    "multi-az": "RDS PostgreSQL (use rds_instance_class)",
+    "multi-az-ha": "Aurora PostgreSQL (use aurora_instance_class)",
+    "multi-region": "Aurora PostgreSQL (use aurora_instance_class)",
+    "_source": "preferences.data.database_ha if set else preferences.global.availability",
+    "_on_unset_or_unrecognized": "default to multi-az + RDS PostgreSQL + warning"
+  },
+  "_multi_az": "true when the selected availability is multi-az, multi-az-ha, or multi-region",
+  "_rds_proxy": "true when the INVENTORY addon's config.connection_pooling == true (the discovered source fact). NOT the row's src_connection_pooling provenance column.",
+  "_shield_note": "shield-* plans are HIPAA/PCI equivalents of private-*; map identically but note the compliance requirement",
+  "rows": {
+    "essential-0": {
+      "ram": "0 MB (shared)",
+      "storage_gb": 1,
+      "connections": 20,
+      "ha": false,
+      "src_connection_pooling": false,
+      "rds_instance_class": "db.t4g.micro",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "essential-1": {
+      "ram": "0 MB (shared)",
+      "storage_gb": 10,
+      "connections": 20,
+      "ha": false,
+      "src_connection_pooling": false,
+      "rds_instance_class": "db.t4g.micro",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "essential-2": {
+      "ram": "0 MB (shared)",
+      "storage_gb": 32,
+      "connections": 40,
+      "ha": false,
+      "src_connection_pooling": false,
+      "rds_instance_class": "db.t4g.micro",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "hobby-dev": {
+      "ram": "0 MB (shared)",
+      "storage_gb": 1,
+      "connections": 20,
+      "ha": false,
+      "src_connection_pooling": false,
+      "rds_instance_class": "db.t4g.micro",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "hobby-basic": {
+      "ram": "0 MB (shared)",
+      "storage_gb": 10,
+      "connections": 20,
+      "ha": false,
+      "src_connection_pooling": false,
+      "rds_instance_class": "db.t4g.micro",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "standard-0": {
+      "ram": "4 GB",
+      "storage_gb": 64,
+      "connections": 120,
+      "ha": false,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.t4g.medium",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "standard-2": {
+      "ram": "8 GB",
+      "storage_gb": 256,
+      "connections": 400,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.large",
+      "aurora_instance_class": "db.r6g.large"
+    },
+    "standard-3": {
+      "ram": "15 GB",
+      "storage_gb": 512,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.xlarge",
+      "aurora_instance_class": "db.r6g.xlarge"
+    },
+    "standard-4": {
+      "ram": "30 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.2xlarge",
+      "aurora_instance_class": "db.r6g.2xlarge"
+    },
+    "standard-5": {
+      "ram": "61 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.4xlarge",
+      "aurora_instance_class": "db.r6g.4xlarge"
+    },
+    "standard-6": {
+      "ram": "122 GB",
+      "storage_gb": 1536,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.8xlarge",
+      "aurora_instance_class": "db.r6g.8xlarge"
+    },
+    "standard-7": {
+      "ram": "244 GB",
+      "storage_gb": 2048,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge"
+    },
+    "premium-0": {
+      "ram": "4 GB",
+      "storage_gb": 64,
+      "connections": 120,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.t4g.medium",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "premium-2": {
+      "ram": "8 GB",
+      "storage_gb": 256,
+      "connections": 400,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.large",
+      "aurora_instance_class": "db.r6g.large"
+    },
+    "premium-3": {
+      "ram": "15 GB",
+      "storage_gb": 512,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.xlarge",
+      "aurora_instance_class": "db.r6g.xlarge"
+    },
+    "premium-4": {
+      "ram": "30 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.2xlarge",
+      "aurora_instance_class": "db.r6g.2xlarge"
+    },
+    "premium-5": {
+      "ram": "61 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.4xlarge",
+      "aurora_instance_class": "db.r6g.4xlarge"
+    },
+    "premium-6": {
+      "ram": "122 GB",
+      "storage_gb": 1536,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.8xlarge",
+      "aurora_instance_class": "db.r6g.8xlarge"
+    },
+    "premium-7": {
+      "ram": "244 GB",
+      "storage_gb": 2048,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge"
+    },
+    "premium-8": {
+      "ram": "488 GB",
+      "storage_gb": 3072,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.r6g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge"
+    },
+    "premium-9": {
+      "ram": "768 GB",
+      "storage_gb": 4096,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.x2g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge"
+    },
+    "private-0": {
+      "ram": "4 GB",
+      "storage_gb": 64,
+      "connections": 120,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.t4g.medium",
+      "aurora_instance_class": "db.t4g.medium"
+    },
+    "private-2": {
+      "ram": "8 GB",
+      "storage_gb": 256,
+      "connections": 400,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.large",
+      "aurora_instance_class": "db.r6g.large"
+    },
+    "private-3": {
+      "ram": "15 GB",
+      "storage_gb": 512,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.xlarge",
+      "aurora_instance_class": "db.r6g.xlarge"
+    },
+    "private-4": {
+      "ram": "30 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.2xlarge",
+      "aurora_instance_class": "db.r6g.2xlarge"
+    },
+    "private-5": {
+      "ram": "61 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.4xlarge",
+      "aurora_instance_class": "db.r6g.4xlarge"
+    },
+    "private-6": {
+      "ram": "122 GB",
+      "storage_gb": 1536,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.8xlarge",
+      "aurora_instance_class": "db.r6g.8xlarge"
+    },
+    "private-7": {
+      "ram": "244 GB",
+      "storage_gb": 2048,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge"
+    },
+    "shield-0": {
+      "ram": "4 GB",
+      "storage_gb": 64,
+      "connections": 120,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.t4g.medium",
+      "aurora_instance_class": "db.t4g.medium",
+      "compliance": "hipaa/pci"
+    },
+    "shield-2": {
+      "ram": "8 GB",
+      "storage_gb": 256,
+      "connections": 400,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.large",
+      "aurora_instance_class": "db.r6g.large",
+      "compliance": "hipaa/pci"
+    },
+    "shield-3": {
+      "ram": "15 GB",
+      "storage_gb": 512,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.xlarge",
+      "aurora_instance_class": "db.r6g.xlarge",
+      "compliance": "hipaa/pci"
+    },
+    "shield-4": {
+      "ram": "30 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.2xlarge",
+      "aurora_instance_class": "db.r6g.2xlarge",
+      "compliance": "hipaa/pci"
+    },
+    "shield-5": {
+      "ram": "61 GB",
+      "storage_gb": 1024,
+      "connections": 500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.4xlarge",
+      "aurora_instance_class": "db.r6g.4xlarge",
+      "compliance": "hipaa/pci"
+    },
+    "shield-6": {
+      "ram": "122 GB",
+      "storage_gb": 1536,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.8xlarge",
+      "aurora_instance_class": "db.r6g.8xlarge",
+      "compliance": "hipaa/pci"
+    },
+    "shield-7": {
+      "ram": "244 GB",
+      "storage_gb": 2048,
+      "connections": 1500,
+      "ha": true,
+      "src_connection_pooling": true,
+      "rds_instance_class": "db.m6g.16xlarge",
+      "aurora_instance_class": "db.r6g.16xlarge",
+      "compliance": "hipaa/pci"
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/redis-elasticache-sizing.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/redis-elasticache-sizing.json
@@ -1,0 +1,171 @@
+{
+  "_comment": "Heroku Redis plan -> ElastiCache sizing. DIRECT LOOKUP: read node_type column. memory_limit is PROVENANCE ONLY (encodes meets-or-exceeds) — do not recompute node_type from it.",
+  "_match": "exact, case-insensitive, on addon config.plan",
+  "_on_not_found": "defer to specialist gate; append warning 'Unrecognized heroku-redis plan tier: {plan}. Cannot determine ElastiCache node type. Deferring to specialist engagement.'; continue",
+  "_ha": "if row ha == true OR config.ha_enabled == true -> multi_az: true, automatic_failover: true; else both false",
+  "_transit_encryption": "if config.encryption_in_transit == true OR row encryption == true -> transit_encryption: true",
+  "_engine_version": "use design-defaults.json engine_versions.elasticache_redis (pinned); the row redis_version is PROVENANCE only (why the node meets the source) — do not derive the engine from it",
+  "rows": {
+    "hobby": {
+      "memory_limit": "25 MB",
+      "ha": false,
+      "encryption": false,
+      "redis_version": "6.2",
+      "node_type": "cache.t4g.micro"
+    },
+    "premium-0": {
+      "memory_limit": "50 MB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.micro"
+    },
+    "premium-1": {
+      "memory_limit": "100 MB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.micro"
+    },
+    "premium-2": {
+      "memory_limit": "250 MB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.micro"
+    },
+    "premium-3": {
+      "memory_limit": "500 MB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.small"
+    },
+    "premium-4": {
+      "memory_limit": "1 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.small"
+    },
+    "premium-5": {
+      "memory_limit": "2.5 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.medium"
+    },
+    "premium-6": {
+      "memory_limit": "5 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.large"
+    },
+    "premium-7": {
+      "memory_limit": "10 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.xlarge"
+    },
+    "premium-8": {
+      "memory_limit": "15 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.xlarge"
+    },
+    "premium-9": {
+      "memory_limit": "25 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.2xlarge"
+    },
+    "premium-10": {
+      "memory_limit": "50 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.4xlarge"
+    },
+    "premium-11": {
+      "memory_limit": "75 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.8xlarge"
+    },
+    "premium-12": {
+      "memory_limit": "100 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.8xlarge"
+    },
+    "premium-13": {
+      "memory_limit": "150 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.12xlarge"
+    },
+    "premium-14": {
+      "memory_limit": "200 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.16xlarge"
+    },
+    "private-1": {
+      "memory_limit": "1 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.small"
+    },
+    "private-2": {
+      "memory_limit": "2.5 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.t4g.medium"
+    },
+    "private-3": {
+      "memory_limit": "5 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.large"
+    },
+    "private-4": {
+      "memory_limit": "10 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.xlarge"
+    },
+    "private-5": {
+      "memory_limit": "25 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.2xlarge"
+    },
+    "private-6": {
+      "memory_limit": "50 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.4xlarge"
+    },
+    "private-7": {
+      "memory_limit": "100 GB",
+      "ha": true,
+      "encryption": true,
+      "redis_version": "7.0",
+      "node_type": "cache.m6g.8xlarge"
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/dyno-type-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/dyno-type-table.md
@@ -6,27 +6,14 @@ This table maps Heroku dyno types to AWS Fargate task definition CPU and memory 
 
 ## Lookup Table
 
-| Heroku Dyno Type  | CPU (shares) | Memory (MB) | Fargate CPU (units) | Fargate Memory (MiB) |
-| ----------------- | ------------ | ----------- | ------------------- | -------------------- |
-| standard-1x       | 1x           | 512         | 256                 | 512                  |
-| standard-2x       | 2x           | 1024        | 512                 | 1024                 |
-| performance-m     | 6x           | 2560        | 1024                | 2048                 |
-| performance-l     | 12x          | 14336       | 4096                | 16384                |
-| performance-l-ram | 12x          | 30720       | 4096                | 30720                |
-| performance-xl    | 12x          | 63488       | 8192                | 65536                |
-| performance-2xl   | 12x          | 129024      | 16384               | 122880               |
-| private-s         | 1x           | 1024        | 512                 | 1024                 |
-| private-m         | 6x           | 2560        | 1024                | 2048                 |
-| private-l         | 12x          | 14336       | 4096                | 16384                |
-| private-l-ram     | 12x          | 30720       | 4096                | 30720                |
-| private-xl        | 12x          | 63488       | 8192                | 65536                |
-| private-2xl       | 12x          | 129024      | 16384               | 122880               |
-| shield-s          | 1x           | 1024        | 512                 | 1024                 |
-| shield-m          | 6x           | 2560        | 1024                | 2048                 |
-| shield-l          | 12x          | 14336       | 4096                | 16384                |
-| shield-l-ram      | 12x          | 30720       | 4096                | 30720                |
-| shield-xl         | 12x          | 63488       | 8192                | 65536                |
-| shield-2xl        | 12x          | 129024      | 16384               | 122880               |
+> **Data:** [`knowledge/design/dyno-fargate-sizing.json`](../../knowledge/design/dyno-fargate-sizing.json)
+>
+> The dyno-type → Fargate sizing rows are maintained as structured data in that
+> JSON file. Read the `rows` map keyed by Heroku dyno type; each row carries
+> `fargate_cpu` (CPU units, 1024 = 1 vCPU) and `fargate_memory` (MiB). The
+> `heroku_cpu_share` and `heroku_memory_mb` fields are provenance only (they
+> explain why the row meets-or-exceeds the source) — do NOT recompute the Fargate
+> values from them.
 
 ## Interpretation Notes
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/fast-path-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/fast-path-table.md
@@ -6,25 +6,19 @@ This table provides deterministic mappings from Heroku add-ons to AWS service eq
 
 ## Lookup Table
 
-| Heroku Add-On        | AWS Service(s)        | Mapping Type | Notes                                                    |
-| -------------------- | --------------------- | ------------ | -------------------------------------------------------- |
-| Papertrail           | CloudWatch Logs       | Single       | Log aggregation and search                               |
-| SendGrid             | Amazon SES            | Single       | Transactional and marketing email                        |
-| Heroku Scheduler     | EventBridge Scheduler | Single       | Cron-style scheduled jobs                                |
-| Memcachier           | ElastiCache Memcached | Single       | In-memory caching (Memcached protocol)                   |
-| Bucketeer            | S3                    | Single       | Object/file storage                                      |
-| CloudAMQP            | Amazon MQ             | Single       | RabbitMQ-compatible message broker                       |
-| Bonsai Elasticsearch | Amazon OpenSearch     | Single       | Full-text search and analytics                           |
-| Scout APM            | CloudWatch + X-Ray    | Composite    | Application performance monitoring + distributed tracing |
-| Rollbar              | CloudWatch            | Single       | Error tracking via structured logs                       |
-| New Relic            | CloudWatch + X-Ray    | Composite    | Full-stack observability + distributed tracing           |
-| Twilio               | Amazon SNS (SMS)      | Single       | SMS messaging                                            |
-| Cloudinary           | S3 + CloudFront       | Composite    | Media storage + CDN delivery                             |
-| Sentry               | CloudWatch            | Single       | Error tracking via structured logs                       |
+> **Data:** [`knowledge/design/fast-path-addons.json`](../../knowledge/design/fast-path-addons.json)
+>
+> The add-on → AWS service mappings are maintained as structured data in that JSON
+> file. Read the `rows` map keyed by NORMALIZED add-on name; each row carries
+> `type` (`single` or `composite`), `aws_services`, and `notes`. A discovered
+> add-on name is normalized before matching (strip a leading `heroku-`, hyphens →
+> spaces, lowercase, then apply the `_prefix_aliases`); matching is exact
+> full-string (partial matches are invalid). All matches produce confidence
+> `"deterministic"`.
 
 ## Interpretation Notes
 
-- **Matching rule**: The add-on name from the inventory is matched against the "Heroku Add-On" column using **exact case-insensitive string comparison**. Partial matches (e.g., "Paper" matching "Papertrail") are NOT valid and must be treated as unmatched.
+- **Matching rule**: The add-on name from the inventory is matched against each row's key (the normalized add-on name) using **exact case-insensitive string comparison**. Partial matches (e.g., "Paper" matching "Papertrail") are NOT valid and must be treated as unmatched.
 - **Confidence level**: All matches from this table produce a confidence level of `"deterministic"` in the design output.
 - **Single mappings**: Map the source add-on to exactly one AWS service.
 - **Composite mappings**: Map the source add-on to multiple AWS services that together replicate the source functionality. All listed services must appear in the design output as a single composite mapping with one `"deterministic"` confidence level assigned to the group.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/kafka-plan-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/kafka-plan-table.md
@@ -6,18 +6,13 @@ This table maps Apache Kafka on Heroku plan tiers to recommended Amazon MSK brok
 
 ## Lookup Table
 
-| Heroku Plan        | Max Topics | Max Partitions | Storage | Throughput | Recommended MSK Broker Instance Type | Recommended Storage Per Broker |
-| ------------------ | ---------- | -------------- | ------- | ---------- | ------------------------------------ | ------------------------------ |
-| basic-0            | 20         | 40             | 4 GB    | 5 MB/s     | kafka.t3.small                       | 10 GB                          |
-| standard-0         | 40         | 160            | 50 GB   | 20 MB/s    | kafka.m5.large                       | 100 GB                         |
-| standard-1         | 100        | 400            | 200 GB  | 50 MB/s    | kafka.m5.xlarge                      | 250 GB                         |
-| standard-2         | 200        | 1600           | 1 TB    | 100 MB/s   | kafka.m5.2xlarge                     | 500 GB                         |
-| extended-0         | 200        | 2000           | 2 TB    | 150 MB/s   | kafka.m5.4xlarge                     | 1 TB                           |
-| extended-1         | 400        | 4000           | 4 TB    | 200 MB/s   | kafka.m5.8xlarge                     | 2 TB                           |
-| extended-2         | 600        | 8000           | 8 TB    | 300 MB/s   | kafka.m5.12xlarge                    | 4 TB                           |
-| private-extended-0 | 200        | 2000           | 2 TB    | 150 MB/s   | kafka.m5.4xlarge                     | 1 TB                           |
-| private-extended-1 | 400        | 4000           | 4 TB    | 200 MB/s   | kafka.m5.8xlarge                     | 2 TB                           |
-| private-extended-2 | 600        | 8000           | 8 TB    | 300 MB/s   | kafka.m5.12xlarge                    | 4 TB                           |
+> **Data:** [`knowledge/design/kafka-msk-sizing.json`](../../knowledge/design/kafka-msk-sizing.json)
+>
+> The Heroku Kafka plan → MSK sizing rows are maintained as structured data in
+> that JSON file. Read the `rows` map keyed by Heroku plan; each row carries
+> `broker_instance_type`, `storage_per_broker_gb`, `max_topics`, `max_partitions`,
+> and `default_replication_factor`. The `throughput` and `storage` fields are
+> provenance only.
 
 ## Interpretation Notes
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/postgres-plan-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/postgres-plan-table.md
@@ -6,54 +6,26 @@ This table maps Heroku Postgres plan tiers to recommended AWS RDS PostgreSQL and
 
 ## Lookup Table
 
-| Heroku Plan | RAM           | Storage | Connections | HA  | Connection Pooling | Recommended RDS Instance Class | Recommended Aurora Instance Class |
-| ----------- | ------------- | ------- | ----------- | --- | ------------------ | ------------------------------ | --------------------------------- |
-| essential-0 | 0 MB (shared) | 1 GB    | 20          | No  | No                 | db.t4g.micro                   | db.t4g.medium                     |
-| essential-1 | 0 MB (shared) | 10 GB   | 20          | No  | No                 | db.t4g.micro                   | db.t4g.medium                     |
-| essential-2 | 0 MB (shared) | 32 GB   | 40          | No  | No                 | db.t4g.micro                   | db.t4g.medium                     |
-| hobby-dev   | 0 MB (shared) | 1 GB    | 20          | No  | No                 | db.t4g.micro                   | db.t4g.medium                     |
-| hobby-basic | 0 MB (shared) | 10 GB   | 20          | No  | No                 | db.t4g.micro                   | db.t4g.medium                     |
-| standard-0  | 4 GB          | 64 GB   | 120         | No  | Yes                | db.t4g.medium                  | db.t4g.medium                     |
-| standard-2  | 8 GB          | 256 GB  | 400         | Yes | Yes                | db.m6g.large                   | db.r6g.large                      |
-| standard-3  | 15 GB         | 512 GB  | 500         | Yes | Yes                | db.m6g.xlarge                  | db.r6g.xlarge                     |
-| standard-4  | 30 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.2xlarge                 | db.r6g.2xlarge                    |
-| standard-5  | 61 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.4xlarge                 | db.r6g.4xlarge                    |
-| standard-6  | 122 GB        | 1.5 TB  | 1500        | Yes | Yes                | db.m6g.8xlarge                 | db.r6g.8xlarge                    |
-| standard-7  | 244 GB        | 2 TB    | 1500        | Yes | Yes                | db.m6g.16xlarge                | db.r6g.16xlarge                   |
-| premium-0   | 4 GB          | 64 GB   | 120         | Yes | Yes                | db.t4g.medium                  | db.t4g.medium                     |
-| premium-2   | 8 GB          | 256 GB  | 400         | Yes | Yes                | db.m6g.large                   | db.r6g.large                      |
-| premium-3   | 15 GB         | 512 GB  | 500         | Yes | Yes                | db.m6g.xlarge                  | db.r6g.xlarge                     |
-| premium-4   | 30 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.2xlarge                 | db.r6g.2xlarge                    |
-| premium-5   | 61 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.4xlarge                 | db.r6g.4xlarge                    |
-| premium-6   | 122 GB        | 1.5 TB  | 1500        | Yes | Yes                | db.m6g.8xlarge                 | db.r6g.8xlarge                    |
-| premium-7   | 244 GB        | 2 TB    | 1500        | Yes | Yes                | db.m6g.16xlarge                | db.r6g.16xlarge                   |
-| premium-8   | 488 GB        | 3 TB    | 1500        | Yes | Yes                | db.r6g.16xlarge                | db.r6g.16xlarge                   |
-| premium-9   | 768 GB        | 4 TB    | 1500        | Yes | Yes                | db.x2g.16xlarge                | db.r6g.16xlarge                   |
-| private-0   | 4 GB          | 64 GB   | 120         | Yes | Yes                | db.t4g.medium                  | db.t4g.medium                     |
-| private-2   | 8 GB          | 256 GB  | 400         | Yes | Yes                | db.m6g.large                   | db.r6g.large                      |
-| private-3   | 15 GB         | 512 GB  | 500         | Yes | Yes                | db.m6g.xlarge                  | db.r6g.xlarge                     |
-| private-4   | 30 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.2xlarge                 | db.r6g.2xlarge                    |
-| private-5   | 61 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.4xlarge                 | db.r6g.4xlarge                    |
-| private-6   | 122 GB        | 1.5 TB  | 1500        | Yes | Yes                | db.m6g.8xlarge                 | db.r6g.8xlarge                    |
-| private-7   | 244 GB        | 2 TB    | 1500        | Yes | Yes                | db.m6g.16xlarge                | db.r6g.16xlarge                   |
-| shield-0    | 4 GB          | 64 GB   | 120         | Yes | Yes                | db.t4g.medium                  | db.t4g.medium                     |
-| shield-2    | 8 GB          | 256 GB  | 400         | Yes | Yes                | db.m6g.large                   | db.r6g.large                      |
-| shield-3    | 15 GB         | 512 GB  | 500         | Yes | Yes                | db.m6g.xlarge                  | db.r6g.xlarge                     |
-| shield-4    | 30 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.2xlarge                 | db.r6g.2xlarge                    |
-| shield-5    | 61 GB         | 1 TB    | 500         | Yes | Yes                | db.m6g.4xlarge                 | db.r6g.4xlarge                    |
-| shield-6    | 122 GB        | 1.5 TB  | 1500        | Yes | Yes                | db.m6g.8xlarge                 | db.r6g.8xlarge                    |
-| shield-7    | 244 GB        | 2 TB    | 1500        | Yes | Yes                | db.m6g.16xlarge                | db.r6g.16xlarge                   |
+> **Data:** [`knowledge/design/postgres-rds-sizing.json`](../../knowledge/design/postgres-rds-sizing.json)
+>
+> The Heroku Postgres plan → RDS/Aurora sizing rows are maintained as structured
+> data in that JSON file. Read the `rows` map keyed by Heroku plan; each row
+> carries `rds_instance_class` and `aurora_instance_class` (select per the engine
+> rule below), plus `storage_gb` (minimum storage to allocate) and a `compliance`
+> tag on shield-* rows. The `ram` / `connections` / `ha` / `src_connection_pooling`
+> fields are provenance only (source-plan facts that explain the row choice) — do
+> NOT recompute the instance class from them.
 
 ## Interpretation Notes
 
 - **Service selection rule**:
-  - If user availability preference is `single-az` or `multi-az` → select **RDS PostgreSQL** using the "Recommended RDS Instance Class" column.
-  - If user availability preference is `multi-az-ha` or `multi-region` → select **Aurora PostgreSQL** using the "Recommended Aurora Instance Class" column.
+  - If user availability preference is `single-az` or `multi-az` → select **RDS PostgreSQL** using the row's `rds_instance_class` field.
+  - If user availability preference is `multi-az-ha` or `multi-region` → select **Aurora PostgreSQL** using the row's `aurora_instance_class` field.
   - If availability preference is unset or unrecognized → default to `multi-az` + RDS PostgreSQL and include a warning.
 - **Sizing rule**: Select the smallest instance class that meets or exceeds the source plan's RAM and vCPU capacity. The table already maps each plan to the minimum adequate instance class.
-- **Storage rule**: Configure RDS/Aurora storage allocation to meet or exceed the source plan's storage column value.
+- **Storage rule**: Configure RDS/Aurora storage allocation to meet or exceed the row's `storage_gb` value.
 - **Connection pooling**: If the source Heroku Postgres plan has connection pooling enabled, include **RDS Proxy** in the design.
-- **HA column**: Indicates whether the source plan includes high availability. When HA is "Yes" and the user selects RDS, configure Multi-AZ deployment.
+- **HA field**: The row's `ha` field indicates whether the source plan includes high availability. When `ha` is `true` and the user selects RDS, configure Multi-AZ deployment.
 - **Shield plans**: These are HIPAA/PCI-compliant equivalents of private plans. Map identically to private plans but note the compliance requirement in the design.
 
 ## Error Handling

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/redis-plan-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/redis-plan-table.md
@@ -6,31 +6,14 @@ This table maps Heroku Redis (Key-Value Store) plan tiers to recommended AWS Ela
 
 ## Lookup Table
 
-| Heroku Plan | Memory Limit | HA  | Encryption | Redis Version | Recommended ElastiCache Node Type |
-| ----------- | ------------ | --- | ---------- | ------------- | --------------------------------- |
-| hobby       | 25 MB        | No  | No         | 6.2           | cache.t4g.micro                   |
-| premium-0   | 50 MB        | Yes | Yes        | 7.0           | cache.t4g.micro                   |
-| premium-1   | 100 MB       | Yes | Yes        | 7.0           | cache.t4g.micro                   |
-| premium-2   | 250 MB       | Yes | Yes        | 7.0           | cache.t4g.micro                   |
-| premium-3   | 500 MB       | Yes | Yes        | 7.0           | cache.t4g.small                   |
-| premium-4   | 1 GB         | Yes | Yes        | 7.0           | cache.t4g.small                   |
-| premium-5   | 2.5 GB       | Yes | Yes        | 7.0           | cache.t4g.medium                  |
-| premium-6   | 5 GB         | Yes | Yes        | 7.0           | cache.m6g.large                   |
-| premium-7   | 10 GB        | Yes | Yes        | 7.0           | cache.m6g.xlarge                  |
-| premium-8   | 15 GB        | Yes | Yes        | 7.0           | cache.m6g.xlarge                  |
-| premium-9   | 25 GB        | Yes | Yes        | 7.0           | cache.m6g.2xlarge                 |
-| premium-10  | 50 GB        | Yes | Yes        | 7.0           | cache.m6g.4xlarge                 |
-| premium-11  | 75 GB        | Yes | Yes        | 7.0           | cache.m6g.8xlarge                 |
-| premium-12  | 100 GB       | Yes | Yes        | 7.0           | cache.m6g.8xlarge                 |
-| premium-13  | 150 GB       | Yes | Yes        | 7.0           | cache.m6g.12xlarge                |
-| premium-14  | 200 GB       | Yes | Yes        | 7.0           | cache.m6g.16xlarge                |
-| private-1   | 1 GB         | Yes | Yes        | 7.0           | cache.t4g.small                   |
-| private-2   | 2.5 GB       | Yes | Yes        | 7.0           | cache.t4g.medium                  |
-| private-3   | 5 GB         | Yes | Yes        | 7.0           | cache.m6g.large                   |
-| private-4   | 10 GB        | Yes | Yes        | 7.0           | cache.m6g.xlarge                  |
-| private-5   | 25 GB        | Yes | Yes        | 7.0           | cache.m6g.2xlarge                 |
-| private-6   | 50 GB        | Yes | Yes        | 7.0           | cache.m6g.4xlarge                 |
-| private-7   | 100 GB       | Yes | Yes        | 7.0           | cache.m6g.8xlarge                 |
+> **Data:** [`knowledge/design/redis-elasticache-sizing.json`](../../knowledge/design/redis-elasticache-sizing.json)
+>
+> The Heroku Redis plan → ElastiCache sizing rows are maintained as structured
+> data in that JSON file. Read the `rows` map keyed by Heroku plan; each row
+> carries `node_type`, `ha`, and `encryption`. The `memory_limit` and
+> `redis_version` fields are provenance only — do NOT recompute the node type from
+> `memory_limit`, and do NOT derive the engine version from `redis_version` (the
+> engine version is pinned; see the Redis version note below).
 
 ## Interpretation Notes
 


### PR DESCRIPTION
## What

Moves the 5 design-phase lookup tables out of inline markdown into structured JSON under `skills/heroku-to-aws/knowledge/design/`, so the sizing/mapping data lives in one machine-readable place that's easy to review and edit.

Tables converted: **dyno-type, postgres-plan, redis-plan, kafka-plan, fast-path**.

## How

For each table, the row data moves into a JSON file (one copy), and the reference `.md` keeps its prose (Description / Interpretation Notes / Error Handling) and links to the JSON via a `> **Data:** [...]` pointer. The `.md` stays the load target, so `design.md` / `SKILL.md` references are unchanged — no procedure-prose edits.

```
references/design-refs/dyno-type-table.md   # prose kept; table -> pointer
  -> knowledge/design/dyno-fargate-sizing.json   # the rows (single copy)
```

## Behavior

**No behavior change.** Table values are identical to the markdown they replace.

Two places where the prose was *ambiguous* are now pinned explicitly in the JSON. Please confirm the **resolution**, not just the format:

- **postgres** — RDS Proxy is included based on the inventory's `config.connection_pooling` (the discovered source fact), not the per-row provenance column.
- **redis** — the ElastiCache engine version is pinned (was prose "compatible with… where possible").

Also reconciled stale "column" phrasing in the Interpretation Notes to the JSON field-key names (e.g. "Recommended RDS Instance Class column" → the row's `rds_instance_class` field).

## Validation

Ran the repointed skill cold against a large Terraform sample repo (discover → design): a zero-context agent followed every `.md → .json` pointer hop and reproduced all design mappings exactly (Fargate sizings, RDS classes, Redis nodes, MSK broker) against hand-computed ground truth. The one-hop indirection is navigable; no "which file/column?" confusion.

- `dprint fmt:check` clean
- `markdownlint` clean (0 errors)
- All 5 JSON parse; all `.md → JSON` relative links resolve

## Not in this PR

- **EKS** (`eks-mapping-table.md`): deferred — it carries reviewable design decisions (k8s version handling, node-sizing) beyond a mechanical move.
- **Shared `pricing-cache.md`**: follows separately (it's shared with the gcp-to-aws skill and carries rate additions needing focused review).
