### PR TITLE
Extract heroku-to-aws AWS pricing rates to shared structured JSON

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -177,7 +177,7 @@ Use **read-merge-write** updates for `.phase-status.json`:
 
 - Provides `get_pricing`, `get_pricing_service_codes`, `get_pricing_service_attributes` tools
 - Only needed during Estimate phase. Discover and Design do not require it.
-- Primary pricing source: `references/shared/pricing-cache.md` (cached rates, ±5-10% for infrastructure). MCP is secondary — used only for services not found in the cache.
+- Primary pricing source: `shared/pricing/aws-infra-pricing.json` (cached AWS infrastructure rates, ±5-10% for infrastructure). MCP is secondary — used only for services not found in the pricing file.
 
 ---
 
@@ -218,7 +218,6 @@ heroku-to-aws/
 │           ├── handoff-gates.md                # Fail-closed phase handoff protocol
 │           ├── schema-phase-status.md          # .phase-status.json schema
 │           ├── migration-complexity.md         # Complexity tier definitions (Small/Medium/Large)
-│           ├── pricing-cache.md                # Cached AWS pricing (primary source)
 │           ├── schema-estimate-infra.md        # estimation-infra.json schema
 │           └── validate-artifacts.md           # Pre-report validation
 ```
@@ -227,7 +226,7 @@ heroku-to-aws/
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | No Terraform files with `heroku_*` resources found       | Stop. Output: "No Terraform files with heroku_* resources found. Heroku Terraform is required for discovery. Procfile and app.json alone are not sufficient." |
 | `.phase-status.json` missing phase gate                  | Stop. Output: "Cannot enter Phase X: Phase Y-1 not completed. Start from Phase Y or resume Phase Y-1."                                                        |
-| awspricing unavailable after 3 attempts                  | Display user warning about ±5-10% accuracy. Use `pricing-cache.md`. Add `pricing_source: "cached_fallback"` to `estimation-infra.json`.                       |
+| awspricing unavailable after 3 attempts                  | Display user warning about ±5-10% accuracy. Use `shared/pricing/aws-infra-pricing.json`. Add `pricing_source: "cached_fallback"` to `estimation-infra.json`.  |
 | User skips questions or says "use defaults for the rest" | Apply documented defaults for remaining questions. Phase 2 completes either way.                                                                              |
 | Dyno type not in Dyno Type Table                         | Reject mapping for that formation. Output: "Unsupported dyno type: {type}. Cannot map to Fargate."                                                            |
 | Add-on not in Fast-Path Table                            | Mark as "Deferred — specialist engagement". No automated mapping produced.                                                                                    |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -27,10 +27,12 @@ Calculate projected monthly AWS costs for the designed Heroku-to-AWS architectur
 
 ### Step 0a: Load Pricing Cache
 
-Read `shared/pricing-cache.md`. Check the `Last updated` date in the header:
+Read `../../../../shared/pricing/aws-infra-pricing.json` (shared AWS infrastructure pricing data). Check the `_meta.last_updated` date:
 
-- If ≤ 30 days old: **Cached prices are the primary source.** No MCP calls needed for services listed in the cache. Set `pricing_source: "cached"`.
-- If > 30 days old: Cache is stale for AI model prices. Infrastructure prices (Fargate, RDS, S3, etc.) remain reliable. Attempt MCP (Step 0b) for services not in cache; use stale cache as fallback with `pricing_source: "cached_stale"`.
+- If ≤ 30 days old: **Cached prices are the primary source.** No MCP calls needed for services listed in the file. Set `pricing_source: "cached"`.
+- If > 30 days old: Infrastructure prices (Fargate, RDS, S3, etc.) remain reliable. Attempt MCP (Step 0b) for services not in the file; use the cached rates as fallback with `pricing_source: "cached_stale"`.
+
+Each service object carries its rates and (where relevant) a `multi_az_handling` key. Look up the rates from there — do not hardcode them. Apply the cost formula from the Per-Service Calculation Formulas table below.
 
 ### Step 0b: MCP Availability Check (only if cache stale or service not listed)
 
@@ -52,14 +54,14 @@ Attempt to reach awspricing MCP with **up to 2 retries** (3 total attempts, 10-s
 
 ### Pricing Hierarchy (per-service lookup order)
 
-| Priority | Source                    | Condition                                     | `pricing_source` value |
-| -------- | ------------------------- | --------------------------------------------- | ---------------------- |
-| 1        | `shared/pricing-cache.md` | Service found in cache                        | `"cached"`             |
-| 2        | MCP API (`get_pricing`)   | Service NOT in cache, MCP available           | `"live"`               |
-| 3        | Cache after MCP failure   | MCP attempted but failed, service IS in cache | `"cached_fallback"`    |
-| 4        | Unavailable               | NOT in cache AND MCP failed                   | `"unavailable"`        |
+| Priority | Source                                  | Condition                                    | `pricing_source` value |
+| -------- | --------------------------------------- | -------------------------------------------- | ---------------------- |
+| 1        | `shared/pricing/aws-infra-pricing.json` | Service found in the pricing file            | `"cached"`             |
+| 2        | MCP API (`get_pricing`)                 | Service NOT in the file, MCP available       | `"live"`               |
+| 3        | Pricing file after MCP failure          | MCP attempted but failed, service IS in file | `"cached_fallback"`    |
+| 4        | Unavailable                             | NOT in file AND MCP failed                   | `"unavailable"`        |
 
-For typical Heroku migrations (Fargate, RDS, Aurora, ElastiCache, ALB, NAT Gateway, S3, CloudWatch, Secrets Manager, EventBridge, SES, OpenSearch, MQ), ALL prices are in `pricing-cache.md`. Zero MCP calls needed.
+For typical Heroku migrations (Fargate, RDS, Aurora, ElastiCache, ALB, NAT Gateway, S3, CloudWatch, Secrets Manager, EventBridge, SES, OpenSearch, MQ), ALL prices are in `aws-infra-pricing.json`. Zero MCP calls needed.
 
 ---
 
@@ -113,31 +115,33 @@ When billing data or pricing cache is available, present the Heroku baseline as:
 
 ## Part 2: Calculate Projected AWS Costs
 
-For each service in `aws-design.json → services[]`, calculate monthly cost using rates from `pricing-cache.md`. Track `pricing_source` per service.
+For each service in `aws-design.json → services[]`, calculate monthly cost by applying the formula from the Per-Service Calculation Formulas table below, looking up its rates from `shared/pricing/aws-infra-pricing.json`. Track `pricing_source` per service. (`hours_per_month` = 730, from `_meta`.)
 
 ### Per-Service Calculation Formulas
 
-| AWS Service               | Formula                                                                                              | Key inputs from `aws_config`                                                  |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **Fargate**               | (task_cpu/1024 × $0.04048 + task_memory/1024 × $0.004445) × 730 hrs × desired_count                  | `task_cpu`, `task_memory`, `desired_count`                                    |
-| **EKS (cluster + nodes)** | $0.10/hr control plane ($73/month) + node_instance_rate × 730 hrs × node_count + ALB per web service | `eks_cluster.node_groups[].instance_types`, `desired_size`, web service count |
-| **ALB**                   | $16.43/month fixed + LCU estimate ($0.008/LCU-hr × 730)                                              | Per web service with `load_balancer: true`                                    |
-| **RDS PostgreSQL**        | instance_rate × 730 hrs + storage_gb × $0.23/GB-month                                                | `instance_class`, `storage_gb`, `multi_az`                                    |
-| **Aurora PostgreSQL**     | instance_rate × 730 hrs + storage_gb × $0.10/GB-month + I/O estimate                                 | `instance_class`, `storage_gb`                                                |
-| **ElastiCache Redis**     | node_rate × 730 hrs (× 2 if Multi-AZ)                                                                | `node_type`, `multi_az`                                                       |
-| **MSK**                   | broker_rate × 730 hrs × broker_count + storage_gb × rate                                             | `broker_instance_type`, `broker_count`, `storage_per_broker_gb`               |
-| **CloudWatch Logs**       | log_volume_gb × $0.50/GB + storage × $0.03/GB-month                                                  | `retention_days`, estimated log volume                                        |
-| **S3**                    | storage_gb × $0.023/GB-month + request estimates                                                     | `storage_gb` (from Bucketeer/Cloudinary mapping)                              |
-| **Amazon SES**            | $0.10 per 1000 emails (minimal baseline)                                                             | Flat estimate from SendGrid mapping                                           |
-| **EventBridge Scheduler** | $1.00 per million events (minimal for cron jobs)                                                     | From Heroku Scheduler mapping                                                 |
-| **Amazon MQ**             | instance_rate × 730 hrs + storage                                                                    | From CloudAMQP mapping                                                        |
-| **Amazon OpenSearch**     | instance_rate × 730 hrs + storage                                                                    | From Bonsai Elasticsearch mapping                                             |
-| **Secrets Manager**       | secret_count × $0.40/month + API calls × $0.05/10K                                                   | Config var count from inventory                                               |
-| **NAT Gateway**           | $32.85/month fixed + data processing estimate                                                        | From VPC design (if new VPC)                                                  |
-| **RDS Proxy**             | $0.015 per vCPU-hour × 730 hrs × vCPUs                                                               | When connection pooling mapped                                                |
-| **Route 53**              | $0.50/hosted zone + query estimate                                                                   | When DNS strategy = route53                                                   |
-| **CloudFront**            | $0.085/GB (first 10TB) + request costs                                                               | From Cloudinary composite mapping                                             |
-| **X-Ray**                 | $5.00 per million traces                                                                             | Only if tracing detected in source                                            |
+Rates below come from the named keys in `aws-infra-pricing.json` — do not hardcode them here. The formula shape + key inputs are shown for reference.
+
+| AWS Service               | Formula (rates from `aws-infra-pricing.json`)                                                                                            | Key inputs from `aws_config`                                                  |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Fargate**               | (task_cpu/1024 × `fargate.per_vcpu_hour` + task_memory/1024 × `fargate.per_gb_mem_hour`) × 730 × desired_count                           | `task_cpu`, `task_memory`, `desired_count`                                    |
+| **EKS (cluster + nodes)** | `eks.control_plane_monthly` + `eks.node_rates_monthly[type]` × node_count + ALB per web service                                          | `eks_cluster.node_groups[].instance_types`, `desired_size`, web service count |
+| **ALB**                   | `alb.monthly_fixed` + LCU estimate (`alb.per_lcu_hour` × 730)                                                                            | Per web service with `load_balancer: true`                                    |
+| **RDS PostgreSQL**        | `rds_postgresql.instances[class]` × 730 + storage_gb × `rds_postgresql.storage_per_gb_month` (rate is baked_in Multi-AZ — do NOT double) | `instance_class`, `storage_gb`, `multi_az`                                    |
+| **Aurora PostgreSQL**     | `aurora_postgresql.instances[class]` × 730 + storage_gb × `aurora_postgresql.storage_per_gb_month` + I/O estimate (intrinsic multi-AZ)   | `instance_class`, `storage_gb`                                                |
+| **ElastiCache Redis**     | `elasticache.nodes[type]` × 730 (× 2 if Multi-AZ — `multiplier_x2`)                                                                      | `node_type`, `multi_az`                                                       |
+| **MSK**                   | `msk.brokers[type]` × 730 × broker_count + storage_gb × `msk.storage_per_gb_month` (intrinsic multi-AZ)                                  | `broker_instance_type`, `broker_count`, `storage_per_broker_gb`               |
+| **CloudWatch Logs**       | log_volume_gb × `cloudwatch.log_ingestion_per_gb` + storage × `cloudwatch.log_storage_per_gb_month`                                      | `retention_days`, estimated log volume                                        |
+| **S3**                    | storage_gb × `fast_path_services.s3.storage_per_gb_month` + request estimates (or `s3.monthly_baseline_est`)                             | `storage_gb` (from Bucketeer/Cloudinary mapping)                              |
+| **Amazon SES**            | `fast_path_services.ses.monthly_baseline_est` (flat baseline; see `_basis`)                                                              | Flat estimate from SendGrid mapping                                           |
+| **EventBridge Scheduler** | `fast_path_services.eventbridge.monthly_baseline_est` (flat; per_million_events basis)                                                   | From Heroku Scheduler mapping                                                 |
+| **Amazon MQ**             | `fast_path_services.amazon_mq.instance_monthly_est` + storage                                                                            | From CloudAMQP mapping                                                        |
+| **Amazon OpenSearch**     | `fast_path_services.opensearch.instance_monthly_est` + storage                                                                           | From Bonsai Elasticsearch mapping                                             |
+| **Secrets Manager**       | secret_count × `fast_path_services.secrets_manager.per_secret_month` + API calls × `per_10k_api_calls` (or `monthly_baseline_est`)       | Config var count from inventory                                               |
+| **NAT Gateway**           | `nat_gateway.monthly_fixed` + data processing estimate (`nat_gateway.per_gb_processed`)                                                  | From VPC design (if new VPC)                                                  |
+| **RDS Proxy**             | `rds_proxy.per_vcpu_hour` × 730 × vCPUs                                                                                                  | When connection pooling mapped                                                |
+| **Route 53**              | `route53.hosted_zone_monthly` + query estimate (`route53.per_million_queries`)                                                           | When DNS strategy = route53                                                   |
+| **CloudFront**            | `fast_path_services.cloudfront.per_gb_first_10tb` × GB + request costs (or `cloudfront.monthly_baseline_est`)                            | From Cloudinary composite mapping                                             |
+| **X-Ray**                 | `cloudwatch.xray_per_million_traces` × trace_millions                                                                                    | Only if tracing detected in source                                            |
 
 ### Unpriced Resource Handling
 
@@ -152,26 +156,16 @@ IF pricing data for a service is unavailable from both MCP and cache:
 
 When `aws-design.json` contains EKS services (`aws_service: "EKS"`):
 
-1. **EKS Control Plane**: $0.10/hour = **$73.00/month** (fixed, one cluster regardless of node count)
-2. **EC2 Node Group**: Look up instance type hourly rate × 730 hours × `desired_size` nodes
+1. **EKS Control Plane**: `eks.control_plane_monthly` (fixed, one cluster regardless of node count)
+2. **EC2 Node Group**: Look up the node instance type's monthly rate in `eks.node_rates_monthly[type]` × `desired_size` nodes. The monthly rates (m6i.large, m6i.xlarge, m6i.4xlarge, r6i.4xlarge, m6i.8xlarge, m6i.16xlarge) are maintained in `aws-infra-pricing.json` — do not hardcode them here.
+3. **ALB for web services**: Same as Fargate ALB pricing (`alb.monthly_fixed` per web service)
+4. **NAT Gateway** (if private subnets): Same as Fargate path (`nat_gateway.monthly_fixed` + data processing)
 
-   | Node Instance Type | Hourly Rate | Monthly (730 hrs) |
-   | ------------------ | ----------- | ----------------- |
-   | m6i.large          | $0.096      | $70.08/node       |
-   | m6i.xlarge         | $0.192      | $140.16/node      |
-   | m6i.4xlarge        | $0.768      | $560.64/node      |
-   | r6i.4xlarge        | $1.008      | $735.84/node      |
-   | m6i.8xlarge        | $1.536      | $1,121.28/node    |
-   | m6i.16xlarge       | $3.072      | $2,242.56/node    |
-
-3. **ALB for web services**: Same as Fargate ALB pricing ($16.43/month per web service)
-4. **NAT Gateway** (if private subnets): Same as Fargate path ($32.85/month + data processing)
-
-**Total EKS monthly cost** = control_plane + (node_rate × 730 × node_count) + ALB_costs + NAT_costs
+**Total EKS monthly cost** = `eks.control_plane_monthly` + (node_monthly_rate × node_count) + ALB_costs + NAT_costs. Pods are NOT charged a per-task cost (compute is billed via the EC2 nodes); ALB and NAT are the separate lines above, not re-added here.
 
 **EKS vs Fargate cost comparison note**: When presenting EKS estimates alongside the Heroku baseline, include this note:
 
-> "EKS with EC2 nodes is typically cheaper than Fargate for sustained workloads (>60% utilization) because there is no per-pod Fargate surcharge. However, EKS has a higher base cost ($73/month control plane + minimum 2 nodes) and requires Kubernetes operational expertise."
+> "EKS with EC2 nodes is typically cheaper than Fargate for sustained workloads (>60% utilization) because there is no per-pod Fargate surcharge. However, EKS has a higher base cost (`eks.control_plane_monthly` control plane + minimum 2 nodes) and requires Kubernetes operational expertise."
 
 ### Cost Tier Calculation
 
@@ -223,14 +217,16 @@ Sum all applicable services.
 ### Step 3: Calculate CloudWatch Costs
 
 ```
