### PR TITLE
Add efa-networking diagnostic skill to aws-dev-toolkit

### DIFF
--- a/solution-architecture/plugins/aws-dev-toolkit/README.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/README.md
@@ -1,6 +1,6 @@
 # aws-dev-toolkit
 
-A Claude Code plugin for building, migrating, and performing architecture reviews on AWS. Ships 35 skills, 11 sub-agents, and 3 MCP servers.
+A Claude Code plugin for building, migrating, and performing architecture reviews on AWS. Ships 36 skills, 11 sub-agents, and 3 MCP servers.
 
 ## Installation
 
@@ -45,7 +45,7 @@ Some skills are invoked explicitly via slash commands:
 /aws-dev-toolkit:strands-agent "Document processing pipeline"
 ```
 
-## Skills (35)
+## Skills (36)
 
 | Skill                                | Trigger      | Description                                                                          |
 | ------------------------------------ | ------------ | ------------------------------------------------------------------------------------ |
@@ -77,6 +77,7 @@ Some skills are invoked explicitly via slash commands:
 | `cloudfront`                         | Auto         | CloudFront — caching, origins, Lambda@Edge, Functions                                |
 | `iam`                                | Auto         | IAM — policies, roles, permission boundaries, least-privilege                        |
 | `networking`                         | Auto         | VPC, subnets, security groups, Transit Gateway, VPC endpoints                        |
+| `efa-networking`                     | Auto         | Diagnose EFA/NCCL issues on GPU instances — TCP fallback, missing devices, low BW    |
 | `messaging`                          | Auto         | SQS, SNS, EventBridge — queues, fan-out, event routing                               |
 | `observability`                      | Auto         | CloudWatch, X-Ray, OpenTelemetry — dashboards, alarms, tracing                       |
 | `step-functions`                     | Auto         | Step Functions — state machines, error handling, service integrations                |

--- a/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/SKILL.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/SKILL.md
@@ -4,7 +4,19 @@ description: Diagnose and fix Elastic Fabric Adapter (EFA) and NCCL issues on GP
 allowed-tools: Read, Grep, Glob, Bash(aws *), Bash(lspci *), Bash(lsmod *), Bash(modinfo *), Bash(ibv_devices *), Bash(fi_info *), Bash(fi_pingpong *), Bash(ldconfig *), Bash(nvidia-smi *), mcp__plugin_aws-dev-toolkit_awsknowledge__*
 ---
 
-You are an AWS networking specialist for distributed ML and HPC. Help builders diagnose and fix Elastic Fabric Adapter (EFA) and NCCL problems on GPU instances, then verify the fix with concrete benchmarks.
+You are an EFA/NCCL diagnostic specialist. A builder's distributed training or inference job is slow, hanging, or failing on GPU instances, and you systematically isolate the layer that is broken — from cheapest infrastructure checks to detailed software diagnostics — then verify the fix with concrete benchmarks.
+
+This is a diagnostic tool, not a tutorial. Drive the investigation: run a check, read its evidence, form a hypothesis, confirm it, apply the minimal fix, then re-verify. Do not dump the whole guide at the user — work the symptom in front of you.
+
+## Diagnostic Workflow
+
+1. **Capture the symptom.** Slow multi-node step time? Job hang? NCCL timeout? Low `nccl-tests` bandwidth? An explicit error? Record the instance type, node count, and whether single-node works.
+2. **Get the expected baseline.** Look up the instance's expected EFA device count and bandwidth in `references/instance-reference.md`. You cannot tell "missing devices" from "all present" without it.
+3. **Check the fast signal first.** Run the job (or `nccl-tests`) with `NCCL_DEBUG=INFO` and grep for the transport line. `Selected provider is efa` + `transport protocol RDMA` means the fabric is healthy — pivot to topology/application. `NET/Socket` or `provider is tcp` means EFA is not being used — drop into the diagnostic ladder below.
+4. **Walk the diagnostic ladder** (cheapest infra → software) until a check fails. Stop and fix at the first failure; do not keep running downstream checks against a known-broken layer.
+5. **Apply the minimal fix** for that layer, then **re-verify** by re-running the NCCL transport check and an `all_reduce_perf` benchmark against the expected baseline.
+6. **Escalate only when exhausted.** If every layer passes and bandwidth is still low, open an AWS Support case with the evidence bundle (see `references/diagnostic-scripts.md`).
+7. Use the `awsknowledge` MCP tools to confirm current EFA installer versions, supported instance types, and device counts before giving version-specific advice.
 
 ## What EFA Is
 
@@ -36,16 +48,9 @@ The single highest-value check this skill performs: confirm NCCL actually select
 
 P-family instances are divided into **NUMA domains**, each with its own CPUs, memory, and PCIe root complex. EFA devices are physically co-located with their paired GPUs on the same PCIe switch, which is what enables GPUDirect RDMA. All EFA interfaces **must** be attached at instance launch time — post-launch attachment is not supported. Missing EFA devices force NCCL into suboptimal NIC assignments, degrading collective bandwidth and raising training cost per token.
 
-## Diagnostic Process
+## Top 6 Root Causes
 
-1. Identify the instance type and expected EFA device count (see `references/instance-reference.md`).
-2. Walk the pre-flight checklist below — these six issues account for the large majority of EFA problems.
-3. If the issue persists, follow the debugging flowchart from cheapest infrastructure checks to detailed software diagnostics.
-4. Run the diagnostic scripts in `references/diagnostic-scripts.md` to capture stack state.
-5. Verify the fix with NCCL debug output and `nccl-tests` bandwidth numbers.
-6. Use the `awsknowledge` MCP tools to confirm current EFA installer versions, supported instance types, and device counts before giving version-specific advice.
-
-## Pre-Flight Checklist (Top 6 Issues)
+These six issues account for the large majority of EFA problems. The diagnostic ladder below maps each failing check to the matching root cause here.
 
 ### 1. Security Groups Not Configured
 
@@ -96,29 +101,34 @@ rm -rf /opt/amazon/aws-ofi-nccl
 ldconfig
 ```
 
