### PR TITLE
Phase frontmatter + interpreter + typed CI validator (phase/fragment/assembler)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -1,0 +1,100 @@
+# Interpreter
+
+How to read and act on the structured frontmatter that phase files carry. This is
+the runtime contract: when a phase file begins with a `---` YAML block, read it
+first and act on the keys below, then execute the phase's prose body.
+
+Frontmatter is being introduced phase-by-phase. A phase file with no frontmatter
+runs entirely from its prose, as before.
+
+## Phase frontmatter keys
+
+| Key                 | Meaning                                                                                                                                        |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_phase` / `_title` | the phase's id and human title                                                                                                                 |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase)                                                     |
+| `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                   |
+| `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                         |
+| `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires |
+| `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                         |
+| `_produces`         | the artifact file(s) the phase writes                                                                                                          |
+| `_advances_to`      | the phase that runs next on success                                                                                                            |
+
+### `_trigger` forms
+
+- `{ _always: true }` — the fragment always runs.
+- `{ _glob: "<pattern>" }` — the fragment runs when one or more files matching the glob exist in the workspace; otherwise it is skipped.
+
+## Fragment unit keys
+
+Each fragment file (named by a phase's `_fragments[]._file`) carries its own frontmatter:
+
+| Key            | Meaning                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_fragment`    | the fragment's id — must match the `_id` the phase's `_fragments` list uses to reference it                                                 |
+| `_of_phase`    | the phase this fragment belongs to                                                                                                          |
+| `_contributes` | the artifact section(s) this fragment writes into (fragments contribute to the phase's artifact; they do not each create a standalone file) |
+
+## Assembler unit keys
+
+The assembler file (named by a phase's `_assemble._file`) carries:
+
+| Key         | Meaning                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `_assemble` | the assembler's id                                                                            |
+| `_of_phase` | the phase this assembler belongs to                                                           |
+| `_reads`    | the fragment contributions it combines                                                        |
+| `_produces` | the artifact file(s) it creates — the assembler is the single creator of the phase's artifact |
+
+## `_init: true` — establish migration state
+
+When the phase being entered has `_init: true`, perform migration-state setup
+BEFORE running any of its fragments. This replaces what was previously written
+out as a per-phase "initialize" step.
+
+1. Check for an existing `.migration/` directory at the project root.
+   - **If existing runs are found:** list them with their phase status and ask:
+     - `[A] Resume: Continue with [latest run]`
+     - `[B] Fresh: Create new migration run`
+     - `[C] Cancel`
+   - **If resuming:** set `$MIGRATION_DIR` to the selected run's directory. Read
+     its `.phase-status.json` and validate it per the State Machine in `SKILL.md`.
+     If the `_init` phase is already `completed`, apply the re-entry rules (see the
+     phase's prose and `shared/handoff-gates.md`) before proceeding.
+   - **If fresh, or no existing runs:** continue to step 2.
+
+2. Create `.migration/[MMDD-HHMM]/` (e.g. `.migration/0315-1030/`) using the
+   current timestamp (MMDD = month/day, HHMM = hour/minute). Set `$MIGRATION_DIR`
+   to this new directory.
+
+3. Create `.migration/.gitignore` (if not already present) with exact content:
+
+   ```
+   # Auto-generated migration state (temporary, do not commit)
+   *
+   !.gitignore
+   ```
+
+   This prevents accidental commits of migration artifacts.
+
+4. Write `.phase-status.json` with the exact schema (schema reference:
+   `shared/schema-phase-status.md`):
+
+   ```json
+   {
+     "migration_id": "[MMDD-HHMM]",
+     "last_updated": "[ISO 8601 timestamp]",
+     "current_phase": "discover",
+     "phases": {
+       "discover": "in_progress",
+       "clarify": "pending",
+       "design": "pending",
+       "estimate": "pending",
+       "generate": "pending",
+       "feedback": "pending"
+     }
+   }
+   ```
+
+5. Confirm both `.migration/.gitignore` and `.phase-status.json` exist before
+   running the phase's fragments.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -27,6 +27,16 @@ description: "Migrate workloads from Heroku to AWS. Triggers on: migrate from He
 
 ---
 
+## Phase Structure (frontmatter)
+
+A phase orchestrator file (e.g. `references/phases/discover/discover.md`) may carry a small YAML frontmatter block that names how the phase is composed — its inputs, the **fragments** it runs (each with a trigger), the **assembler** that combines their outputs, what it produces, and what it requires/advances-to. `INTERPRETER.md` is the contract: it lists every frontmatter key and how to act on it (including `_init`, which establishes migration state on the first phase).
+
+**Fragment vs assembler:** a **fragment** does one unit of work and writes its own contribution; fragments are independent (none reads another's output). The **assembler** runs last and combines/validates the fragments' outputs into the phase's final artifact. A phase has 1..N fragments and exactly one assembler.
+
+When a phase file has frontmatter, read it (and `INTERPRETER.md`) first, then execute the phase body. Frontmatter is being introduced phase-by-phase; phases without it run from their prose as before.
+
+---
+
 ## Context Loading Rules
 
 Each phase loads reference files on demand. To keep per-turn context manageable and prevent instruction-following degradation:

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-assemble.md
@@ -1,0 +1,43 @@
+---
+_assemble: assemble-inventory
+_of_phase: discover
+_reads:
+  - terraform (fragment contribution)
+  - billing (fragment contribution)
+_produces:
+  - heroku-resource-inventory.json
+---
+
+# Discover — Assemble Inventory
+
+> **Assembler unit.** Runs after the discover fragments (`discover-terraform.md`,
+> `discover-billing.md`) have produced their contributions. It combines them into
+> the single `heroku-resource-inventory.json` artifact and owns that artifact's
+> final contract. See `discover.md` for how this unit is composed into the phase.
+
+After all sub-discoveries complete, assemble `heroku-resource-inventory.json` in `$MIGRATION_DIR/`.
+
+**Schema reference**: `shared/schema-discover-heroku.md` — consult for complete field definitions, per-type config schemas, and validation checklist.
+
+## Assembly Rules
+
+1. Merge all discovered resources into a flat array (no clustering, no dependency graphs).
+2. Each resource entry MUST have: `resource_id`, `resource_type`, `heroku_app`, `config`.
+3. Resources grouped by `heroku_app` field. Unassociable resources (spaces, pipelines) get `heroku_app: "unassociated"`.
+4. Include `metadata` section: `discovery_timestamp`, `total_apps_discovered`, `discovery_sources`, `confidence`.
+5. Include `apps[]` section with per-app entries containing:
+   - `app_name`, `app_id`, `discovery_status` (success/discovery_failed), `failure_reason`
+   - `heroku_generation` (cedar/fir/unknown), `generation_action` (always `detect_only`), `generation_diagnostics` (array of diagnostic reasons)
+   - `space` (Private Space name or null)
+   - `procfile_parse_warning`, `app_json_parse_warning` (per-app parse warnings or null)
+6. Include `billing_profile` section (if billing data available, with `available`, `total_monthly_cost`, `currency`, `billing_period`, `line_items`).
+7. Include `terraform_metadata` section (if Terraform discovery ran, with `found`, `tf_files_scanned`, `resource_types_extracted`, `parse_warnings`).
+8. Verify NO forbidden fields exist: `cluster_id`, `creation_order_depth`, `edges`, `dependencies`, `must_migrate_together`.
+
+**If assembly fails** (no valid resources from any source after sub-discoveries ran):
+
+Apply **unrecoverable error behavior** (Rule 4 in `discover.md`):
+
+- Revert `phases.discover` to `"pending"`.
+- Preserve prior completed phases.
+- STOP and output: "Discovery ran but produced no valid resources. Check that your input files contain valid Heroku resources and try again."

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-billing.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-billing.md
@@ -1,3 +1,10 @@
+---
+_fragment: billing
+_of_phase: discover
+_contributes:
+  - heroku-resource-inventory.json (billing_profile section)
+---
+
 # Discover Phase: Billing Discovery
 
 > Self-contained billing discovery sub-file. Scans for Heroku Dashboard invoice files and Enterprise CSV billing exports, parses billing data, builds a billing profile with per-app cost breakdowns, and contributes the `billing_profile` section to `heroku-resource-inventory.json`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
@@ -1,3 +1,10 @@
+---
+_fragment: terraform
+_of_phase: discover
+_contributes:
+  - heroku-resource-inventory.json (resource entries, apps, metadata, terraform_metadata sections)
+---
+
 # Discover Phase: Terraform Discovery (Primary Path)
 
 > Self-contained Terraform discovery sub-file. Scans `.tf` files for `heroku_*` resource types, extracts resource configuration attributes, maps them to inventory format, and integrates Procfile/app.json parsing when repo artifacts are available.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -1,3 +1,22 @@
+---
+_phase: discover
+_title: "Discover Heroku Resources"
+_init: true
+_input: workspace
+_fragments:
+  - _id: terraform
+    _trigger: { _always: true }
+    _file: phases/discover/discover-terraform.md
+  - _id: billing
+    _trigger: { _glob: "**/*{billing,invoice}*.{csv,json}" }
+    _file: phases/discover/discover-billing.md
+_assemble:
+  _file: phases/discover/discover-assemble.md
+_produces:
+  - heroku-resource-inventory.json
+_advances_to: clarify
+---
+
 # Phase 1: Discover Heroku Resources
 
 Lightweight orchestrator that delegates to domain-specific discoverers. Each sub-discovery file is self-contained — it scans for its own input, processes what it finds, and exits cleanly if nothing is relevant.
@@ -80,47 +99,10 @@ GATE_FAIL | phase=<target_phase> | field=phases.<active_phase> | reason=invalid
 
 ## Step 0: Initialize Migration State
 
-1. Check for existing `.migration/` directory at the project root.
-   - **If existing runs found:** List them with their phase status and ask:
-     - `[A] Resume: Continue with [latest run]`
-     - `[B] Fresh: Create new migration run`
-     - `[C] Cancel`
-   - **If resuming:** Set `$MIGRATION_DIR` to the selected run's directory. Read its `.phase-status.json` and validate per the State Machine in SKILL.md. If `phases.discover` is already `completed`, check re-entry rules (Rule 5).
-   - **If fresh or no existing runs:** Continue to step 2.
-
-2. Create `.migration/[MMDD-HHMM]/` directory (e.g., `.migration/0315-1030/`) using current timestamp (MMDD = month/day, HHMM = hour/minute). Set `$MIGRATION_DIR` to this new directory.
-
-3. Create `.migration/.gitignore` file (if not already present) with exact content:
-
-   ```
-   # Auto-generated migration state (temporary, do not commit)
-   *
-   !.gitignore
-   ```
-
-   This prevents accidental commits of migration artifacts.
-
-4. Write `.phase-status.json` with exact schema:
-
-   ```json
-   {
-     "migration_id": "[MMDD-HHMM]",
-     "last_updated": "[ISO 8601 timestamp]",
-     "current_phase": "discover",
-     "phases": {
-       "discover": "in_progress",
-       "clarify": "pending",
-       "design": "pending",
-       "estimate": "pending",
-       "generate": "pending",
-       "feedback": "pending"
-     }
-   }
-   ```
-
-   Schema reference: `shared/schema-phase-status.md`.
-
-5. Confirm both `.migration/.gitignore` and `.phase-status.json` exist before proceeding to Step 1.
+This phase has `_init: true`. Per `INTERPRETER.md` (§ `_init`), establish migration
+state before running the sub-discovery fragments: resolve resume-vs-fresh, set
+`$MIGRATION_DIR`, create `.migration/.gitignore`, and write the initial
+`.phase-status.json`. Confirm both files exist before proceeding to Step 1.
 
 ---
 
@@ -186,32 +168,7 @@ This produces:
 
 ## Step 3: Assemble Inventory
 
-After all sub-discoveries complete, assemble `heroku-resource-inventory.json` in `$MIGRATION_DIR/`.
-
-**Schema reference**: `shared/schema-discover-heroku.md` — consult for complete field definitions, per-type config schemas, and validation checklist.
-
-### Assembly Rules
-
-1. Merge all discovered resources into a flat array (no clustering, no dependency graphs).
-2. Each resource entry MUST have: `resource_id`, `resource_type`, `heroku_app`, `config`.
-3. Resources grouped by `heroku_app` field. Unassociable resources (spaces, pipelines) get `heroku_app: "unassociated"`.
-4. Include `metadata` section: `discovery_timestamp`, `total_apps_discovered`, `discovery_sources`, `confidence`.
-5. Include `apps[]` section with per-app entries containing:
-   - `app_name`, `app_id`, `discovery_status` (success/discovery_failed), `failure_reason`
-   - `heroku_generation` (cedar/fir/unknown), `generation_action` (always `detect_only`), `generation_diagnostics` (array of diagnostic reasons)
-   - `space` (Private Space name or null)
-   - `procfile_parse_warning`, `app_json_parse_warning` (per-app parse warnings or null)
-6. Include `billing_profile` section (if billing data available, with `available`, `total_monthly_cost`, `currency`, `billing_period`, `line_items`).
-7. Include `terraform_metadata` section (if Terraform discovery ran, with `found`, `tf_files_scanned`, `resource_types_extracted`, `parse_warnings`).
-8. Verify NO forbidden fields exist: `cluster_id`, `creation_order_depth`, `edges`, `dependencies`, `must_migrate_together`.
-
-**If assembly fails** (no valid resources from any source after sub-discoveries ran):
-
-Apply **unrecoverable error behavior** (Rule 4):
-
-- Revert `phases.discover` to `"pending"`.
-- Preserve prior completed phases.
-- STOP and output: "Discovery ran but produced no valid resources. Check that your input files contain valid Heroku resources and try again."
+Load `references/phases/discover/discover-assemble.md` (the phase's assembler) and follow it to combine the sub-discovery outputs into the single `heroku-resource-inventory.json` artifact. It owns that artifact's assembly rules and the failure behavior if no valid resources were produced.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -1,0 +1,143 @@
+// Tests for the skill-agnostic frontmatter validator (tools/frontmatter-validator).
+//
+// The "guard on the guard": feed the validator KNOWN-GOOD and KNOWN-BAD frontmatter
+// (as ephemeral fixture skills in a temp dir) and assert it accepts the good and
+// rejects each bad variant. The bad frontmatter lives ONLY here as fixtures — it
+// never touches a real skill or git history. If someone breaks the validator so it
+// stops catching a bad edit, these tests go red.
+//
+// Run: node --test tests/tools/frontmatter-validator.test.ts
+//
+// (TypeScript, imports the TypeScript validator; run via Node 24 type-stripping.)
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { validateSkill } from '../../tools/frontmatter-validator/validate.ts';
+import type { Finding } from '../../tools/frontmatter-validator/types.ts';
+
+// Build an ephemeral skill on disk from a map of {relativePath: contents}, run the
+// validator against it, and clean up.
+function validateFixture(files: Record<string, string>): Finding[] {
+  const root = mkdtempSync(join(tmpdir(), 'fm-fixture-'));
+  try {
+    for (const [rel, contents] of Object.entries(files)) {
+      const abs = join(root, rel);
+      mkdirSync(abs.slice(0, abs.lastIndexOf('/')), { recursive: true });
+      writeFileSync(abs, contents);
+    }
+    return validateSkill(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// A minimal, VALID single-phase skill: phase + 1 fragment + assembler.
+function goodSkill(): Record<string, string> {
+  return {
+    'references/phases/discover/discover.md':
+`---
+_phase: discover
+_title: "Discover"
+_init: true
+_input: workspace
+_fragments:
+  - _id: terraform
+    _trigger: { _always: true }
+    _file: phases/discover/discover-terraform.md
+_assemble:
+  _file: phases/discover/discover-assemble.md
+_produces:
+  - inventory.json
+_advances_to: clarify
+---
+# Discover
+prose body.
+`,
+    'references/phases/discover/discover-terraform.md':
+`---
+_fragment: terraform
+_of_phase: discover
+_contributes:
+  - inventory.json (resource entries)
+---
+# Terraform fragment
+prose body.
+`,
+    'references/phases/discover/discover-assemble.md':
+`---
+_assemble: assemble-inventory
+_of_phase: discover
+_reads:
+  - terraform
+_produces:
+  - inventory.json
+---
+# Assembler
+prose body.
+`,
+  };
+}
+
+describe('frontmatter-validator', () => {
+  it('accepts a well-formed phase/fragment/assembler skill', () => {
+    const findings = validateFixture(goodSkill());
+    assert.equal(findings.length, 0, `expected no findings, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects a phase _fragments._file that does not resolve', () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('discover-terraform.md', 'discover-MISSING.md');
+    const findings = validateFixture(files);
+    assert.ok(findings.length >= 1, 'expected a finding for the unresolved _file');
+    assert.match(findings.map((f) => f.message).join('\n'), /_file does not resolve/);
+  });
+
+  it("rejects an unknown (typo'd) frontmatter key", () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover-terraform.md'] = files[
+      'references/phases/discover/discover-terraform.md'
+    ].replace('_fragment:', '_fragmnet:');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /unknown fragment frontmatter key '_fragmnet'/);
+  });
+
+  it("rejects a fragment whose _fragment id != the phase's reference _id", () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover-terraform.md'] = files[
+      'references/phases/discover/discover-terraform.md'
+    ].replace('_fragment: terraform', '_fragment: terraformX');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /_fragment id 'terraformX' != phase reference _id 'terraform'/);
+  });
+
+  it('rejects an unrecognized _trigger form', () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('{ _always: true }', '{ _whenever: true }');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /unrecognized _trigger form/);
+  });
+
+  it('rejects a phase _produces artifact the assembler does not create (single-creator)', () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('  - inventory.json\n_advances_to', '  - inventory.json\n  - orphan.json\n_advances_to');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /single-creator rule/);
+  });
+
+  it('does NOT fail an _advances_to that points at a phase without frontmatter (partial rollout)', () => {
+    const findings = validateFixture(goodSkill());
+    assert.ok(
+      !findings.some((f) => /advances_to|clarify/.test(f.message)),
+      'should not fail on an unverifiable forward reference',
+    );
+  });
+});

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -1,0 +1,101 @@
+// check.ts — structural checks over the typed frontmatter. Skill-AGNOSTIC: every
+// check is a property of the phase/fragment/assembler grammar (INTERPRETER.md),
+// not of any particular skill. The valid phase set is DERIVED from the phase files
+// that declare frontmatter (never hardcoded); references to phases that don't yet
+// carry frontmatter are left UNVERIFIED rather than failed (tolerant of a
+// phase-by-phase rollout).
+
+import type {
+  AssemblerFrontmatter,
+  Finding,
+  FragmentFrontmatter,
+  PhaseFrontmatter,
+} from "./types.ts";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface BoundSkill {
+  /** absolute path to the skill's `references/` root (where phase _file paths resolve). */
+  referencesRoot: string;
+  phases: PhaseFrontmatter[];
+  fragments: Map<string, FragmentFrontmatter>; // by resolved absolute path
+  assemblers: Map<string, AssemblerFrontmatter>; // by resolved absolute path
+  rel: (absPath: string) => string; // for readable messages
+}
+
+export function check(skill: BoundSkill): Finding[] {
+  const findings: Finding[] = [];
+  const add = (file: string, message: string) => findings.push({ file, message });
+
+  // Derived phase set: only phases that declare frontmatter.
+  const declaredPhases = new Set(skill.phases.map((p) => p.phase).filter(Boolean));
+  const TERMINALS = new Set(["complete", "done", "end"]);
+
+  for (const phase of skill.phases) {
+    const pf = skill.rel(phase.sourceFile);
+
+    // closed vocab
+    for (const k of phase.unknownKeys) add(pf, `unknown phase frontmatter key '${k}'`);
+
+    // _advances_to / _requires_phase: verify only when the target declares frontmatter;
+    // otherwise UNVERIFIED (skip) — tolerant of partial rollout.
+    if (phase.advancesTo && !TERMINALS.has(phase.advancesTo) && !declaredPhases.has(phase.advancesTo)) {
+      // unverified — target phase has no frontmatter yet. no finding.
+    }
+    if (phase.requiresPhase && declaredPhases.size > 1 && !declaredPhases.has(phase.requiresPhase)) {
+      // unverified likewise. no finding.
+    }
+
+    // fragments
+    for (const fr of phase.fragments) {
+      if (fr.trigger.kind === "unknown") {
+        add(pf, `fragment '${fr.id}' has an unrecognized _trigger form: ${fr.trigger.raw}`);
+      }
+      const fpath = join(skill.referencesRoot, fr.file);
+      if (!existsSync(fpath)) {
+        add(pf, `fragment '${fr.id}' _file does not resolve: ${fr.file}`);
+        continue;
+      }
+      const frag = skill.fragments.get(fpath);
+      if (!frag) {
+        add(skill.rel(fpath), `referenced as a fragment by '${phase.phase}' but has no fragment frontmatter`);
+        continue;
+      }
+      for (const k of frag.unknownKeys) add(skill.rel(fpath), `unknown fragment frontmatter key '${k}'`);
+      if (frag.fragment !== fr.id) {
+        add(skill.rel(fpath), `_fragment id '${frag.fragment || "(missing)"}' != phase reference _id '${fr.id}'`);
+      }
+      if (frag.ofPhase !== phase.phase) {
+        add(skill.rel(fpath), `_of_phase '${frag.ofPhase || "(missing)"}' != '${phase.phase}'`);
+      }
+    }
+
+    // assembler: exactly one, resolves, back-references, single-creator ownership
+    if (!phase.assembleFile) {
+      add(pf, `missing _assemble._file (a phase must have exactly one assembler)`);
+      continue;
+    }
+    const apath = join(skill.referencesRoot, phase.assembleFile);
+    if (!existsSync(apath)) {
+      add(pf, `_assemble._file does not resolve: ${phase.assembleFile}`);
+      continue;
+    }
+    const asm = skill.assemblers.get(apath);
+    if (!asm) {
+      add(skill.rel(apath), `referenced as the assembler by '${phase.phase}' but has no assembler frontmatter`);
+      continue;
+    }
+    for (const k of asm.unknownKeys) add(skill.rel(apath), `unknown assembler frontmatter key '${k}'`);
+    if (asm.ofPhase !== phase.phase) {
+      add(skill.rel(apath), `_of_phase '${asm.ofPhase || "(missing)"}' != '${phase.phase}'`);
+    }
+    // single-creator: everything the phase _produces must be created by the assembler.
+    for (const art of phase.produces) {
+      if (!asm.produces.includes(art)) {
+        add(pf, `phase _produces '${art}' but the assembler does not declare it in _produces (single-creator rule)`);
+      }
+    }
+  }
+
+  return findings;
+}

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/node-shims.d.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/node-shims.d.ts
@@ -1,0 +1,55 @@
+// node-shims.d.ts
+//
+// Minimal ambient declarations for the slice of Node's stdlib this validator uses.
+// Runs under Node 24 (native type-stripping); this file exists ONLY so `tsc` can
+// type-check without pulling @types/node — keeping the validator zero-dependency.
+
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: "utf8"): string;
+  export function existsSync(path: string): boolean;
+  export function readdirSync(path: string): string[];
+  export function statSync(path: string): { isDirectory(): boolean };
+  export function mkdtempSync(prefix: string): string;
+  export function mkdirSync(path: string, options?: { recursive: boolean }): void;
+  export function writeFileSync(path: string, data: string): void;
+  export function rmSync(path: string, options?: { recursive: boolean; force: boolean }): void;
+}
+
+declare module "node:path" {
+  export function join(...parts: string[]): string;
+  export function resolve(...parts: string[]): string;
+  export function dirname(p: string): string;
+}
+
+declare module "node:os" {
+  export function tmpdir(): string;
+}
+
+declare module "node:test" {
+  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function describe(name: string, fn: () => void): void;
+  export function it(name: string, fn: () => void | Promise<void>): void;
+}
+
+declare module "node:assert/strict" {
+  interface Assert {
+    (value: unknown, message?: string): void;
+    equal(actual: unknown, expected: unknown, message?: string): void;
+    ok(value: unknown, message?: string): void;
+    match(value: string, regex: RegExp, message?: string): void;
+  }
+  const assert: Assert;
+  export default assert;
+}
+
+declare const process: {
+  readonly argv: string[];
+  exit(code: number): never;
+};
+
+declare const console: {
+  log(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+};
+
+declare const import_meta_url: string;

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -1,0 +1,119 @@
+// parse.ts — read a markdown file's `---` frontmatter block and bind it into the
+// typed shapes in types.ts. Zero-dep: a small reader for the YAML subset we author
+// (flat scalars, a `_fragments` list of `{_id, _trigger, _file}`, and `_assemble`
+// / `_produces` / `_reads` / `_contributes` lists). Not a general YAML parser.
+
+import type {
+  AssemblerFrontmatter,
+  FragmentFrontmatter,
+  FragmentRef,
+  PhaseFrontmatter,
+  Trigger,
+} from "./types.ts";
+import { readFileSync } from "node:fs";
+
+const PHASE_KEYS = new Set([
+  "_phase", "_title", "_requires_phase", "_init", "_input",
+  "_fragments", "_assemble", "_produces", "_advances_to",
+]);
+const FRAGMENT_KEYS = new Set(["_fragment", "_of_phase", "_contributes"]);
+const ASSEMBLER_KEYS = new Set(["_assemble", "_of_phase", "_reads", "_produces"]);
+
+/** Return the frontmatter block text (between the leading `---` fences), or null. */
+export function extractFrontmatter(path: string): string | null {
+  const text = readFileSync(path, "utf8");
+  if (!text.startsWith("---\n")) return null;
+  const end = text.indexOf("\n---", 4);
+  if (end === -1) return null;
+  return text.slice(4, end + 1);
+}
+
+/** Top-level `_`-keys appearing at column 0. */
+function topLevelKeys(fm: string): string[] {
+  const keys: string[] = [];
+  for (const line of fm.split("\n")) {
+    const m = /^(_[a-z_]+):/.exec(line);
+    if (m) keys.push(m[1]);
+  }
+  return keys;
+}
+
+function unknownAmong(fm: string, allowed: Set<string>): string[] {
+  return topLevelKeys(fm).filter((k) => !allowed.has(k));
+}
+
+function scalar(fm: string, key: string): string | null {
+  const m = new RegExp(`^${key}:\\s*(.+)$`, "m").exec(fm);
+  if (!m) return null;
+  return m[1].trim().replace(/^["']|["']$/g, "");
+}
+
+/** A block-list: `key:\n  - a\n  - b`. */
+function blockList(fm: string, key: string): string[] {
+  const re = new RegExp(`^${key}:\\s*\\n((?:\\s*-\\s*.+\\n?)+)`, "m");
+  const m = re.exec(fm);
+  if (!m) return [];
+  return m[1]
+    .split("\n")
+    .map((l) => l.replace(/^\s*-\s*/, "").trim())
+    .filter(Boolean);
+}
+
+function parseTrigger(raw: string): Trigger {
+  const t = raw.trim();
+  if (/_always\s*:\s*true/.test(t)) return { kind: "always" };
+  const g = /_glob\s*:\s*["']?([^"'}]+)["']?/.exec(t);
+  if (g) return { kind: "glob", pattern: g[1].trim() };
+  return { kind: "unknown", raw: t };
+}
+
+function parseFragments(fm: string): FragmentRef[] {
+  const out: FragmentRef[] = [];
+  // each entry: - _id: X ... _trigger: { ... } ... _file: Y
+  const re = /-\s*_id:\s*([\w-]+)[\s\S]*?_trigger:\s*\{([^}]*)\}[\s\S]*?_file:\s*([^\n]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(fm))) {
+    out.push({ id: m[1], trigger: parseTrigger(m[2]), file: m[3].trim() });
+  }
+  return out;
+}
+
+export function parsePhase(path: string, fm: string): PhaseFrontmatter {
+  const assembleBlock = /_assemble:\s*\n\s*_file:\s*([^\n]+)/.exec(fm);
+  return {
+    kind: "phase",
+    sourceFile: path,
+    phase: scalar(fm, "_phase") ?? "",
+    title: scalar(fm, "_title"),
+    requiresPhase: scalar(fm, "_requires_phase"),
+    init: /^_init:\s*true\s*$/m.test(fm),
+    fragments: parseFragments(fm),
+    assembleFile: assembleBlock ? assembleBlock[1].trim() : null,
+    produces: blockList(fm, "_produces"),
+    advancesTo: scalar(fm, "_advances_to"),
+    unknownKeys: unknownAmong(fm, PHASE_KEYS),
+  };
+}
+
+export function parseFragment(path: string, fm: string): FragmentFrontmatter {
+  return {
+    kind: "fragment",
+    sourceFile: path,
+    fragment: scalar(fm, "_fragment") ?? "",
+    ofPhase: scalar(fm, "_of_phase"),
+    contributes: blockList(fm, "_contributes"),
+    unknownKeys: unknownAmong(fm, FRAGMENT_KEYS),
+  };
+}
+
+export function parseAssembler(path: string, fm: string): AssemblerFrontmatter {
+  return {
+    kind: "assembler",
+    sourceFile: path,
+    assemble: scalar(fm, "_assemble"),
+    ofPhase: scalar(fm, "_of_phase"),
+    reads: blockList(fm, "_reads"),
+    produces: blockList(fm, "_produces"),
+    unknownKeys: unknownAmong(fm, ASSEMBLER_KEYS),
+  };
+}

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -1,0 +1,60 @@
+// types.ts — the minimal typed model of the heroku-to-aws phase frontmatter.
+//
+// This is the shape the parser binds raw frontmatter into, and what the checks
+// operate on. Kept intentionally small: only the keys the frontmatter uses today
+// (phase composition + fragment/assembler units). Mirrors INTERPRETER.md.
+
+/** A fragment's run condition (see INTERPRETER.md § _trigger forms). */
+export type Trigger =
+  | { kind: "always" }
+  | { kind: "glob"; pattern: string }
+  | { kind: "unknown"; raw: string }; // parsed but not a recognized form → a check flags it
+
+/** One entry in a phase's `_fragments` list. */
+export interface FragmentRef {
+  id: string;
+  trigger: Trigger;
+  file: string; // path relative to the skill's references/ root
+}
+
+/** The phase orchestrator file's frontmatter. */
+export interface PhaseFrontmatter {
+  kind: "phase";
+  sourceFile: string; // absolute path, for messages
+  phase: string; // _phase
+  title: string | null;
+  requiresPhase: string | null;
+  init: boolean; // _init
+  fragments: FragmentRef[];
+  assembleFile: string | null; // _assemble._file
+  produces: string[];
+  advancesTo: string | null;
+  unknownKeys: string[]; // top-level _keys not in the closed vocab
+}
+
+/** A fragment unit file's frontmatter. */
+export interface FragmentFrontmatter {
+  kind: "fragment";
+  sourceFile: string;
+  fragment: string; // _fragment (id)
+  ofPhase: string | null; // _of_phase
+  contributes: string[];
+  unknownKeys: string[];
+}
+
+/** The assembler unit file's frontmatter. */
+export interface AssemblerFrontmatter {
+  kind: "assembler";
+  sourceFile: string;
+  assemble: string | null; // _assemble (id)
+  ofPhase: string | null;
+  reads: string[];
+  produces: string[];
+  unknownKeys: string[];
+}
+
+/** A validation problem. */
+export interface Finding {
+  file: string; // path relative to skill root, for readable output
+  message: string;
+}

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/validate.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/validate.ts
@@ -1,0 +1,90 @@
+// validate.ts — orchestrator + CLI. Discovers the phase files of a skill, binds
+// their frontmatter (+ referenced fragments/assemblers) into the typed model, runs
+// the structural checks, reports, and exits non-zero on any finding.
+//
+// Usage: node validate.ts <skill-root>
+//   where <skill-root> contains references/phases/<name>/<name>.md
+//
+// Skill-agnostic: it knows the phase/fragment/assembler grammar, not any skill.
+
+import type { Finding } from "./types.ts";
+import { type BoundSkill, check } from "./check.ts";
+import {
+  extractFrontmatter,
+  parseAssembler,
+  parseFragment,
+  parsePhase,
+} from "./parse.ts";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/** Bind a skill root into the typed model (exported so tests can reuse it). */
+export function bindSkill(skillRoot: string): BoundSkill {
+  const referencesRoot = join(skillRoot, "references");
+  const phasesDir = join(referencesRoot, "phases");
+  const rel = (abs: string) => abs.replace(skillRoot + "/", "");
+
+  const phases: BoundSkill["phases"] = [];
+  const fragments: BoundSkill["fragments"] = new Map();
+  const assemblers: BoundSkill["assemblers"] = new Map();
+
+  if (!existsSync(phasesDir)) {
+    return { referencesRoot, phases, fragments, assemblers, rel };
+  }
+
+  const phaseNames = readdirSync(phasesDir).filter((d) =>
+    statSync(join(phasesDir, d)).isDirectory()
+  );
+
+  for (const name of phaseNames) {
+    const phaseFile = join(phasesDir, name, `${name}.md`);
+    if (!existsSync(phaseFile)) continue;
+    const fm = extractFrontmatter(phaseFile);
+    if (!fm) continue; // no frontmatter yet — skip (phase-by-phase rollout)
+    const phase = parsePhase(phaseFile, fm);
+    phases.push(phase);
+
+    // bind referenced fragments
+    for (const fr of phase.fragments) {
+      const fpath = join(referencesRoot, fr.file);
+      if (existsSync(fpath) && !fragments.has(fpath)) {
+        const ffm = extractFrontmatter(fpath);
+        if (ffm) fragments.set(fpath, parseFragment(fpath, ffm));
+      }
+    }
+    // bind the assembler
+    if (phase.assembleFile) {
+      const apath = join(referencesRoot, phase.assembleFile);
+      if (existsSync(apath) && !assemblers.has(apath)) {
+        const afm = extractFrontmatter(apath);
+        if (afm) assemblers.set(apath, parseAssembler(apath, afm));
+      }
+    }
+  }
+
+  return { referencesRoot, phases, fragments, assemblers, rel };
+}
+
+/** Validate a skill root; returns findings (empty = clean). Exported for tests. */
+export function validateSkill(skillRoot: string): Finding[] {
+  return check(bindSkill(resolve(skillRoot)));
+}
+
+// --- CLI ---
+// Run only when invoked directly (not when imported by the test).
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.endsWith("validate.ts")) {
+  const skillRoot = process.argv[2];
+  if (!skillRoot) {
+    console.error("usage: node validate.ts <skill-root>");
+    process.exit(2);
+  }
+  const findings = validateSkill(skillRoot);
+  if (findings.length) {
+    console.error(`frontmatter validation: ${findings.length} problem(s)`);
+    for (const f of findings) console.error(`  - ${f.file}: ${f.message}`);
+    process.exit(1);
+  }
+  const boundPhases = bindSkill(resolve(skillRoot)).phases.length;
+  console.log(`frontmatter validation: OK (${boundPhases} phase file(s) with frontmatter checked)`);
+}

--- a/migrate/plugins/migration-to-aws/tsconfig.json
+++ b/migrate/plugins/migration-to-aws/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2023",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": [
+    "tools/frontmatter-validator/**/*.ts",
+    "tests/tools/**/*.ts"
+  ]
+}

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ min_version = "2026.2.4"
 node = "24"
 "npm:markdownlint-cli2" = "0.17"
 "npm:dprint" = "0.51"
+"npm:typescript" = "5"
 "pipx:pre-commit" = "4"
 "pipx:bandit[sarif]" = "1"
 "pipx:checkov" = "3"
@@ -42,10 +43,25 @@ run = "markdownlint-cli2 '**/*.md' '#node_modules' '#.git'"
 description = "Lint Markdown files with auto-fix"
 run = "markdownlint-cli2 '**/*.md' '#node_modules' --fix"
 
+[tasks."lint:frontmatter"]
+description = "Validate phase/fragment/assembler frontmatter (typed, zero-dep; skill-agnostic)"
+run = "node migrate/plugins/migration-to-aws/tools/frontmatter-validator/validate.ts migrate/plugins/migration-to-aws/skills/heroku-to-aws"
+
+[tasks."lint:types"]
+description = "Type-check the frontmatter validator + its test (tsc --noEmit, strict)"
+run = "cd migrate/plugins/migration-to-aws && tsc --noEmit"
+
+[tasks.test]
+description = "Run the frontmatter-validator test suite (node --test)"
+run = "node --test migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts"
+
 [tasks.lint]
 description = "Run all linters"
 run = [
   { task = "lint:md" },
+  { task = "lint:types" },
+  { task = "lint:frontmatter" },
+  { task = "test" },
 ]
 
 # =========


### PR DESCRIPTION
## What

Introduces the **phase / fragment / assembler** structure on the discover phase as frontmatter, a minimal **`INTERPRETER.md`** contract for reading it, and a **typed, tested, skill-agnostic frontmatter validator that runs in CI**. Introduced phase-by-phase; phases without frontmatter run from their prose as before.

## Structure (discover — 4 real units)

- **`discover.md`** — phase frontmatter (`_phase`/`_title`/`_init`/`_input`/`_fragments`[terraform `_always`, billing `_glob`]/`_assemble`/`_produces`/`_advances_to`). Step 0 init + Step 3 assembly prose removed (relocated / interpreter-driven).
- **`discover-terraform.md`** / **`discover-billing.md`** — fragment frontmatter (`_fragment`/`_of_phase`/`_contributes`). Prose bodies unchanged.
- **`discover-assemble.md`** (NEW) — the assembler unit; sole creator of the inventory.

## Interpreter

- **`INTERPRETER.md`** (NEW) — every frontmatter key + how to act on it, the `_trigger` forms, fragment/assembler unit keys, and a full `_init` definition.
- **`_init` is load-bearing** — its procedure lives only in `INTERPRETER.md` (Step 0 prose removed): one source of truth. `SKILL.md` points at it.

## Validator — typed, tested, skill-agnostic, in CI

Lives at the **plugin root** (`tools/frontmatter-validator/`), *not* inside the skill — it's shared infrastructure run **against** skills, not part of any skill (and shouldn't ship in the packaged skill tree). It's **skill-agnostic**: it knows the phase/fragment/assembler grammar, derives the valid phase set from declared frontmatter (no hardcoded phase list), and works against any skill using this structure.

- **`tools/frontmatter-validator/*.ts`** — TypeScript: `types.ts` (minimal typed model), `parse.ts` (frontmatter → typed), `check.ts` (structural checks), `validate.ts` (orchestrator/CLI). **Zero runtime deps** (Node 24 type-stripping); type-checked by `tsc --noEmit` (`node-shims.d.ts` keeps it dep-free).
- **Checks:** `_file` refs resolve · closed `_`-vocabulary · fragment `_id` ↔ phase-ref match · `_of_phase` back-refs · `_trigger` well-formed · single-creator artifact ownership. References to phases without frontmatter yet are left *unverified* (tolerant of the phase-by-phase rollout).
- **`tests/tools/frontmatter-validator.test.ts`** (`node:test`, TypeScript — type-checked by `tsc` alongside the validator) — the **guard-on-the-guard**: ephemeral good/bad fixtures assert the validator accepts good frontmatter and **rejects** a bad `_file` ref, a typo'd key, an id mismatch, a bad `_trigger`, and a single-creator violation. The bad frontmatter lives **only as fixtures** — never in a real skill or git history. This is the value demo: CI proves it catches issues, with no bad edit committed anywhere.
- **mise:** `+ npm:typescript`; `lint:frontmatter` (typed validator), `lint:types` (`tsc`), `test` (`node --test`) — all wired into `lint` / `build`.

> **@awslabs/startups-admins:** adds `npm:typescript` + `lint:types` / `lint:frontmatter` / `test` tasks to `mise.toml` (admin-owned), wired into `build`.

## Validation

Full `mise build` green: `tsc` clean, validator OK on the real skill, **7/7 tests pass**. Plus three cold-agent runs of discover (fragment routing; `_init` fresh-create; existing-`.migration` resume) — zero divergence from prior behavior.