-log_ingestion_cost    = monthly_log_gb × $0.50
-log_storage_cost      = monthly_log_gb × $0.03 × retention_months (use preferences.operational.log_retention_days / 30, default: 1)
-custom_metrics_cost   = custom_metrics_count × $0.30
-alarms_cost           = alarm_count × $0.10
+log_ingestion_cost    = monthly_log_gb × cloudwatch.log_ingestion_per_gb
+log_storage_cost      = monthly_log_gb × cloudwatch.log_storage_per_gb_month × retention_months (use preferences.operational.log_retention_days / 30, default: 1)
+custom_metrics_cost   = custom_metrics_count × cloudwatch.custom_metric_month
+alarms_cost           = alarm_count × cloudwatch.standard_alarm_month
 tracing_cost          = 0 (do not add X-Ray costs unless tracing detected in source)
 
 total_observability   = log_ingestion_cost + log_storage_cost + custom_metrics_cost + alarms_cost + tracing_cost
 ```
+
+(All `cloudwatch.*` rates are in `shared/pricing/aws-infra-pricing.json`.)
 
 ### Step 4: Add Observability Entry
 
@@ -679,7 +675,7 @@ Keep under 25 lines. The user can ask for details or re-read `estimation-infra.j
 
 ## Pricing Recipes (MCP Fallback Only)
 
