### PR TITLE
feat(heroku-to-aws): first-class checkpoint phase + backbone chain check

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -9,22 +9,46 @@ runs entirely from its prose, as before.
 
 ## Phase frontmatter keys
 
-| Key                 | Meaning                                                                                                                                        |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_phase` / `_title` | the phase's id and human title                                                                                                                 |
-| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase)                                                     |
-| `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                   |
-| `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                         |
-| `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires |
-| `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                         |
-| `_produces`         | the artifact file(s) the phase writes                                                                                                          |
-| `_advances_to`      | the phase that runs next on success                                                                                                            |
+| Key                 | Meaning                                                                                                                                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_phase` / `_title` | the phase's id and human title                                                                                                                                                                                                                                                  |
+| `_kind`             | `backbone` (default when absent) or `checkpoint`. A **backbone** phase is a step on the linear lifecycle (see below). A **checkpoint** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a checkpoint. |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a checkpoint, its minimum precondition)                                                                                                                                           |
+| `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                                                                                                                                                    |
+| `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                                                                                                                                                          |
+| `_trigger`          | (checkpoint phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                           |
+| `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires                                                                                                                                  |
+| `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                          |
+| `_produces`         | the artifact file(s) the phase writes                                                                                                                                                                                                                                           |
+| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                    |
 
 ### `_trigger` forms
 
 - `{ _always: true }` — the fragment always runs.
 - `{ _glob: "<pattern>" }` — the fragment runs when one or more files matching the glob exist in the workspace; otherwise it is skipped.
 - `{ _when: "<condition>" }` — the fragment runs when the prose condition holds (evaluated by you, the interpreter, against the phase's inputs); otherwise it is skipped. The condition is opaque prose — CI validates only that the form is well-formed, not the condition's truth. Used for fragments gated on a preference or a design-artifact shape (e.g. the EKS branches, gated on the Kubernetes preference / an `eks_cluster` design entry).
+
+### Backbone vs checkpoint phases
+
+A **backbone** phase (the default) is a step on the linear lifecycle: it is
+advanced into by its predecessor's `_advances_to`, and it advances to the next
+phase (or the `complete` terminal). The backbone is
+`discover → clarify → design → estimate → generate → complete`.
+
+A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
+It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
+opts in), and it returns control to the flow rather than advancing `current_phase`
+— so it has no `_advances_to`, and it never appears as a `current_phase` value.
+WHERE a checkpoint is offered is orchestration prose (see SKILL.md), not part of
+the phase contract.
+
+**Checkpoint status semantics (important):** marking a checkpoint's
+`phases.<checkpoint>` as `"completed"` means the checkpoint was RESOLVED (offered
+and dealt with) — NOT that the user participated. A declined checkpoint is still
+`"completed"` (the lifecycle is resolved, so the migration can terminate cleanly).
+Whether the user actually participated is a SEPARATE signal, carried by the
+presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
+user engaged). Do not conflate "checkpoint resolved" with "user participated."
 
 ## Fragment unit keys
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
@@ -1,8 +1,10 @@
 ---
 _phase: feedback
 _title: "Feedback (Optional)"
+_kind: checkpoint
 _requires_phase: discover
 _input: "**/.phase-status.json"
+_trigger: { _when: "the user opts in to providing feedback at a feedback checkpoint" }
 _fragments:
   - _id: collect
     _trigger: { _always: true }
@@ -12,7 +14,6 @@ _assemble:
 _produces:
   - feedback.json
   - trace.json
-_advances_to: complete
 ---
 
 # Phase 6: Feedback (Optional)
@@ -28,7 +29,7 @@ Collects user feedback and generates a shareable migration plan link. Reuses the
 - **feedback-collect.md** → the collection work: detect IDE/version, build the anonymized trace, present the survey link, optionally generate a share link, and write `feedback.json`.
 - **feedback-assemble.md** → the assembler: output gate, phase-status update, and marking the migration complete.
 