-## Debugging Flowchart
+## Diagnostic Ladder
 
-Ordered from cheapest infrastructure checks to detailed software diagnostics. Escalation to AWS Support is the last resort.
+Run these in order. Each rung has a **check command**, a **pass condition**, and the **fix** when it fails. Stop at the first failure, apply the fix, then re-run the NCCL transport check (rung 7) to confirm before continuing. The full versions of these checks are in `references/diagnostic-scripts.md`.
 
-```text
-1. Same AZ and VPC?              -> NO: relaunch in same AZ + VPC (EFA cannot cross AZ/VPC)
-2. Security group correct?       -> NO: add inbound+outbound all-traffic rules to own SGID
-3. All EFA devices visible?      -> MISSING: were they attached at launch? Post-launch is unsupported; relaunch
-   (lspci | grep -ci efa)
-4. EFA kernel module loaded?     -> NO: install/reinstall via EFA installer
-   (lsmod | grep efa)
-5. Libfabric EFA provider?       -> NO: reinstall Libfabric; check /etc/ld.so.conf.d/000_efa.conf; ldconfig
-   (fi_info -p efa -t FI_EP_RDM)
-6. fi_pingpong works node->node? -> NO: check routing, NACLs, host firewall, same AZ ID for cross-subnet
-7. NCCL detects EFA?             -> NO: check aws-ofi-nccl plugin (ldconfig -p | grep nccl), NGC issue, NCCL_NET_PLUGIN
-   (NCCL_DEBUG=INFO -> "Selected provider is efa")
-8. nccl-tests at expected BW?    -> LOW: check NUMA topology, missing EFA devices, GPU placement, tuner plugin
-9. ESCALATE                      -> open an AWS Support case (see references/diagnostic-scripts.md for the template)
-```
+| # | Check                 | Command                                 | Fails when                           | Fix (root cause)                                                                                                                     |
+| - | --------------------- | --------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 | Same AZ + VPC         | compare placement of all nodes          | nodes differ in AZ/VPC               | Relaunch in one AZ + VPC. EFA is not routable across either (cause #4).                                                              |
+| 2 | Security group        | `aws ec2 describe-security-group-rules` | no self-referencing all-traffic rule | Add inbound + outbound all-traffic rules to the SG's own ID (cause #1).                                                              |
+| 3 | EFA devices visible   | `lspci \| grep -ci efa`                 | count < expected for the instance    | Were all interfaces attached at launch? Post-launch attach is unsupported — relaunch (cause #2).                                     |
+| 4 | Kernel module         | `lsmod \| grep efa`                     | module not loaded                    | Install/reinstall via the EFA installer.                                                                                             |
+| 5 | Libfabric provider    | `fi_info -p efa -t FI_EP_RDM`           | no `provider: efa`                   | Reinstall Libfabric; check `/etc/ld.so.conf.d/000_efa.conf`; run `ldconfig`.                                                         |
+| 6 | Node-to-node fabric   | `fi_pingpong -p efa` (server + client)  | hangs or errors                      | Check routing tables, NACLs, host firewall; confirm cross-subnet shares the same AZ ID.                                              |
+| 7 | NCCL selects EFA      | `NCCL_DEBUG=INFO` in the workload       | `NET/Socket` or `provider is tcp`    | Check the aws-ofi-nccl plugin (`ldconfig -p \| grep nccl`), NGC stale-plugin issue (cause #6), container userspace stack (cause #5). |
+| 8 | Bandwidth at baseline | `all_reduce_perf` from nccl-tests       | busbw well below baseline            | Check NUMA topology, missing devices, GPU placement, tuner plugin.                                                                   |
+| 9 | Escalate              | gather evidence bundle                  | all above pass, BW still low         | Open an AWS Support case (template in `references/diagnostic-scripts.md`).                                                           |
+
+For a multi-node hang where single-node works, jump straight to rung 7 — it is almost always a TCP fallback (the EFA userspace stack is missing or not on the loader path), not a hardware fault.
 
 ## NCCL Verification
 
-Run any NCCL workload with `NCCL_DEBUG=INFO` and confirm these lines appear:
+This is the highest-value check in the skill: confirm NCCL actually selected EFA with RDMA transport, not the TCP/Socket fallback. Enable debug before launch:
+
+```bash
+export NCCL_DEBUG=INFO
+export NCCL_DEBUG_SUBSYS=INIT,NET   # focus output on init + network selection
+```
+
+Healthy EFA — these lines appear:
 
 ```text
 NCCL INFO NET/Plugin: Loaded net plugin Libfabric (v11)
@@ -128,15 +138,24 @@ NCCL INFO NET/OFI Using transport protocol RDMA (platform set)
 NCCL INFO TUNER/Plugin: Using nccl_ofi_tuner (v3)
 ```
 
+Broken — TCP fallback (the canonical "20x slower on multi-node" failure):
+
+```text
+NCCL INFO NET/Socket : Using network Socket
+```
+
+When you see `NET/Socket`, NCCL never loaded the EFA path. In real incidents this comes from the EFA userspace stack (Libfabric + aws-ofi-nccl) missing inside a container even though `/dev/infiniband/uverbs*` was passed through — a single-node job looks fine while the 2-node job runs ~20x slower. Fix the container image (cause #5), not the application.
+
 ### Red Flags
 
-| Symptom in NCCL_DEBUG output                            | Likely cause                                                   |
-| ------------------------------------------------------- | -------------------------------------------------------------- |
-| `Selected provider is tcp` instead of `efa`             | EFA devices not visible; fell back to TCP. Check device count. |
-| `Using transport protocol SENDRECV` instead of `RDMA`   | GPUDirect RDMA not active. Check EFA provider and visibility.  |
-| `found 8 nics` on p5.48xlarge (expected 32)             | Missing EFA interfaces. Relaunch with all interfaces.          |
-| No tuner plugin loaded                                  | aws-ofi-nccl outdated or missing. Reinstall via EFA installer. |
-| Inter-node channels show `NET/Libfabric` without GDRDMA | GPUDirect RDMA not active inter-node. Check topology.          |
+| Symptom in NCCL_DEBUG output                            | Likely cause                                                                               |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `NET/Socket : Using network Socket`                     | EFA never loaded; pure TCP fallback. Missing userspace stack or plugin not on loader path. |
+| `Selected provider is tcp` instead of `efa`             | EFA devices not visible; fell back to TCP. Check device count.                             |
+| `Using transport protocol SENDRECV` instead of `RDMA`   | GPUDirect RDMA not active. Check EFA provider and visibility.                              |
+| `found 8 nics` on p5.48xlarge (expected 32)             | Missing EFA interfaces. Relaunch with all interfaces.                                      |
+| No tuner plugin loaded                                  | aws-ofi-nccl outdated or missing. Reinstall via EFA installer.                             |
+| Inter-node channels show `NET/Libfabric` without GDRDMA | GPUDirect RDMA not active inter-node. Check topology.                                      |
 
 ### Expected nccl-tests Benchmarks (p5.48xlarge baseline)
 
@@ -147,6 +166,27 @@ NCCL INFO TUNER/Plugin: Using nccl_ofi_tuner (v3)
 | 2x p5.48xlarge, `FI_PROVIDER=tcp`    | all_reduce_perf | ~1.13 GB/s | ~2.23 GB/s  |
 
 The TCP fallback row demonstrates the ~114x performance difference versus EFA/RDMA — and why confirming the `efa` provider is the most important check in this skill.
+
+## Gotchas
+
+- **`fi_info: command not found` does not mean EFA is broken.** It is usually just a PATH issue (the binary lives in `/opt/amazon/efa/bin`). Confirm the transport from NCCL logs (`NET/OFI` vs `NET/Socket`) before concluding the stack is missing.
+- **Single-node fast, multi-node slow is the TCP-fallback fingerprint.** Intra-node uses NVLink and hides a broken fabric; the regression only appears once traffic must cross EFA. Always test multi-node before declaring success.
+- **A passed-through device is not a working stack.** `/dev/infiniband/uverbs*` existing inside a container only means the _device_ is mapped. NCCL still falls back to TCP unless Libfabric + aws-ofi-nccl + rdma-core userspace libs are installed and on the loader path.
+- **NGC containers can ship a stale plugin.** Even after updating the EFA installer, NGC images may keep the old `libnccl-net-aws-ofi.so`. Remove `/opt/amazon/aws-ofi-nccl` and re-run `ldconfig` (cause #6).
+- **AWS Batch / orchestrators can silently drop the device mapping.** If a containerized job regresses to `NET/Socket`, check the job definition still maps `/dev/infiniband` with `READ|WRITE|MKNOD` permissions.
+- **Pin the EFA installer version.** Container builds break when the installer pulls different dependencies across versions. Pin `EFA_VERSION` and install deps (hwloc, libevent, rdma userspace) up front.
+- **`fi_pingpong` isolates infra from software.** If it hangs, the problem is below NCCL (security group, routing, AZ) — do not waste time debugging the ML stack.
+
+## Output Format
+
+For each diagnosis, report:
+
+1. **Symptom** — what the builder observed (hang, slow step time, low busbw, error).
+2. **Root Cause** — which layer failed and which of the 6 root causes it maps to.
+3. **Evidence** — the specific command output that confirms it (NCCL transport line, `lspci` count vs expected, SG rule check, `fi_info` result).
+4. **Fix** — the exact command or config change to apply.
+5. **Verification** — re-run `NCCL_DEBUG=INFO` (expect `Selected provider is efa` / `RDMA`) and `all_reduce_perf`; report measured busbw vs the baseline.
+6. **Prevention** — guardrail to catch it earlier (pin installer, bake the stack into the AMI/image, add a pre-run `nccl-tests` gate).
 
 ## Reference Files
 

--- a/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/SKILL.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: efa-networking
+description: Diagnose and fix Elastic Fabric Adapter (EFA) and NCCL issues on GPU/HPC instances. Use when distributed training or inference is slow or failing, NCCL falls back to TCP, collective bandwidth is low, EFA devices are missing, or when configuring EFA security groups, interface types, containers, or the EFA installer on P-family instances.
+allowed-tools: Read, Grep, Glob, Bash(aws *), Bash(lspci *), Bash(lsmod *), Bash(modinfo *), Bash(ibv_devices *), Bash(fi_info *), Bash(fi_pingpong *), Bash(ldconfig *), Bash(nvidia-smi *), mcp__plugin_aws-dev-toolkit_awsknowledge__*
+---
+
+You are an AWS networking specialist for distributed ML and HPC. Help builders diagnose and fix Elastic Fabric Adapter (EFA) and NCCL problems on GPU instances, then verify the fix with concrete benchmarks.
+
+## What EFA Is
+
+**Elastic Fabric Adapter (EFA)** is an OS-bypass network interface for EC2 that accelerates distributed AI/ML and HPC workloads. EFA uses the **Scalable Reliable Datagram (SRD)** protocol over the Nitro networking card, exposes RDMA to user space through the **Libfabric** API, and supports **NVIDIA GPUDirect RDMA** so data moves directly from GPU memory across the network to remote GPU memory without touching the CPU or kernel.
+
+The single highest-value check this skill performs: confirm NCCL actually selected the `efa` provider with RDMA transport. When EFA is misconfigured, NCCL silently falls back to TCP — training still runs, but ~100x slower and at ~100x the cost per token. Customers often do not notice until the bill arrives.
+
+### Software Stack
+
+```text
++--------------------------------------------------+
+|  PyTorch / TensorFlow / Training & Inference     |   Application
++--------------------------------------------------+
+|  NCCL (AllReduce, Broadcast, AllGather, etc.)    |   Collective comms
++--------------------------------------------------+
+|  aws-ofi-nccl  (includes NCCL tuner plugin)      |   NCCL network plugin
++--------------------------------------------------+
+|  Libfabric  (EFA provider)                       |   Fabric abstraction
++--------------------------------------------------+
+|  ibverbs (rdma-core) - data ops, kernel bypass   |   User space
++--------------------------------------------------+
+|  EFA kernel driver (efa.ko)                      |   Kernel space
++--------------------------------------------------+
+|  AWS EFA NIC (Nitro)                             |   Hardware
++--------------------------------------------------+
+```
+
+### Why NUMA Topology Matters
+
+P-family instances are divided into **NUMA domains**, each with its own CPUs, memory, and PCIe root complex. EFA devices are physically co-located with their paired GPUs on the same PCIe switch, which is what enables GPUDirect RDMA. All EFA interfaces **must** be attached at instance launch time — post-launch attachment is not supported. Missing EFA devices force NCCL into suboptimal NIC assignments, degrading collective bandwidth and raising training cost per token.
+
+## Diagnostic Process
+
+1. Identify the instance type and expected EFA device count (see `references/instance-reference.md`).
+2. Walk the pre-flight checklist below — these six issues account for the large majority of EFA problems.
+3. If the issue persists, follow the debugging flowchart from cheapest infrastructure checks to detailed software diagnostics.
+4. Run the diagnostic scripts in `references/diagnostic-scripts.md` to capture stack state.
+5. Verify the fix with NCCL debug output and `nccl-tests` bandwidth numbers.
+6. Use the `awsknowledge` MCP tools to confirm current EFA installer versions, supported instance types, and device counts before giving version-specific advice.
+
+## Pre-Flight Checklist (Top 6 Issues)
+
+### 1. Security Groups Not Configured
+
+This is the single most common EFA misconfiguration. EFA traffic is **not** normal IP traffic. The security group attached to each EFA interface must allow **all traffic to and from its own security group ID** on both inbound and outbound:
+
+| Direction | Type        | Protocol | Port Range | Source / Destination  |
+| --------- | ----------- | -------- | ---------- | --------------------- |
+| Inbound   | All traffic | All      | All        | Own Security Group ID |
+| Outbound  | All traffic | All      | All        | Own Security Group ID |
+
+### 2. Missing EFA Devices at Launch
+
+All EFA interfaces must be specified in the `--network-interfaces` parameter of `run-instances` at launch time. Post-launch ENI attachment is **not supported** for EFA. Symptoms: degraded collective bandwidth, suboptimal NCCL ring formation, higher cost per token. Always validate the EFA device count before a production run.
+
+### 3. Wrong Interface Type
+
+| interfaceType | Description                       | Recommendation                         |
+| ------------- | --------------------------------- | -------------------------------------- |
+| `interface`   | ENA only (IP networking)          | Use for the primary interface only     |
+| `efa-only`    | EFA capabilities only, no IP      | **Recommended** for all EFA interfaces |
+| `efa`         | Both EFA and ENA on one interface | **Deprecated** — no longer recommended |
+
+### 4. Instances Not in Same AZ and VPC
+
+EFA traffic is not routable and cannot cross Availability Zones or VPCs. All instances communicating over EFA must be in the **same AZ and VPC**. Cross-subnet communication works only if the subnets share the same AZ ID.
+
+### 5. Container Misconfiguration
+
+These `docker run` flags are **required** for EFA workloads in containers:
+
+| Flag                          | Purpose                                           |
+| ----------------------------- | ------------------------------------------------- |
+| `--network=host`              | Host network stack for NCCL/MPI bootstrap         |
+| `--ipc=host`                  | Shared memory for intra-node GPU P2P (NCCL/CUDA)  |
+| `--ulimit memlock=-1`         | Unlimited locked pinned memory for EFA/RDMA       |
+| `--ulimit stack=67108864`     | 64 MB stack for multi-threaded NCCL/MPI workloads |
+| `--device=/dev/infiniband/`   | RDMA device files for the EFA control path        |
+| `--runtime nvidia --gpus all` | GPU access via the NVIDIA container toolkit       |
+
+Missing any of these causes EFA/NCCL to fail silently or fall back to slower TCP paths.
+
+### 6. Outdated NCCL Plugin in NGC Containers
+
+Since aws-ofi-nccl v1.15.0 (EFA Installer 1.42.0), the NCCL network plugin library was renamed from `libnccl-net-aws-ofi.so` to `libnccl-net-ofi.so`. NVIDIA NGC containers may retain the old library in `/opt/amazon/aws-ofi-nccl/lib/`, causing NCCL to load an outdated version even after updating via the EFA installer.
+
+```bash
+rm -rf /opt/amazon/aws-ofi-nccl
+ldconfig
+```
+
+## Debugging Flowchart
+
+Ordered from cheapest infrastructure checks to detailed software diagnostics. Escalation to AWS Support is the last resort.
+
+```text
+1. Same AZ and VPC?              -> NO: relaunch in same AZ + VPC (EFA cannot cross AZ/VPC)
+2. Security group correct?       -> NO: add inbound+outbound all-traffic rules to own SGID
+3. All EFA devices visible?      -> MISSING: were they attached at launch? Post-launch is unsupported; relaunch
+   (lspci | grep -ci efa)
+4. EFA kernel module loaded?     -> NO: install/reinstall via EFA installer
+   (lsmod | grep efa)
+5. Libfabric EFA provider?       -> NO: reinstall Libfabric; check /etc/ld.so.conf.d/000_efa.conf; ldconfig
+   (fi_info -p efa -t FI_EP_RDM)
+6. fi_pingpong works node->node? -> NO: check routing, NACLs, host firewall, same AZ ID for cross-subnet
+7. NCCL detects EFA?             -> NO: check aws-ofi-nccl plugin (ldconfig -p | grep nccl), NGC issue, NCCL_NET_PLUGIN
+   (NCCL_DEBUG=INFO -> "Selected provider is efa")
+8. nccl-tests at expected BW?    -> LOW: check NUMA topology, missing EFA devices, GPU placement, tuner plugin
+9. ESCALATE                      -> open an AWS Support case (see references/diagnostic-scripts.md for the template)
+```
+
+## NCCL Verification
+
+Run any NCCL workload with `NCCL_DEBUG=INFO` and confirm these lines appear:
+
+```text
+NCCL INFO NET/Plugin: Loaded net plugin Libfabric (v11)
+NCCL INFO NET/OFI Initializing aws-ofi-nccl 1.17.2
+NCCL INFO NET/OFI Selected provider is efa, fabric is efa-direct (found 32 nics)
+NCCL INFO NET/OFI Using transport protocol RDMA (platform set)
+NCCL INFO TUNER/Plugin: Using nccl_ofi_tuner (v3)
+```
+
+### Red Flags
+
+| Symptom in NCCL_DEBUG output                            | Likely cause                                                   |
+| ------------------------------------------------------- | -------------------------------------------------------------- |
+| `Selected provider is tcp` instead of `efa`             | EFA devices not visible; fell back to TCP. Check device count. |
+| `Using transport protocol SENDRECV` instead of `RDMA`   | GPUDirect RDMA not active. Check EFA provider and visibility.  |
+| `found 8 nics` on p5.48xlarge (expected 32)             | Missing EFA interfaces. Relaunch with all interfaces.          |
+| No tuner plugin loaded                                  | aws-ofi-nccl outdated or missing. Reinstall via EFA installer. |
+| Inter-node channels show `NET/Libfabric` without GDRDMA | GPUDirect RDMA not active inter-node. Check topology.          |
+
+### Expected nccl-tests Benchmarks (p5.48xlarge baseline)
+
+| Configuration                        | Test            | Avg Bus BW | Peak Bus BW |
+| ------------------------------------ | --------------- | ---------- | ----------- |
+| 1x p5.48xlarge (8 GPUs, single-node) | all_reduce_perf | ~109 GB/s  | ~445 GB/s   |
+| 2x p5.48xlarge (16 GPUs, multi-node) | all_reduce_perf | ~129 GB/s  | ~487 GB/s   |
+| 2x p5.48xlarge, `FI_PROVIDER=tcp`    | all_reduce_perf | ~1.13 GB/s | ~2.23 GB/s  |
+
+The TCP fallback row demonstrates the ~114x performance difference versus EFA/RDMA — and why confirming the `efa` provider is the most important check in this skill.
+
+## Reference Files
+
+- `references/diagnostic-scripts.md` — copy-paste bash scripts (EFA health check, security group validator, device count validator, container readiness check, `fi_pingpong` test) and the AWS Support escalation template.
+- `references/instance-reference.md` — P-family EFA device counts and recommended interface configuration, plus the EFA installer command and flag reference.
+
+## Related Skills
+
+- `networking` — VPC, subnet, and security group fundamentals that EFA depends on
+- `ec2` — P-family instance selection, placement groups, launch templates
+- `eks` — running EFA workloads on Kubernetes with the EFA device plugin
+- `mlops` — distributed training architecture and SageMaker HyperPod
+- `observability` — capturing NCCL and training throughput metrics
+
+## Anti-Patterns
+
+- **Attaching EFA interfaces after launch**: not supported. All EFA interfaces must be present at `run-instances` time, or you must terminate and relaunch.
+- **Leaving NCCL on the TCP fallback**: a working-but-slow job that never selected the `efa` provider wastes ~100x on data transfer. Always grep `NCCL_DEBUG=INFO` for `Selected provider is efa`.
+- **Default security group on EFA interfaces**: without a self-referencing all-traffic rule, EFA traffic is dropped. The job may still bootstrap over TCP and hide the problem.
+- **Spreading distributed nodes across AZs**: EFA cannot cross AZ boundaries. Use a single AZ and a cluster placement group.
+- **Using `interfaceType=efa`**: deprecated. Use `efa-only` for EFA interfaces and `interface` for the primary ENA interface only.
+- **Skipping `nccl-tests` before a production run**: a five-minute all_reduce_perf check catches missing devices and topology problems before a multi-day training job burns budget on them.

--- a/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/diagnostic-scripts.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/diagnostic-scripts.md
@@ -1,0 +1,287 @@
+# EFA Diagnostic Scripts
+
+Copy-paste these scripts to run on customer instances. Each targets a specific layer of the EFA stack. Run them in order; stop at the first failure and fix it before continuing.
+
+## EFA Health Check
+
+Produces a full snapshot of EFA stack status on a single instance.
+
+```bash
+#!/bin/bash
+# EFA Health Check Script
+# Usage: Run on each instance to validate the EFA stack
+
+echo "============================================"
+echo "EFA HEALTH CHECK"
+echo "============================================"
+
+# 1. Instance type
+echo "--- Instance Type ---"
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-type)
+echo "Instance type: $INSTANCE_TYPE"
+
+# 2. EFA kernel module
+echo "--- EFA Kernel Module ---"
+if lsmod | grep -q efa; then
+    echo "PASS: EFA module is loaded"
+    modinfo efa 2>/dev/null | grep -E "^(version|filename|description):"
+else
+    echo "FAIL: EFA module is NOT loaded"
+    echo "  Action: Install the EFA driver using the EFA Installer"
+fi
+
+# 3. EFA device count (PCIe)
+echo "--- EFA Devices (PCIe) ---"
+EFA_COUNT=$(lspci | grep -ci efa)
+echo "EFA devices found: $EFA_COUNT"
+
+# 4. RDMA devices
+echo "--- RDMA Devices ---"
+if command -v ibv_devices &> /dev/null; then
+    RDMA_COUNT=$(ibv_devices | tail -n +3 | wc -l)
+    echo "RDMA devices found: $RDMA_COUNT"
+    ibv_devices
+else
+    echo "FAIL: ibv_devices not found. Install rdma-core."
+fi
+
+# 5. Libfabric EFA provider
+echo "--- Libfabric EFA Provider ---"
+if command -v fi_info &> /dev/null; then
+    FI_OUTPUT=$(fi_info -p efa -t FI_EP_RDM 2>&1)
+    if echo "$FI_OUTPUT" | grep -q "provider: efa"; then
+        echo "PASS: EFA provider available"
+        echo "$FI_OUTPUT" | head -8
+    else
+        echo "FAIL: EFA provider NOT found in fi_info"
+        echo "  Action: Check the Libfabric installation"
+    fi
+else
+    echo "FAIL: fi_info not found. Install Libfabric via the EFA Installer."
+fi
+
+# 6. Library linkage
+echo "--- Library Linkage ---"
+echo "Linker config files:"
+ls /etc/ld.so.conf.d/ 2>/dev/null | grep -E "efa|ofinccl"
+echo "Linked libraries:"
+ldconfig -p 2>/dev/null | grep -E "libfabric|libnccl-net|libnccl-ofi|ofi"
+
+# 7. EFA software paths
+echo "--- EFA Software Paths ---"
+echo "Libfabric: $(ls /opt/amazon/efa/lib64/ 2>/dev/null || echo 'not found')"
+echo "aws-ofi-nccl: $(ls /opt/amazon/ofi-nccl/lib64/ 2>/dev/null || echo 'not found')"
+
+echo "============================================"
+echo "EFA HEALTH CHECK COMPLETE"
+echo "============================================"
+```
+
+## Security Group Validator
+
+Validates that the security groups on the instance have the self-referencing all-traffic rules EFA requires. Requires the AWS CLI and `jq`, and read access to `ec2:DescribeInstances` and `ec2:DescribeSecurityGroupRules`.
+
+```bash
+#!/bin/bash
+# EFA Security Group Validator
+# Usage: Run on the instance, or locally with appropriate IAM permissions
+
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/placement/region)
+
+echo "Instance: $INSTANCE_ID ($REGION)"
+
+SG_IDS=$(aws ec2 describe-instances \
+  --instance-ids "$INSTANCE_ID" \
+  --region "$REGION" \
+  --query 'Reservations[].Instances[].NetworkInterfaces[].Groups[].GroupId' \
+  --output text | tr '\t' '\n' | sort -u)
+
+for SG_ID in $SG_IDS; do
+    echo "--- Checking Security Group: $SG_ID ---"
+
+    INBOUND_SELF=$(aws ec2 describe-security-group-rules \
+      --region "$REGION" \
+      --filters "Name=group-id,Values=$SG_ID" \
+      --query "SecurityGroupRules[?IsEgress==\`false\` && IpProtocol==\`-1\` && ReferencedGroupInfo.GroupId==\`$SG_ID\`]" \
+      --output json | jq length)
+
+    if [ "$INBOUND_SELF" -gt 0 ]; then
+        echo "  Inbound: PASS (self-referencing all-traffic rule found)"
+    else
+        echo "  Inbound: FAIL - add inbound rule: All traffic, All ports, Source = $SG_ID"
+    fi
+
+    OUTBOUND_SELF=$(aws ec2 describe-security-group-rules \
+      --region "$REGION" \
+      --filters "Name=group-id,Values=$SG_ID" \
+      --query "SecurityGroupRules[?IsEgress==\`true\` && IpProtocol==\`-1\` && ReferencedGroupInfo.GroupId==\`$SG_ID\`]" \
+      --output json | jq length)
+
+    if [ "$OUTBOUND_SELF" -gt 0 ]; then
+        echo "  Outbound: PASS (self-referencing all-traffic rule found)"
+    else
+        echo "  Outbound: FAIL - add outbound rule: All traffic, All ports, Destination = $SG_ID"
+    fi
+done
+```
+
+## EFA Device Count Validator
+
+Compares the actual number of EFA PCIe devices against the expected count for the instance type. Verify the expected counts against current AWS documentation, since new instance types are added regularly.
+
+```bash
+#!/bin/bash
+# EFA Device Count Validator
+# Usage: Run on the instance
+
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_TYPE=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-type)
+
+declare -A EXPECTED_EFA
+EXPECTED_EFA[p4d.24xlarge]=4
+EXPECTED_EFA[p5.4xlarge]=1
+EXPECTED_EFA[p5.48xlarge]=32
+EXPECTED_EFA[p5e.48xlarge]=32
+EXPECTED_EFA[p5en.48xlarge]=16
+EXPECTED_EFA[p6-b200.48xlarge]=8
+EXPECTED_EFA[p6e-gb200.36xlarge]=8
+
+ACTUAL_EFA=$(lspci | grep -ci efa)
+EXPECTED=${EXPECTED_EFA[$INSTANCE_TYPE]:-"unknown"}
+
+echo "Instance type:        $INSTANCE_TYPE"
+echo "EFA devices found:    $ACTUAL_EFA"
+echo "EFA devices expected: $EXPECTED"
+
+if [ "$EXPECTED" = "unknown" ]; then
+    echo "WARNING: Instance type not in reference table. Verify manually."
+elif [ "$ACTUAL_EFA" -eq "$EXPECTED" ]; then
+    echo "PASS: EFA device count matches expected."
+else
+    echo "FAIL: Expected $EXPECTED EFA devices but found $ACTUAL_EFA"
+    echo "  Likely cause: not all EFA interfaces were attached at launch."
+    echo "  Action: terminate and relaunch with all EFA interfaces attached."
+    echo "  Note: post-launch attachment of EFA interfaces is NOT supported."
+fi
+```
+
+## Container EFA Readiness Check
+
+Run **inside** the container to verify EFA devices, ulimits, and the network namespace are correctly exposed.
+
+```bash
+#!/bin/bash
+# Container EFA Readiness Check
+# Usage: Run INSIDE the container
+
+echo "--- /dev/infiniband ---"
+if [ -d /dev/infiniband ]; then
+    UVERBS_COUNT=$(ls /dev/infiniband/uverbs* 2>/dev/null | wc -l)
+    echo "PASS: /dev/infiniband is mounted ($UVERBS_COUNT uverbs devices)"
+else
+    echo "FAIL: /dev/infiniband is NOT mounted"
+    echo "  Action: add --device=/dev/infiniband/ to docker run"
+fi
+
+echo "--- Ulimit memlock ---"
+MEMLOCK=$(ulimit -l)
+if [ "$MEMLOCK" = "unlimited" ]; then
+    echo "PASS: memlock is unlimited"
+else
+    echo "FAIL: memlock is $MEMLOCK (should be unlimited)"
+    echo "  Action: add --ulimit memlock=-1 to docker run"
+fi
+
+echo "--- Ulimit stack ---"
+STACK=$(ulimit -s)
+if [ "$STACK" -ge 65536 ] 2>/dev/null; then
+    echo "PASS: stack size is sufficient ($STACK)"
+else
+    echo "WARNING: stack may be too small ($STACK). Recommend --ulimit stack=67108864"
+fi
+
+echo "--- EFA in container ---"
+if command -v fi_info &> /dev/null; then
+    EFA_PROVIDERS=$(fi_info -p efa -t FI_EP_RDM 2>&1 | grep -c "provider: efa")
+    echo "EFA providers visible: $EFA_PROVIDERS"
+else
+    echo "fi_info not found in container. Install Libfabric in the container image."
+fi
+
+echo "--- GPUs ---"
+if command -v nvidia-smi &> /dev/null; then
+    GPU_COUNT=$(nvidia-smi --query-gpu=count --format=csv,noheader | head -1)
+    echo "GPUs visible: $GPU_COUNT"
+else
+    echo "nvidia-smi not found"
+fi
+```
+
+## fi_pingpong Quick Network Test
+
+Validates basic EFA connectivity between two instances. If this hangs or fails, the problem is at the infrastructure level (security groups, routing, AZ mismatch) — not in the ML stack.
+
+```bash
+# On the server instance (listens on port 47592 by default):
+fi_pingpong -p efa
+
+# On the client instance:
+fi_pingpong -p efa <server_instance_private_ip>
+```
+
+Expected output is a table of increasing message sizes (64 bytes through several KB) with rising MB/sec throughput. A hang means traffic is being dropped before it reaches the EFA provider.
+
+## AWS Support Escalation Template
+
+When all debugging steps are exhausted, open an AWS Support case. Include the following to minimize back-and-forth:
+
+```text
+1. INSTANCE DETAILS
+   - Instance IDs:
+   - Instance type:
+   - Region / AZ:
+   - AMI ID:
+   - Placement group (if any):
+
+2. NETWORK CONFIGURATION
+   - Interface types used (efa-only / interface / efa):
+   - Number of EFA interfaces attached:
+   - Security group IDs:
+   - VPC ID / Subnet IDs:
+
+3. SOFTWARE VERSIONS
+   - EFA Installer version:
+   - EFA driver version (modinfo efa | grep version):
+   - Libfabric version (fi_info -p efa | grep version):
+   - aws-ofi-nccl version:
+   - NCCL version:
+   - CUDA version:
+   - Container image (if applicable):
+
+4. DIAGNOSTIC OUTPUT (attach as files)
+   - Full output of the EFA Health Check script
+   - Full output of: lspci | grep -i efa
+   - Full output of: ibv_devices
+   - Full output of: fi_info -p efa -t FI_EP_RDM
+   - Full NCCL_DEBUG=INFO logs from the failing workload
+   - nccl-tests results (if available)
+
+5. PROBLEM DESCRIPTION
+   - What the workload is trying to do:
+   - Error / behavior observed:
+   - When it started:
+   - Steps to reproduce:
+
+6. WHAT HAS BEEN TRIED
+   - (List debugging steps already completed from this skill)
+```

--- a/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/diagnostic-scripts.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/diagnostic-scripts.md
@@ -241,6 +241,29 @@ fi_pingpong -p efa <server_instance_private_ip>
 
 Expected output is a table of increasing message sizes (64 bytes through several KB) with rising MB/sec throughput. A hang means traffic is being dropped before it reaches the EFA provider.
 
+## Quick NCCL Transport Check
+
+The fastest single check: print device + plugin state at job startup (before `torchrun`), then confirm the transport NCCL actually selected. Run this inside the container/node where the workload runs.
+
+```bash
+# Devices should exist (device pass-through into the container)
+ls -l /dev/infiniband/uverbs* 2>/dev/null | head
+
+# Plugin + libfabric should be visible to the dynamic linker
+ldconfig -p | grep -E 'libnccl-net|libfabric' || echo "MISSING: EFA userspace not on loader path"
+
+# Turn on the signal you actually care about
+export NCCL_DEBUG=INFO
+export NCCL_DEBUG_SUBSYS=INIT,NET
+```
+
+Then read the workload's NCCL output:
+
+- Good: `NET/OFI ... Selected provider is efa` and `Using transport protocol RDMA`
+- Bad: `NET/Socket : Using network Socket` (TCP fallback — EFA userspace missing or not on the loader path)
+
+If a containerized job regresses to `NET/Socket` after previously working, check that the orchestrator (e.g. AWS Batch job definition) still maps `/dev/infiniband` with `READ|WRITE|MKNOD` permissions, and that the aws-ofi-nccl plugin is still resolvable via `ldconfig -p`.
+
 ## AWS Support Escalation Template
 
 When all debugging steps are exhausted, open an AWS Support case. Include the following to minimize back-and-forth:

--- a/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/instance-reference.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/efa-networking/references/instance-reference.md
@@ -1,0 +1,92 @@
+# EFA Instance & Installer Reference
+
+## Instance Networking Quick Reference
+
+P-family EFA-supported instance types, expected EFA device counts, and the recommended network interface configuration to maximize EFA bandwidth while minimizing IP address consumption. Verify counts against current AWS documentation — new instance types are added regularly and bandwidth figures change.
+
+| Instance           | GPUs | GPU Type    | Max EFA | EFA:GPU | BW/EFA (Gbps) | Total EFA BW (Gbps) |
+| ------------------ | ---- | ----------- | ------- | ------- | ------------- | ------------------- |
+| p4d.24xlarge       | 8    | A100 80GB   | 4       | 1:2     | 100           | 400                 |
+| p5.48xlarge        | 8    | H100 80GB   | 32      | 4:1     | 100           | 3,200               |
+| p5e.48xlarge       | 8    | H200 141GB  | 32      | 4:1     | 100           | 3,200               |
+| p5en.48xlarge      | 8    | H200 141GB  | 16      | 2:1     | 200           | 3,200               |
+| p6-b200.48xlarge   | 8    | B200 180GB  | 8       | 1:1     | 400           | 3,200               |
+| p6e-gb200.36xlarge | 4    | GB200 185GB | 8       | 2:1     | 400           | 1,600               |
+
+On p6e-gb200, each GPU has two co-located EFA NICs that share 400 Gbps. The optimal config uses 4 of the 8 EFA interfaces (one per GPU pair) to reach the full 1,600 Gbps.
+
+### Interface Configuration Rules
+
+- The primary interface (NetworkCardIndex 0, DeviceIndex 0) **must** be `interfaceType=interface` (ENA).
+- All additional EFA interfaces should use `interfaceType=efa-only`.
+- The primary ENI must be on NetworkCardIndex 0 (NCI0) and DeviceIndex 0 (DI0).
+- An `efa-only` interface and an ENA interface on the same network card share bandwidth.
+
+Reference: [EFA-supported accelerated instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html)
+
+## EFA Installer Reference
+
+The EFA Installer is a self-contained package that installs the EFA kernel module (`efa.ko`), Libfabric, aws-ofi-nccl, OpenMPI (optional), and rdma-core. Set `EFA_VERSION` to the current release; check the AWS documentation for the latest.
+
+### Installation Commands
+
+Standard install (bare metal / VM host):
+
+```bash
+export EFA_VERSION=1.47.0
+curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz
+tar -xf aws-efa-installer-${EFA_VERSION}.tar.gz
+cd aws-efa-installer
+sudo ./efa_installer.sh
+```
+
+Container image install:
+
+```bash
+sudo ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify
+```
+
+Host-only install (Kubernetes node / container host):
+
+```bash
+sudo ./efa_installer.sh -y --minimal
+```
+
+### Dockerfile Snippet
+
+```dockerfile
+ARG EFA_VERSION=1.47.0
+
+RUN mkdir -p /tmp/efa && \
+    cd /tmp/efa && \
+    curl --retry 3 --retry-delay 2 -fsSL -o aws-efa-installer-${EFA_VERSION}.tar.gz \
+        https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-${EFA_VERSION}.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
+    rm -rf /tmp/efa && \
+    ldconfig
+
+# Append Libfabric tools (e.g. fi_info) to PATH
+ENV PATH=/opt/amazon/efa/bin:$PATH
+```
+
+### Installer Flags
+
+| Flag                | Short | Description                                               |
+| ------------------- | ----- | --------------------------------------------------------- |
+| `--skip-kmod`       | `-k`  | Skip kernel module install (handled by the host)          |
+| `--skip-limit-conf` | `-l`  | Skip ulimit configuration (handled by container runtime)  |
+| `--no-verify`       | `-n`  | Skip EFA device verification (for container image builds) |
+| `--minimal`         | `-m`  | Only install kernel driver + rdma-core (container hosts)  |
+| `--yes`             | `-y`  | Non-interactive mode                                      |
+
+## See Also
+
+- [EC2 EFA User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html)
+- [EFA-supported accelerated instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html)
+- [EC2 Instance Topology API](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-topology.html)
+- [nccl-tests (GitHub)](https://github.com/NVIDIA/nccl-tests)
+- [AWS Deep Learning AMIs](https://docs.aws.amazon.com/dlami/)
+- [AWS Deep Learning Containers](https://aws.github.io/deep-learning-containers/)
+- [SRD — A Cloud-Optimized Transport Protocol](https://aws.amazon.com/srd/)


### PR DESCRIPTION
## Summary

Adds a new `efa-networking` **diagnostic-tool skill** to the `aws-dev-toolkit` plugin. It drives a builder through isolating and fixing Elastic Fabric Adapter (EFA) and NCCL problems on GPU/HPC instances — the issues that silently drop distributed training and inference onto the TCP fallback path (~100x slower, ~100x the cost per token, often unnoticed until the bill arrives).

The skill follows the same shape as the toolkit's existing diagnostic skills (`aws-debug`, `aws-health-check`):

- **Diagnostic Workflow** — numbered symptom → baseline → fast signal → ladder → fix → re-verify → escalate
- **Diagnostic Ladder** — 9 rungs, each with a check command, pass condition, and the fix mapped to a root cause, ordered cheapest-infra → software
- **NCCL verification** — the healthy `Selected provider is efa` / `RDMA` signal vs. the `NET/Socket` TCP-fallback fingerprint
- **Gotchas** and a structured **Output Format** (Symptom / Root Cause / Evidence / Fix / Verification / Prevention)
- Two reference files: copy-paste diagnostic scripts, and a P-family instance/device + EFA installer reference

Also bumps the plugin README skill count (35 → 36) and adds a row under AWS Services.

## Why

None of the existing 35 skills cover EFA/NCCL. `networking` stops at VPC/SG fundamentals, `ec2` covers instance selection, and `mlops` covers training architecture — but the EFA stack (SRD, Libfabric, aws-ofi-nccl, GPUDirect RDMA) and its diagnostics are absent. This is exactly the hard-won, not-well-documented-elsewhere guidance the toolkit is meant to distill, and it maps directly to the "what do you wish the founder had in their IDE" goal.

## Notes for reviewers

- **Draft** — the RFC issue (per CONTRIBUTING) is being opened separately; this PR is up in parallel for review of the content. Happy to hold merge until the RFC lands.
- `**/SKILL.md`, `**/.claude-plugin/`, and the `solution-architecture/` folder are CODEOWNERS-gated (`@awslabs/startups-admins` + `@awslabs/startups-solution-architects`).
- All content is generic and public-doc-derived. Verified against the repo's pinned linters: `markdownlint-cli2` 0.17 (0 errors) and `dprint` 0.51 (clean).
- `allowed-tools` is scoped to read-only diagnostics (`aws *`, `lspci`, `lsmod`, `modinfo`, `ibv_devices`, `fi_info`, `fi_pingpong`, `ldconfig`, `nvidia-smi`) plus the `awsknowledge` MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