-Only use these recipes when a service is NOT in `pricing-cache.md` and MCP is available. Do NOT call `get_pricing_service_codes` or `get_pricing_service_attributes` — go directly to `get_pricing`.
+Only use these recipes when a service is NOT in `shared/pricing/aws-infra-pricing.json` and MCP is available. Do NOT call `get_pricing_service_codes` or `get_pricing_service_attributes` — go directly to `get_pricing`.
 
 | AWS Service       | service_code      | filters                                                                                                     | output_options                                                                                                                                     |
 | ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
@@ -13,7 +13,6 @@ The heroku-to-aws skill reuses these shared files from the gcp-to-aws sibling sk
 | `handoff-gates.md`         | Fail-closed phase handoff protocol (HANDOFF_OK / GATE_FAIL) |
 | `schema-phase-status.md`   | `.phase-status.json` schema (canonical reference)           |
 | `migration-complexity.md`  | Complexity tier definitions (Small/Medium/Large)            |
-| `pricing-cache.md`         | Cached AWS pricing rates (primary source for estimates)     |
 | `schema-estimate-infra.md` | `estimation-infra.json` schema                              |
 | `validate-artifacts.md`    | Pre-report validation (Generate Step 0; read-only)          |
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/pricing-cache.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/pricing-cache.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/pricing-cache.md

