### PR TITLE
Extract heroku-to-aws estimate-phase default heuristics to JSON

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/estimate/estimate-defaults.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/estimate/estimate-defaults.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Tunable estimate-phase assumptions for the heroku-to-aws skill (the heuristic knobs an org adjusts, independent of the cost algorithm and the AWS rate table). AWS rates live in shared/pricing/aws-infra-pricing.json; cost FORMULAS and tier/heuristic logic stay in estimate.md prose. Complexity-tier bands + timelines are NOT here (they live in the shared references/shared/migration-complexity.md).",
+  "log_volume_gb_per_service": {
+    "_comment": "Per-service monthly CloudWatch log-volume heuristic, counted PER DESIGNED SERVICE (MSK is per broker). Used by the observability cost step. Heuristic because Heroku's logging model differs, so source billing doesn't apply.",
+    "fargate_task": 3,
+    "rds_or_aurora_instance": 1,
+    "alb": 2,
+    "nat_gateway": 1,
+    "elasticache_node": 0.5,
+    "msk_broker": 2
+  },
+  "optimization_savings_ranges": {
+    "_comment": "Estimated savings RANGES per post-migration optimization opportunity, shown beyond the Balanced on-demand baseline. Ranges only (the LLM emits the full optimization_opportunities[] entry, with descriptions/references, from estimate.md prose). target_services / timing gate which opportunities are relevant to the designed architecture and match the emitted entry field names.",
+    "compute_savings_plans": {
+      "savings_percent": "20-66%",
+      "target_services": [
+        "Fargate"
+      ],
+      "timing": "Post-migration (after 30-90 day baseline)"
+    },
+    "database_savings_plans": {
+      "savings_percent": "up to 35% (serverless) / ~20% (provisioned)",
+      "target_services": [
+        "Aurora",
+        "RDS",
+        "ElastiCache"
+      ],
+      "timing": "Post-migration or after right-sizing"
+    },
+    "rds_reserved_instances": {
+      "savings_percent": "up to 69%",
+      "target_services": [
+        "RDS",
+        "Aurora (provisioned)"
+      ],
+      "timing": "Post-migration (after architecture stabilizes)"
+    },
+    "s3_intelligent_tiering": {
+      "savings_percent": "38-50%",
+      "target_services": [
+        "S3 storage"
+      ],
+      "timing": "During migration"
+    },
+    "fargate_spot": {
+      "savings_percent": "60-70%",
+      "target_services": [
+        "Non-critical/batch Fargate tasks"
+      ],
+      "timing": "If worker dynos exist"
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -195,18 +195,9 @@ Heroku includes basic logging via its log drain. AWS CloudWatch charges from the
 
 ### Step 1: Estimate Log Volume
 
-Use per-service heuristic (billing data not applicable for log volume since Heroku logging model differs):
+Use the per-service log-volume heuristic from [`knowledge/estimate/estimate-defaults.json`](../../../knowledge/estimate/estimate-defaults.json) → `log_volume_gb_per_service` (billing data not applicable for log volume since Heroku's logging model differs). Keyed by service: `fargate_task` (per task), `rds_or_aurora_instance` (per instance), `alb` (per load balancer), `nat_gateway` (per gateway), `elasticache_node` (per node), `msk_broker` (per broker).
 
-| AWS Service (from aws-design.json) | Estimated log volume/month | Basis                   |
-| ---------------------------------- | -------------------------- | ----------------------- |
-| Fargate task                       | 3 GB per task              | Container stdout/stderr |
-| RDS/Aurora instance                | 1 GB per instance          | Error log + slow query  |
-| ALB                                | 2 GB per load balancer     | Access logs             |
-| NAT Gateway                        | 1 GB per gateway           | Flow logs               |
-| ElastiCache                        | 0.5 GB per node            | Slow log                |
-| MSK                                | 2 GB per broker            | Broker logs             |
-
-Sum all applicable services.
+Sum across all applicable services.
 
 ### Step 2: Estimate Custom Metrics and Alarms
 
@@ -374,13 +365,7 @@ Present monthly and annual cost difference between Heroku baseline and each AWS 
 
 Present applicable optimizations with estimated savings. These are **incremental post-migration actions** beyond the Balanced on-demand baseline.
 
-| Optimization           | Savings Range                               | Applies To                       | When                                           |
-| ---------------------- | ------------------------------------------- | -------------------------------- | ---------------------------------------------- |
-| Compute Savings Plans  | 20-66%                                      | Fargate                          | Post-migration (after 30-90 day baseline)      |
-| Database Savings Plans | Up to 35% (serverless) / ~20% (provisioned) | Aurora, RDS, ElastiCache         | Post-migration or after right-sizing           |
-| RDS Reserved Instances | Up to 69%                                   | RDS, Aurora (provisioned)        | Post-migration (after architecture stabilizes) |
-| S3 Intelligent-Tiering | 38-50%                                      | S3 storage                       | During migration                               |
-| Fargate Spot           | 60-70%                                      | Non-critical/batch Fargate tasks | If worker dynos exist                          |
+The savings ranges + applicability come from [`knowledge/estimate/estimate-defaults.json`](../../../knowledge/estimate/estimate-defaults.json) → `optimization_savings_ranges` (keys: `compute_savings_plans`, `database_savings_plans`, `rds_reserved_instances`, `s3_intelligent_tiering`, `fargate_spot`; each carries `savings_percent` / `target_services` / `timing`). Include ONLY opportunities relevant to the designed architecture (per each entry's `target_services` / `timing`).
 
 **Emit in `optimization_opportunities[]`:**
 


### PR DESCRIPTION
## What

Extracts two heroku-estimate-specific lookup tables out of `estimate.md` into `knowledge/estimate/estimate-defaults.json`:

- **`log_volume_gb_per_service`** — the per-service CloudWatch log-volume heuristic (Fargate 3GB/task, RDS 1GB, ALB 2GB, NAT 1GB, ElastiCache 0.5GB, MSK 2GB/broker)
- **`optimization_savings_ranges`** — per-optimization savings ranges + applicability (compute/database savings plans, RDS RIs, S3 Intelligent-Tiering, Fargate Spot)

`estimate.md` now references the JSON keys instead of inline tables. **Values unchanged; no behavior change.**

## Deliberately NOT extracted (scope discipline)

- **Cost-tier multipliers + metric/alarm heuristic formulas** stay as prose — algorithm/heuristics belong in prose (consistent with keeping the cost formulas in prose in #88).
- **`optimization_opportunities[]` output skeletons** stay — they're output-shape templates, not lookup data. The JSON's `target_services`/`timing` field names match the emitted entry fields (no naming seam).
- **Complexity-tier bands + timeline weeks** — these already live in the **shared** `references/shared/migration-complexity.md` (heroku symlinks it). `estimate.md` currently restates a *drifted* subset inline; reconciling that (make `estimate.md` defer to the shared file) is a **separate tracked follow-up** — pulling it into a heroku-owned file would create a third divergent copy.

## Validation

Cold-ran the observability + optimization steps against the `large-terraform` sample: a zero-context agent resolved the JSON, computed total log volume (**32 GB/mo**) matching hand-computed ground truth, and correctly gated optimizations — included the 4 applicable, **excluded `s3_intelligent_tiering`** for the S3-less design.

- full `mise build` green; JSON parses; `estimate.md → JSON` link resolves

## Context

Counterpart to the design-table (#87), pricing (#88), and EKS (#89) extractions — same data-in-JSON / algorithm-in-prose split.
