### PR TITLE
Extract heroku-to-aws EKS pod sizing + cluster constants to JSON

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/eks-pod-sizing.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/design/eks-pod-sizing.json
@@ -1,0 +1,162 @@
+{
+  "_comment": "Dyno type -> EKS pod sizing + node selection. Used by the design EKS branch when design_constraints.kubernetes.value is eks-managed or eks-or-ecs. DIRECT LOOKUP: read req_cpu/req_mem/lim_cpu/lim_mem + node_type per dyno. This file holds DATA only (pod rows, node-rank, cluster constants); the node-group SIZING ALGORITHM lives in design-eks.md prose.",
+  "_match": "exact, case-insensitive, on formation config.dyno_type",
+  "_on_not_found": "reject the formation; produce NO entry; warn 'Unsupported dyno type: {dyno_type}. Cannot map to EKS.'; continue (same as the Fargate path)",
+
+  "rows": {
+    "standard-1x": {
+      "req_cpu": "250m",
+      "req_mem": "512Mi",
+      "lim_cpu": "500m",
+      "lim_mem": "512Mi",
+      "node_type": "m6i.large"
+    },
+    "standard-2x": {
+      "req_cpu": "500m",
+      "req_mem": "1024Mi",
+      "lim_cpu": "1000m",
+      "lim_mem": "1024Mi",
+      "node_type": "m6i.large"
+    },
+    "performance-m": {
+      "req_cpu": "1000m",
+      "req_mem": "2560Mi",
+      "lim_cpu": "2000m",
+      "lim_mem": "2560Mi",
+      "node_type": "m6i.xlarge"
+    },
+    "performance-l": {
+      "req_cpu": "4000m",
+      "req_mem": "14336Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "14336Mi",
+      "node_type": "m6i.4xlarge"
+    },
+    "performance-l-ram": {
+      "req_cpu": "4000m",
+      "req_mem": "30720Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "30720Mi",
+      "node_type": "r6i.4xlarge"
+    },
+    "performance-xl": {
+      "req_cpu": "8000m",
+      "req_mem": "63488Mi",
+      "lim_cpu": "16000m",
+      "lim_mem": "63488Mi",
+      "node_type": "m6i.8xlarge"
+    },
+    "performance-2xl": {
+      "req_cpu": "16000m",
+      "req_mem": "129024Mi",
+      "lim_cpu": "32000m",
+      "lim_mem": "129024Mi",
+      "node_type": "m6i.16xlarge"
+    },
+    "private-s": {
+      "req_cpu": "500m",
+      "req_mem": "1024Mi",
+      "lim_cpu": "1000m",
+      "lim_mem": "1024Mi",
+      "node_type": "m6i.large"
+    },
+    "private-m": {
+      "req_cpu": "1000m",
+      "req_mem": "2560Mi",
+      "lim_cpu": "2000m",
+      "lim_mem": "2560Mi",
+      "node_type": "m6i.xlarge"
+    },
+    "private-l": {
+      "req_cpu": "4000m",
+      "req_mem": "14336Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "14336Mi",
+      "node_type": "m6i.4xlarge"
+    },
+    "private-l-ram": {
+      "req_cpu": "4000m",
+      "req_mem": "30720Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "30720Mi",
+      "node_type": "r6i.4xlarge"
+    },
+    "private-xl": {
+      "req_cpu": "8000m",
+      "req_mem": "63488Mi",
+      "lim_cpu": "16000m",
+      "lim_mem": "63488Mi",
+      "node_type": "m6i.8xlarge"
+    },
+    "private-2xl": {
+      "req_cpu": "16000m",
+      "req_mem": "129024Mi",
+      "lim_cpu": "32000m",
+      "lim_mem": "129024Mi",
+      "node_type": "m6i.16xlarge"
+    },
+    "shield-s": {
+      "req_cpu": "500m",
+      "req_mem": "1024Mi",
+      "lim_cpu": "1000m",
+      "lim_mem": "1024Mi",
+      "node_type": "m6i.large"
+    },
+    "shield-m": {
+      "req_cpu": "1000m",
+      "req_mem": "2560Mi",
+      "lim_cpu": "2000m",
+      "lim_mem": "2560Mi",
+      "node_type": "m6i.xlarge"
+    },
+    "shield-l": {
+      "req_cpu": "4000m",
+      "req_mem": "14336Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "14336Mi",
+      "node_type": "m6i.4xlarge"
+    },
+    "shield-l-ram": {
+      "req_cpu": "4000m",
+      "req_mem": "30720Mi",
+      "lim_cpu": "8000m",
+      "lim_mem": "30720Mi",
+      "node_type": "r6i.4xlarge"
+    },
+    "shield-xl": {
+      "req_cpu": "8000m",
+      "req_mem": "63488Mi",
+      "lim_cpu": "16000m",
+      "lim_mem": "63488Mi",
+      "node_type": "m6i.8xlarge"
+    },
+    "shield-2xl": {
+      "req_cpu": "16000m",
+      "req_mem": "129024Mi",
+      "lim_cpu": "32000m",
+      "lim_mem": "129024Mi",
+      "node_type": "m6i.16xlarge"
+    }
+  },
+
+  "node_size_rank": {
+    "_comment": "Rank for the 'largest-pod-class-wins' node selection: pick the node_type of the largest dyno present across all formations. Higher rank = larger. Tie at rank 3 (m6i.4xlarge vs r6i.4xlarge): prefer m6i.4xlarge UNLESS a RAM-optimized dyno (*-l-ram) is the only dyno at that rank, in which case use r6i.4xlarge.",
+    "m6i.large": 1,
+    "m6i.xlarge": 2,
+    "m6i.4xlarge": 3,
+    "r6i.4xlarge": 3,
+    "m6i.8xlarge": 4,
+    "m6i.16xlarge": 5
+  },
+
+  "system_overhead_per_node": { "cpu": "500m", "memory": "512Mi" },
+
+  "cluster": {
+    "cluster_name": "heroku-migration-cluster",
+    "kubernetes_version_fallback": "1.31",
+    "_kubernetes_version_note": "FALLBACK only. The design-eks procedure should query the latest EKS-supported stable version at generation time (aws eks describe-addon-versions) and use this value only when the query is unavailable. Do NOT treat 1.31 as pinned.",
+    "node_group_type_by_pref": { "eks-managed": "self-managed", "eks-or-ecs": "managed" },
+    "_node_group_note": "eks-managed -> self-managed node groups (full K8s control); eks-or-ecs -> managed node groups (less operational burden).",
+    "addons": ["vpc-cni", "coredns", "kube-proxy", "aws-load-balancer-controller"]
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/eks-mapping-table.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/design-refs/eks-mapping-table.md
@@ -6,27 +6,14 @@ Maps each Heroku dyno type to Kubernetes pod resource requests, resource limits,
 
 ## Pod Resource Mapping
 
-| Heroku Dyno Type  | Pod Request CPU | Pod Request Memory | Pod Limit CPU | Pod Limit Memory | Recommended Node Type |
-| ----------------- | --------------- | ------------------ | ------------- | ---------------- | --------------------- |
-| standard-1x       | 250m            | 512Mi              | 500m          | 512Mi            | m6i.large             |
-| standard-2x       | 500m            | 1024Mi             | 1000m         | 1024Mi           | m6i.large             |
-| performance-m     | 1000m           | 2560Mi             | 2000m         | 2560Mi           | m6i.xlarge            |
-| performance-l     | 4000m           | 14336Mi            | 8000m         | 14336Mi          | m6i.4xlarge           |
-| performance-l-ram | 4000m           | 30720Mi            | 8000m         | 30720Mi          | r6i.4xlarge           |
-| performance-xl    | 8000m           | 63488Mi            | 16000m        | 63488Mi          | m6i.8xlarge           |
-| performance-2xl   | 16000m          | 129024Mi           | 32000m        | 129024Mi         | m6i.16xlarge          |
-| private-s         | 500m            | 1024Mi             | 1000m         | 1024Mi           | m6i.large             |
-| private-m         | 1000m           | 2560Mi             | 2000m         | 2560Mi           | m6i.xlarge            |
-| private-l         | 4000m           | 14336Mi            | 8000m         | 14336Mi          | m6i.4xlarge           |
-| private-l-ram     | 4000m           | 30720Mi            | 8000m         | 30720Mi          | r6i.4xlarge           |
-| private-xl        | 8000m           | 63488Mi            | 16000m        | 63488Mi          | m6i.8xlarge           |
-| private-2xl       | 16000m          | 129024Mi           | 32000m        | 129024Mi         | m6i.16xlarge          |
-| shield-s          | 500m            | 1024Mi             | 1000m         | 1024Mi           | m6i.large             |
-| shield-m          | 1000m           | 2560Mi             | 2000m         | 2560Mi           | m6i.xlarge            |
-| shield-l          | 4000m           | 14336Mi            | 8000m         | 14336Mi          | m6i.4xlarge           |
-| shield-l-ram      | 4000m           | 30720Mi            | 8000m         | 30720Mi          | r6i.4xlarge           |
-| shield-xl         | 8000m           | 63488Mi            | 16000m        | 63488Mi          | m6i.8xlarge           |
-| shield-2xl        | 16000m          | 129024Mi           | 32000m        | 129024Mi         | m6i.16xlarge          |
+> **Data:** [`knowledge/design/eks-pod-sizing.json`](../../knowledge/design/eks-pod-sizing.json)
+>
+> The dyno-type → EKS pod sizing rows are maintained as structured data in that
+> JSON file. Read the `rows` map keyed by Heroku dyno type; each row carries
+> `req_cpu` / `req_mem` (pod resource requests), `lim_cpu` / `lim_mem` (limits),
+> and `node_type` (recommended EC2 node instance type). The file also holds
+> `node_size_rank` (for largest-pod-class-wins node selection), the
+> `system_overhead_per_node` constants, and the EKS `cluster` constants.
 
 ## Design Rationale
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-eks.md
@@ -18,19 +18,20 @@ When the Kubernetes preference indicates EKS:
    - If process type is `web` → include Kubernetes Service (type: LoadBalancer) with AWS LB Controller annotations
    - If process type is NOT `web` → Deployment only (no Service)
 
-2. **Produce single EKS cluster entry:**
-   - `cluster_name`: `"heroku-migration-cluster"`
-   - `kubernetes_version`: Use the latest EKS-supported stable version at generation time (query via `aws eks describe-addon-versions` or default to current stable: `"1.31"`). Do not hardcode — EKS deprecates older versions on a rolling basis.
-   - Node group type based on preference:
-     - `"eks-managed"` → `"self-managed"` node groups (more control)
-     - `"eks-or-ecs"` → `"managed"` node groups (less operational burden)
-   - Addons: `["vpc-cni", "coredns", "kube-proxy", "aws-load-balancer-controller"]`
+2. **Produce single EKS cluster entry** (constants from `design-refs/eks-mapping-table.md` → its `cluster` JSON block):
+   - `cluster_name`: from `cluster.cluster_name` (`"heroku-migration-cluster"`)
+   - `kubernetes_version`: query the latest EKS-supported stable version at generation time (`aws eks describe-addon-versions`); if the query is unavailable, fall back to `cluster.kubernetes_version_fallback`. Do not hardcode — EKS deprecates older versions on a rolling basis.
+   - Node group type: from `cluster.node_group_type_by_pref` keyed on the preference (`eks-managed` → `self-managed`, more control; `eks-or-ecs` → `managed`, less operational burden)
+   - Addons: from `cluster.addons`
 
 3. **Node group sizing:**
-   - Determine the largest dyno type present across all formations
-   - Select instance type using **largest-pod-class-wins** rule: use the recommended node type for that largest dyno type. All pods from smaller classes fit on those nodes with room to spare.
-   - Calculate node count: min_size = 2 (HA), max_size = ceil(total_pods / 4) + 2, desired_size = ceil(total_pods / 4)
-   - System overhead per node: 500m CPU, 512Mi memory
+   - Determine the largest dyno type present across all formations.
+   - Select instance type using the **largest-pod-class-wins** rule: use the recommended `node_type` for the largest dyno present, ranked by the JSON's `node_size_rank` (higher = larger). On a rank tie between `m6i.4xlarge` and `r6i.4xlarge`, prefer `m6i.4xlarge` unless a RAM-optimized dyno (`*-l-ram`) is the only dyno at that rank, in which case use `r6i.4xlarge`. All pods from smaller classes fit on those nodes with room to spare.
+   - Calculate node count:
+     - `min_size` = 2 (HA)
+     - `desired_size` = `max(min_size, ceil(total_pods / 4))` — clamp UP to `min_size`; AWS rejects `desired_size < min_size`, which would otherwise happen for small workloads (`total_pods <= 4`).
+     - `max_size` = `desired_size + 2`
+   - System overhead per node: from the JSON's `system_overhead_per_node` (500m CPU, 512Mi memory).
 
 4. **Non-formation resources unchanged:**
    - Postgres → RDS/Aurora (existing path)
@@ -57,7 +58,7 @@ When EKS is selected, ALL formation-type resources map to EKS. No mixing of Farg
   "confidence": "deterministic",
   "aws_config": {
     "region": "<target-region>",
-    "cluster_name": "heroku-migration-cluster",
+    "cluster_name": "<cluster.cluster_name>",
     "namespace": "<heroku-app>",
     "deployment_name": "<process-type>",
     "replicas": <quantity>,
@@ -78,9 +79,9 @@ When EKS is selected, ALL formation-type resources map to EKS. No mixing of Farg
 ```json
 {
   "eks_cluster": {
-    "cluster_name": "heroku-migration-cluster",
-    "kubernetes_version": "<latest EKS-supported stable, e.g. 1.31>",
-    "node_group_type": "<managed|self-managed>",
+    "cluster_name": "<cluster.cluster_name>",
+    "kubernetes_version": "<queried latest stable, else cluster.kubernetes_version_fallback>",
+    "node_group_type": "<managed|self-managed, from cluster.node_group_type_by_pref>",
     "node_groups": [
       {
         "name": "general",
@@ -90,7 +91,7 @@ When EKS is selected, ALL formation-type resources map to EKS. No mixing of Farg
         "desired_size": <calculated>
       }
     ],
-    "addons": ["vpc-cni", "coredns", "kube-proxy", "aws-load-balancer-controller"]
+    "addons": "<cluster.addons>"
   }
 }
 ```


### PR DESCRIPTION
## What

Extracts the EKS design knowledge into `knowledge/design/eks-pod-sizing.json`: the 19 dyno→pod-sizing rows, the node-selection rank, the system-overhead constants, and the EKS cluster constants. The `eks-mapping-table.md` pod-resource table becomes a JSON pointer (rationale / capacity-validation / overhead prose kept); `design-eks.md` references the JSON cluster constants.

Follows the same data/algorithm split as the prior extractions: **data → JSON, algorithm → prose**. The node-group sizing algorithm stays in `design-eks.md`.

## Behavior decisions (please review the resolutions, not just the format)

This PR carries three decisions beyond a mechanical move — flagged explicitly:

1. **`kubernetes_version` stays query-live (NOT pinned).** The JSON key is named `kubernetes_version_fallback` (`"1.31"`), and `design-eks.md` still instructs querying the latest EKS-supported stable version at generation time, using the fallback only when the query is unavailable. Naming it `_fallback` prevents it being read as a pin.

2. **Node-sizing bugfix.** `desired_size` is now `max(min_size, ceil(total_pods/4))`. The old formula `ceil(total_pods/4)` produced `desired_size=1` for small workloads (`total_pods ≤ 4`), which is `< min_size` (2) and is **rejected by AWS at apply time**. The clamp fixes it. **This changes output for small EKS workloads** (desired_size 1 → 2).

3. **Node-type tie-break made explicit.** At rank 3, prefer `m6i.4xlarge` unless a RAM-optimized dyno (`*-l-ram`) is the only dyno at that rank, then `r6i.4xlarge`. Pinned in `node_size_rank`; previously the prose only said "largest-pod-class-wins" without defining the tie.

Pod-sizing row **values are unchanged** from the markdown (19 types).

## Validation

Cold-ran the EKS design branch against three fixtures:
- **small workload** (total_pods=3) → desired_size clamped to 2 (not the buggy 1) ✓
- **multi-class tie** (performance-l + performance-l-ram both at rank 3) → m6i.4xlarge ✓
- **ram-only tie** (performance-l-ram alone at rank 3) → r6i.4xlarge ✓

A zero-context agent resolved the JSON, found every key, and computed pod sizing + node-group sizing matching hand-computed ground truth exactly. Full `mise build` green; JSON parses; the `.md → JSON` link resolves.

## Scope notes

- EKS support landed on `main` via #85; this extracts its design-phase knowledge. The generate-phase EKS prose (`generate-eks.md`) is out of scope.
- This is the EKS counterpart to the design-table extraction (#87) and pricing extraction (#88).