--- a/migrate/plugins/migration-to-aws/skills/shared/pricing/aws-infra-pricing.json
+++ b/migrate/plugins/migration-to-aws/skills/shared/pricing/aws-infra-pricing.json
@@ -1,0 +1,170 @@
+{
+  "_comment": "Shared AWS infrastructure pricing rates (us-east-1, USD) for the estimate phase. Rates evolve on AWS's cadence, independent of the cost algorithm, so they live here as DATA and the estimate procedure does a lookup, not a guess. Each service carries its rates + a multi_az_handling key; the cost FORMULAS live in the estimate phase's prose (the algorithm is not data). Currently consumed by the heroku-to-aws skill; intended to be shared with gcp-to-aws. AI-model / Lambda / DynamoDB / Redshift / Athena / SageMaker rates are NOT here (gcp-specific; they remain in the gcp-to-aws pricing cache).",
+  "_meta": {
+    "last_updated": "2026-06-14",
+    "region": "us-east-1",
+    "currency": "USD",
+    "accuracy": "±5-10% infrastructure",
+    "hours_per_month": 730,
+    "staleness_days": 30,
+    "staleness_note": "If more than staleness_days past last_updated, infrastructure rates remain reliable; set pricing_source=cached_stale and note it. AI-model rates (not used for heroku->aws) may have drifted."
+  },
+  "_multi_az_convention": {
+    "_comment": "THE TRAP: a design's multi_az:true means different things per service. Each service rate below carries multi_az_handling so the formula applies the RIGHT adjustment, never a blanket multiplier.",
+    "baked_in": "rate already INCLUDES multi-AZ; NEVER apply a multiplier (multi_az flag is informational)",
+    "multiplier_x2": "rate is single-AZ; multiply by 2 when design multi_az == true",
+    "intrinsic": "service is inherently multi-AZ; no adjustment; multi_az flag informational"
+  },
+  "fargate": {
+    "per_vcpu_hour": 0.04048,
+    "per_gb_mem_hour": 0.004445,
+    "multi_az_handling": "n/a (Fargate cost is task-size driven, not AZ-driven)"
+  },
+  "alb": {
+    "monthly_fixed": 16.43,
+    "per_lcu_hour": 0.008
+  },
+  "rds_postgresql": {
+    "multi_az_handling": "baked_in",
+    "_note": "pricing-cache RDS PostgreSQL table is labeled (On-Demand, Multi-AZ) — the rate ALREADY includes multi-AZ. Do NOT double for multi_az.",
+    "instances": {
+      "db.t4g.micro": 0.032,
+      "db.t4g.small": 0.065,
+      "db.t4g.medium": 0.129,
+      "db.t4g.large": 0.258,
+      "db.t4g.xlarge": 0.517,
+      "db.t4g.2xlarge": 1.034,
+      "db.m6g.large": 0.356,
+      "db.m6g.xlarge": 0.712,
+      "db.m6g.2xlarge": 1.424,
+      "db.m6g.4xlarge": 2.848,
+      "db.m6g.8xlarge": 5.696,
+      "db.m6g.16xlarge": 11.392,
+      "db.r6g.16xlarge": 14.5,
+      "db.x2g.16xlarge": 18.05
+    },
+    "storage_per_gb_month": 0.23,
+    "_instances_note": "Multi-AZ on-demand hourly, us-east-1. t4g.* verified from the pricing cache; m6g/r6g/x2g families added to MATCH the instance classes the postgres design table can emit — approximate (~2x single-AZ), verify via the AWS Pricing MCP for a large estimate. Every rds_instance_class the design can emit MUST have a rate here (no unpriced production DBs)."
+  },
+  "aurora_postgresql": {
+    "multi_az_handling": "intrinsic",
+    "_note": "Aurora replicates across 3 AZs by default; rate is as-listed, no multi-AZ adjustment.",
+    "instances": {
+      "db.t4g.medium": 0.073,
+      "db.t4g.large": 0.146,
+      "db.r6g.large": 0.26,
+      "db.r6g.xlarge": 0.553,
+      "db.r6g.2xlarge": 1.104,
+      "db.r6g.4xlarge": 2.208,
+      "db.r6g.8xlarge": 4.416,
+      "db.r6g.16xlarge": 8.832
+    },
+    "_instances_note": "r6g.16xlarge extrapolated 2x from 8xlarge; verify via MCP if it drives a large estimate.",
+    "storage_per_gb_month": 0.1,
+    "io_per_million": 0.2
+  },
+  "elasticache": {
+    "multi_az_handling": "multiplier_x2",
+    "_note": "pricing-cache ElastiCache is Single-AZ; apply x2 when design multi_az == true.",
+    "nodes": {
+      "cache.t4g.micro": 0.016,
+      "cache.t4g.small": 0.032,
+      "cache.t4g.medium": 0.065,
+      "cache.t3.micro": 0.017,
+      "cache.t3.small": 0.034,
+      "cache.t3.medium": 0.068,
+      "cache.m6g.large": 0.206,
+      "cache.m6g.xlarge": 0.412,
+      "cache.m6g.2xlarge": 0.824,
+      "cache.m6g.4xlarge": 1.648,
+      "cache.m6g.8xlarge": 3.296,
+      "cache.m6g.12xlarge": 4.944,
+      "cache.m6g.16xlarge": 6.592
+    },
+    "_nodes_note": "m6g sizes above large extrapolated by doubling; verify via MCP if large."
+  },
+  "msk": {
+    "multi_az_handling": "intrinsic",
+    "_note": "broker_count already spans AZs (2 or 3 per design); cost is per-broker, no extra multi-AZ multiplier.",
+    "brokers": {
+      "kafka.t3.small": 0.0456,
+      "kafka.m5.large": 0.21,
+      "kafka.m5.xlarge": 0.42,
+      "kafka.m5.2xlarge": 0.84,
+      "kafka.m5.4xlarge": 1.68,
+      "kafka.m5.8xlarge": 3.36,
+      "kafka.m5.12xlarge": 5.04
+    },
+    "_brokers_note": "MSK broker rates approximate; verify via MCP for a kafka-heavy estimate.",
+    "storage_per_gb_month": 0.1
+  },
+  "eks": {
+    "_comment": "EKS cost = control plane (once) + EC2 nodes; PODS COST $0 (compute billed via nodes — charging pods double-counts). Added per EKS cluster in the design. ALB (web) and NAT are added by their own lines, NOT re-added here.",
+    "control_plane_monthly": 73,
+    "node_rates_monthly": {
+      "m6i.large": 70.08,
+      "m6i.xlarge": 140.16,
+      "m6i.4xlarge": 560.64,
+      "r6i.4xlarge": 735.84,
+      "m6i.8xlarge": 1121.28,
+      "m6i.16xlarge": 2242.56
+    },
+    "pod_cost": 0
+  },
+  "nat_gateway": {
+    "monthly_fixed": 32.85,
+    "per_gb_processed": 0.045
+  },
+  "rds_proxy": {
+    "per_vcpu_hour": 0.015
+  },
+  "route53": {
+    "hosted_zone_monthly": 0.5,
+    "per_million_queries": 0.4
+  },
+  "fast_path_services": {
+    "_comment": "Flat monthly_baseline_est per fast-path add-on — PINNED stated assumptions for the stopgap (these are estimates, not measured rates; an external pricing source will replace them). per-unit rates kept as documentation of the basis. Use monthly_baseline_est as the breakdown mid; mark the line as an estimate.",
+    "s3": {
+      "storage_per_gb_month": 0.023,
+      "monthly_baseline_est": 5,
+      "_basis": "assumes ~50GB + light requests; storage_per_gb_month is the rate basis"
+    },
+    "ses": {
+      "per_1000_emails": 0.1,
+      "monthly_baseline_est": 5,
+      "_basis": "assumes <50k emails/mo @ per_1000_emails; flat placeholder pending usage data"
+    },
+    "eventbridge": {
+      "per_million_events": 1,
+      "monthly_baseline_est": 1,
+      "_basis": "assumes ~1M cron-scale events/mo @ per_million_events"
+    },
+    "amazon_mq": {
+      "instance_monthly_est": 130
+    },
+    "opensearch": {
+      "instance_monthly_est": 100
+    },
+    "cloudfront": {
+      "per_gb_first_10tb": 0.085,
+      "monthly_baseline_est": 10,
+      "_basis": "assumes ~100GB egress/mo @ per_gb_first_10tb + light requests"
+    },
+    "secrets_manager": {
+      "per_secret_month": 0.4,
+      "per_10k_api_calls": 0.05,
+      "monthly_baseline_est": 2,
+      "_basis": "assumes ~3 secrets @ per_secret_month + light API calls"
+    },
+    "elasticache_memcached": {
+      "_use": "same node rates as elasticache (Memcachier mapping)"
+    }
+  },
+  "cloudwatch": {
+    "log_ingestion_per_gb": 0.5,
+    "log_storage_per_gb_month": 0.03,
+    "custom_metric_month": 0.3,
+    "standard_alarm_month": 0.1,
+    "xray_per_million_traces": 5
+  }
+}