-This is the terminal phase — `_advances_to: complete`. There is no next phase to load.
+This is an **optional checkpoint phase** (`_kind: checkpoint`), not a step on the linear backbone. It is entered only when the user opts in at a feedback checkpoint (its `_trigger`), and it returns control to the flow rather than advancing a `current_phase` — so it has no `_advances_to`. SKILL.md decides where the feedback checkpoint is offered (see the Feedback Checkpoints section there).
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -21,7 +21,7 @@ _assemble:
   _file: phases/generate/generate-assemble.md
 _produces:
   - generation-warnings.json
-_advances_to: feedback
+_advances_to: complete
 ---
 
 # Phase 5: Generate Migration Artifacts

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -149,4 +149,108 @@ describe('frontmatter-validator', () => {
       'should not fail on an unverifiable forward reference',
     );
   });
+
+  // ---- backbone / checkpoint + chain-consistency ----
+
+  // A fully-declared 2-phase backbone (discover -> clarify -> complete) plus a
+  // feedback CHECKPOINT (off-backbone, trigger-entered). Minimal but complete.
+  function chainSkill(): Record<string, string> {
+    const phase = (name: string, extra: string, frag = name, assemble = name) => ({
+      [`references/phases/${name}/${name}.md`]:
+`---
+_phase: ${name}
+_title: "${name}"
+${extra}
+_fragments:
+  - _id: ${frag}
+    _trigger: { _always: true }
+    _file: phases/${name}/${name}-frag.md
+_assemble:
+  _file: phases/${name}/${name}-asm.md
+_produces:
+  - ${name}.json
+---
+# ${name}
+`,
+      [`references/phases/${name}/${name}-frag.md`]:
+`---
+_fragment: ${frag}
+_of_phase: ${name}
+_contributes:
+  - ${name}.json
+---
+# frag
+`,
+      [`references/phases/${name}/${name}-asm.md`]:
+`---
+_assemble: asm-${name}
+_of_phase: ${name}
+_reads:
+  - ${frag}
+_produces:
+  - ${name}.json
+---
+# asm
+`,
+    });
+    return {
+      ...phase('discover', '_init: true\n_advances_to: clarify'),
+      ...phase('clarify', '_requires_phase: discover\n_advances_to: complete'),
+      ...phase(
+        'feedback',
+        '_kind: checkpoint\n_requires_phase: discover\n_trigger: { _when: "user opts in" }',
+      ),
+    };
+  }
+
+  it('accepts a valid backbone + a checkpoint phase', () => {
+    const findings = validateFixture(chainSkill());
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects a checkpoint phase that declares _advances_to (must be off-backbone)', () => {
+    const files = chainSkill();
+    files['references/phases/feedback/feedback.md'] = files[
+      'references/phases/feedback/feedback.md'
+    ].replace('_trigger: { _when: "user opts in" }', '_trigger: { _when: "user opts in" }\n_advances_to: complete');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /checkpoint phase 'feedback' must NOT declare _advances_to/);
+  });
+
+  it('rejects a checkpoint phase with no phase-level _trigger', () => {
+    const files = chainSkill();
+    files['references/phases/feedback/feedback.md'] = files[
+      'references/phases/feedback/feedback.md'
+    ].replace('\n_trigger: { _when: "user opts in" }', '');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /checkpoint phase 'feedback' must declare a phase-level _trigger/);
+  });
+
+  it('rejects a backbone phase that declares a phase-level _trigger', () => {
+    const files = chainSkill();
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_requires_phase: discover\n_trigger: { _when: "x" }');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /backbone phase 'clarify' must NOT declare a phase-level _trigger/);
+  });
+
+  it('rejects a backbone phase missing _advances_to', () => {
+    const files = chainSkill();
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('\n_advances_to: complete', '');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /backbone phase 'clarify' must declare _advances_to/);
+  });
+
+  it('rejects a chain inconsistency (forward edge with no matching back-link)', () => {
+    const files = chainSkill();
+    // discover advances to clarify, but make clarify require the wrong predecessor.
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_requires_phase: feedback');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /chain inconsistency/);
+  });
 });

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -37,13 +37,33 @@ export function check(skill: BoundSkill): Finding[] {
     // closed vocab
     for (const k of phase.unknownKeys) add(pf, `unknown phase frontmatter key '${k}'`);
 
-    // _advances_to / _requires_phase: verify only when the target declares frontmatter;
-    // otherwise UNVERIFIED (skip) — tolerant of partial rollout.
-    if (phase.advancesTo && !TERMINALS.has(phase.advancesTo) && !declaredPhases.has(phase.advancesTo)) {
-      // unverified — target phase has no frontmatter yet. no finding.
+    // backbone/checkpoint contract (see INTERPRETER.md § _kind):
+    //   backbone (default): MUST have _advances_to; MUST NOT have a phase-level _trigger.
+    //   checkpoint: MUST have a phase-level _trigger; MUST NOT have _advances_to
+    //               (off-backbone — entered by its trigger, returns control).
+    if (phase.role === "checkpoint") {
+      if (!phase.trigger) {
+        add(pf, `checkpoint phase '${phase.phase}' must declare a phase-level _trigger (how it is entered)`);
+      } else if (phase.trigger.kind === "unknown") {
+        add(pf, `checkpoint phase '${phase.phase}' has an unrecognized phase _trigger form: ${phase.trigger.raw}`);
+      }
+      if (phase.advancesTo) {
+        add(pf, `checkpoint phase '${phase.phase}' must NOT declare _advances_to (it is off-backbone; it returns control, it does not advance)`);
+      }
+    } else {
+      // backbone
+      if (!phase.advancesTo) {
+        add(pf, `backbone phase '${phase.phase}' must declare _advances_to (or mark it '_kind: checkpoint' if it is an off-backbone checkpoint)`);
+      }
+      if (phase.trigger) {
+        add(pf, `backbone phase '${phase.phase}' must NOT declare a phase-level _trigger (only checkpoint phases are trigger-entered)`);
+      }
     }
+
+    // _requires_phase membership: verify only when >1 phase declares frontmatter AND
+    // the target is not itself declared (otherwise UNVERIFIED — tolerant of partial rollout).
     if (phase.requiresPhase && declaredPhases.size > 1 && !declaredPhases.has(phase.requiresPhase)) {
-      // unverified likewise. no finding.
+      add(pf, `_requires_phase '${phase.requiresPhase}' names no declared phase`);
     }
 
     // fragments
@@ -93,6 +113,57 @@ export function check(skill: BoundSkill): Finding[] {
     for (const art of phase.produces) {
       if (!asm.produces.includes(art)) {
         add(pf, `phase _produces '${art}' but the assembler does not declare it in _produces (single-creator rule)`);
+      }
+    }
+  }
+
+  // ---- Backbone chain-consistency (backbone phases only; checkpoints excluded) ----
+  // The backbone is the linear lifecycle wired by _advances_to (forward) and
+  // _requires_phase (backward). Checkpoints (_kind: checkpoint) are off-backbone and
+  // are NOT part of this graph. Enforced only once >1 phase declares frontmatter AND
+  // every backbone _advances_to target is either a terminal or a declared phase
+  // (i.e. the backbone is fully present — tolerant of partial rollout).
+  const backbone = skill.phases.filter((p) => p.role === "backbone");
+  if (backbone.length > 1) {
+    const byName = new Map(backbone.map((p) => [p.phase, p] as const));
+    const advTargetsResolvable = backbone.every(
+      (p) => !p.advancesTo || TERMINALS.has(p.advancesTo) || byName.has(p.advancesTo),
+    );
+    if (advTargetsResolvable) {
+      const relOf = (p: PhaseFrontmatter) => skill.rel(p.sourceFile);
+
+      // (1) single head: exactly one backbone phase with no _requires_phase.
+      const heads = backbone.filter((p) => !p.requiresPhase);
+      if (heads.length !== 1) {
+        const names = heads.map((h) => h.phase).join(", ") || "(none)";
+        add(relOf(backbone[0]), `backbone must have exactly one head (a phase with no _requires_phase); found ${heads.length}: ${names}`);
+      }
+
+      // (2) single terminal: exactly one backbone phase advancing to a terminal.
+      const terminals = backbone.filter((p) => p.advancesTo && TERMINALS.has(p.advancesTo));
+      if (terminals.length !== 1) {
+        const names = terminals.map((t) => t.phase).join(", ") || "(none)";
+        add(relOf(backbone[0]), `backbone must have exactly one terminal (a phase whose _advances_to is complete/done/end); found ${terminals.length}: ${names}`);
+      }
+
+      // (3) forward⇒back: if A _advances_to B and B is a backbone phase, B must _requires_phase A.
+      for (const a of backbone) {
+        if (a.advancesTo && !TERMINALS.has(a.advancesTo)) {
+          const b = byName.get(a.advancesTo);
+          if (b && b.requiresPhase !== a.phase) {
+            add(relOf(a), `chain inconsistency: '${a.phase}' _advances_to '${b.phase}', but '${b.phase}' _requires_phase '${b.requiresPhase ?? "(none)"}' (expected '${a.phase}')`);
+          }
+        }
+      }
+
+      // (4) back⇒forward: if B _requires_phase A (both backbone), A must _advances_to B.
+      for (const b of backbone) {
+        if (b.requiresPhase && byName.has(b.requiresPhase)) {
+          const a = byName.get(b.requiresPhase)!;
+          if (a.advancesTo !== b.phase) {
+            add(relOf(b), `chain inconsistency: '${b.phase}' _requires_phase '${a.phase}', but '${a.phase}' _advances_to '${a.advancesTo ?? "(none)"}' (expected '${b.phase}')`);
+          }
+        }
       }
     }
   }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -13,8 +13,8 @@ import type {
 import { readFileSync } from "node:fs";
 
 const PHASE_KEYS = new Set([
-  "_phase", "_title", "_requires_phase", "_init", "_input",
-  "_fragments", "_assemble", "_produces", "_advances_to",
+  "_phase", "_title", "_kind", "_requires_phase", "_init", "_input",
+  "_fragments", "_trigger", "_assemble", "_produces", "_advances_to",
 ]);
 const FRAGMENT_KEYS = new Set(["_fragment", "_of_phase", "_contributes"]);
 const ASSEMBLER_KEYS = new Set(["_assemble", "_of_phase", "_reads", "_produces"]);
@@ -82,14 +82,21 @@ function parseFragments(fm: string): FragmentRef[] {
 
 export function parsePhase(path: string, fm: string): PhaseFrontmatter {
   const assembleBlock = /_assemble:\s*\n\s*_file:\s*([^\n]+)/.exec(fm);
+  const roleRaw = scalar(fm, "_kind");
+  const role = roleRaw === "checkpoint" ? "checkpoint" : "backbone";
+  // phase-level _trigger: a `_trigger: { ... }` at column 0 (NOT a _fragments[] entry,
+  // which is indented under a `- _id:`). Match only a top-of-line _trigger.
+  const ptrig = /^_trigger:\s*\{([^}]*)\}/m.exec(fm);
   return {
     kind: "phase",
     sourceFile: path,
     phase: scalar(fm, "_phase") ?? "",
     title: scalar(fm, "_title"),
+    role,
     requiresPhase: scalar(fm, "_requires_phase"),
     init: /^_init:\s*true\s*$/m.test(fm),
     fragments: parseFragments(fm),
+    trigger: ptrig ? parseTrigger(ptrig[1]) : null,
     assembleFile: assembleBlock ? assembleBlock[1].trim() : null,
     produces: blockList(fm, "_produces"),
     advancesTo: scalar(fm, "_advances_to"),

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -24,9 +24,13 @@ export interface PhaseFrontmatter {
   sourceFile: string; // absolute path, for messages
   phase: string; // _phase
   title: string | null;
+  /** _kind: 'checkpoint' (off-backbone, trigger-entered) or 'backbone' (default when absent). */
+  role: "backbone" | "checkpoint";
   requiresPhase: string | null;
   init: boolean; // _init
   fragments: FragmentRef[];
+  /** phase-level _trigger (checkpoint phases only) — how the phase is entered. null for backbone. */
+  trigger: Trigger | null;
   assembleFile: string | null; // _assemble._file
   produces: string[];
   advancesTo: string | null;


### PR DESCRIPTION
## What

Introduces a first-class **checkpoint phase** concept and fixes a contract bug that #98 landed on main.

### The bug (#98 regression)

#98 wired `feedback` into the linear backbone: `generate._advances_to: feedback` and `feedback._advances_to: complete`. But SKILL.md treats feedback as an **interleaved, opt-in checkpoint** (offered after Estimate), and generate actually advances to `complete` (`current_phase` is never `feedback`). The frontmatter contract contradicted the orchestration. This PR makes the frontmatter honest.

### The model

A phase is now either **backbone** (default) or **`_kind: checkpoint`**:

| | backbone | checkpoint (`feedback`) |
| --- | --- | --- |
| On the linear lifecycle? | yes | no (off-backbone) |
| Entered by | predecessor's `_advances_to` | its own phase-level `_trigger` (opt-in) |
| `_advances_to` | required | **forbidden** (returns control) |
| phase-level `_trigger` | forbidden | required |
| ever a `current_phase`? | yes | no |

Backbone: `discover → clarify → design → estimate → generate → complete`.

**Where** a checkpoint is offered stays SKILL.md prose (a product-tunable knob — the two skills differ on it), deliberately NOT structured. YAGNI: reuse the `_when` trigger shipped in #98; keep the option to make placement declarative later if it earns its keep.

**Checkpoint status semantics** (documented in INTERPRETER.md, resolves a cold-run question): `phases.<cp> == "completed"` means the checkpoint was **resolved** (offered + dealt with), NOT that the user participated. A declined checkpoint is still `completed` so the lifecycle terminates cleanly. Actual participation is the separate signal of the artifact's presence (`feedback.json` exists only if engaged).

## Changes

**Validator** (`tools/frontmatter-validator/`, skill-agnostic):
- `types.ts` — `PhaseFrontmatter` gains `role: backbone|checkpoint` + optional phase-level `trigger`.
- `parse.ts` — `_kind` + `_trigger` added to `PHASE_KEYS`; parsed (default `role=backbone`).
- `check.ts` — the backbone/checkpoint **contract** + a real **backbone chain-consistency check** (single head, single terminal, forward⇔back agreement; acyclicity falls out). Previously the two chain lines were **no-ops** — the chain was entirely unchecked.
- `INTERPRETER.md` — documents `_kind`, phase-level `_trigger`, backbone-vs-checkpoint, and the resolved-not-participated rule.

**Frontmatter:**
- `generate.md` — `_advances_to: complete` (was `feedback` — the #98 lie).
- `feedback.md` — `_kind: checkpoint` + `_trigger: { _when: … }` + `_requires_phase: discover`; `_advances_to` removed. Prose updated ("terminal phase" → "checkpoint").

## Verification

- **Tests 14/14** — added: checkpoint accepted; checkpoint-with-`_advances_to` rejected; checkpoint-without-`_trigger` rejected; backbone-with-`_trigger` rejected; backbone-missing-`_advances_to` rejected; chain-inconsistency rejected.
- **Cold-run** (heroku, discover→generate): the interpreter treats feedback as opt-in off-backbone, generate advances to `complete`; normal mappings/count/tier intact.
- `mise run build` green: `lint:md` 0 errors, `tsc`, `lint:frontmatter` OK (6 phases), `test`, `fmt:check`, checkov 160/0, gitleaks clean.

## Scope

heroku-to-aws only. gcp adoption is a later rung (gcp has no phase frontmatter yet).

**Follow-up (pre-existing, not this PR):** SKILL.md's "user had two chances" wording vs. "feedback offered once after Estimate" — stale phrasing from the pre-checkpoint model.