### PR DESCRIPTION
## What

Moves the AWS infrastructure pricing rates used by the estimate phase into one structured file: `skills/shared/pricing/aws-infra-pricing.json`. The JSON holds **data only** — rates, multi-AZ handling, and provenance notes. The cost **algorithm** (the per-service formulas) stays in the `estimate.md` prose table, where the LLM executes it directly. So the volatile facts (rates) and the stable procedure (formulas) each have one natural home, and the estimate does a rate lookup instead of embedding dollar amounts in prose.

## Why this is worth doing

Today the same AWS rates live in **two** places that can (and already do) disagree:

1. `references/shared/pricing-cache.md` (a markdown cache shared with the gcp-to-aws skill), and
2. **hardcoded inline** in `estimate.md`'s cost-formula table, EKS node table, and CloudWatch block.

For example the EKS node rates (m6i/r6i) and RDS Proxy rate existed **only inline** in `estimate.md` — the cache never had them. Consolidating into one reviewable JSON kills that dual-source drift and means a missing rate can't hide.

## Why a new `skills/shared/` location

The rates are infrastructure pricing that **both** the heroku-to-aws and gcp-to-aws skills need (big overlap: Fargate, RDS, Aurora, EC2, EKS, ElastiCache, S3, ALB, NAT, Route53, CloudFront, Secrets, CloudWatch, X-Ray). The file lives at `skills/shared/` so neither skill owns it. **This PR repoints heroku-to-aws only**; gcp-to-aws keeps reading its own `pricing-cache.md` and can migrate to the shared file in a follow-up. (Note: AI-model / Lambda / DynamoDB / Redshift / Athena / SageMaker rates stay in gcp's cache — they're gcp-specific and not in this file.)

## Changes

- **add** `skills/shared/pricing/aws-infra-pricing.json` — infra rates + per-service formulas + multi-AZ convention
- **`estimate.md`** — Step 0a, the cost-formula table, the EKS section, and the CloudWatch block now reference JSON keys (e.g. `fargate.per_vcpu_hour`, `rds_postgresql.instances[class]`, `eks.node_rates_monthly[type]`) instead of hardcoded dollar amounts. The MCP fallback path (for services not in the file) is unchanged.
- **remove** heroku's `pricing-cache.md` symlink; repoint `SKILL.md` + `references/shared/README.md`
- `heroku-pricing-cache.md` (source-side Heroku plan prices, a separate concern) is **untouched**

## Data changes (not just format) — for reviewer sign-off

The JSON includes rates the old markdown cache did NOT have. Most are **existing-but-hidden** values the estimate already used inline or implied — now visible in one place:

| Addition | Status |
| --- | --- |
| RDS PostgreSQL `m6g`/`r6g`/`x2g` classes | design tables emit these; ~2× single-AZ approximations (flagged in `_instances_note`) |
| ElastiCache `m6g` ladder; Aurora `r6g` ladder | to match design emissions; `r6g.16xlarge` extrapolated |
| EKS node monthly rates `m6i`/`r6i` | **were inline-only** in estimate.md before — formalized, same values |
| MSK broker rates | **net-new** (cache had no MSK section) |
| Amazon MQ / OpenSearch monthly est | **net-new**, heroku-only services |
| fast-path flat baselines (s3/ses/eventbridge/cloudfront/secrets) | replace prose "minimal" instructions; `_basis`-flagged, meant to be replaced by external pricing |

The genuinely new-to-the-skill numbers are **MSK** and **MQ/OpenSearch**; the rest formalize values already in use.

## Validation

Cold-ran the estimate phase against the `large-terraform` sample repo: a zero-context agent resolved the JSON via the relative path, found every rate key, applied the correct per-service multi-AZ adjustment (RDS baked-in / ElastiCache ×2 / MSK intrinsic), and computed per-service costs **matching hand-computed ground truth exactly** (Fargate, ALB, RDS, ElastiCache, MSK).

- full `mise build` green (lint:md, fmt:check, security suite)
- JSON parses; the `estimate.md → JSON` relative link resolves

## Follow-up (tracked)

Migrate gcp-to-aws's estimate to read this same shared file and retire its `pricing-cache.md` infra sections — closing the temporary two-copy window. Should happen soon so the duplication doesn't become permanent.

