### PR TITLE
feat(heroku-to-aws): encode stale-downstream re-entry as _re_entry_guard frontmatter

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -21,12 +21,51 @@ runs entirely from its prose, as before.
 | `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                          |
 | `_produces`         | the artifact file(s) the phase writes                                                                                                                                                                                                                                           |
 | `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                    |
+| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                    |
 
 ### `_trigger` forms
 
 - `{ _always: true }` — the fragment always runs.
 - `{ _glob: "<pattern>" }` — the fragment runs when one or more files matching the glob exist in the workspace; otherwise it is skipped.
 - `{ _when: "<condition>" }` — the fragment runs when the prose condition holds (evaluated by you, the interpreter, against the phase's inputs); otherwise it is skipped. The condition is opaque prose — CI validates only that the form is well-formed, not the condition's truth. Used for fragments gated on a preference or a design-artifact shape (e.g. the EKS branches, gated on the Kubernetes preference / an `eks_cluster` design entry).
+
+### `_re_entry_guard` — stale-downstream re-entry
+
+A backbone phase whose downstream phase has already completed is unsafe to re-run
+silently: its artifact feeds the downstream, so overwriting it leaves the
+downstream artifact stale. `_re_entry_guard` encodes that check. It has four keys,
+all required when the guard is present:
+
+| Key                   | Meaning                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `_stale_if_completed` | the downstream phase whose `"completed"` status makes re-running THIS phase unsafe (equals `_advances_to`) |
+| `_stale_artifact`     | the downstream artifact named in the `GATE_FAIL` line (one of that downstream phase's `_produces`)         |
+| `_on_reentry`         | what to do on re-entry — `stop_unless_confirmed` (the only value today)                                    |
+| `_on_confirm`         | what to do when the user confirms the re-run — `reset_downstream_to_pending` (the only value today)        |
+
+**Enforcement (at this phase's completion gate, BEFORE the phase's checks):**
+
+1. Read `.phase-status.json`. If `phases.<_stale_if_completed>` is NOT
+   `"completed"`, the guard does not fire — proceed normally.
+2. If it IS `"completed"` **and** the user has not explicitly confirmed re-running
+   this phase: **STOP**. Emit exactly:
+
+   ```
+   GATE_FAIL | phase=<this phase's _phase> | field=<_stale_artifact> | reason=stale_downstream
+   ```
+
+   Do NOT modify artifacts. Do NOT update `.phase-status.json`. Tell the user the
+   downstream work may be stale and they must confirm the re-run.
+3. If the user HAS explicitly confirmed the re-run (`_on_confirm:
+   reset_downstream_to_pending`): before proceeding, set every phase downstream of
+   this one (its `_advances_to` and everything after it on the backbone) back to
+   `"pending"` in `.phase-status.json`. Then run the phase normally.
+
+`phase=` and `reason=stale_downstream` are NOT stored in the frontmatter — you
+reconstruct the `GATE_FAIL` line from this phase's `_phase` plus the constant
+`stale_downstream` reason. This guard is the single source of truth for
+stale-downstream re-entry; there is no separate per-phase prose or shared-file
+table for it.
 
 ### Backbone vs checkpoint phases
 
@@ -84,8 +123,9 @@ out as a per-phase "initialize" step.
      - `[C] Cancel`
    - **If resuming:** set `$MIGRATION_DIR` to the selected run's directory. Read
      its `.phase-status.json` and validate it per the State Machine in `SKILL.md`.
-     If the `_init` phase is already `completed`, apply the re-entry rules (see the
-     phase's prose and `shared/handoff-gates.md`) before proceeding.
+     If the `_init` phase is already `completed`, apply the re-entry rules (see
+     the phase's `_re_entry_guard` frontmatter and § `_re_entry_guard` above)
+     before proceeding.
    - **If fresh, or no existing runs:** continue to step 2.
 
 2. Create `.migration/[MMDD-HHMM]/` (e.g. `.migration/0315-1030/`) using the

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -108,7 +108,7 @@ Load `references/shared/handoff-gates.md` when executing any phase completion st
 2. **Re-read from disk**: Before each phase (and before each handoff gate), Read required artifacts from `$MIGRATION_DIR/`. Do not rely on chat memory.
 3. **Advance only on `HANDOFF_OK`**: A phase is complete only when its orchestrator emits `HANDOFF_OK | phase=<name> | artifacts=...`. Do not load the next phase without it.
 4. **On `GATE_FAIL`**: Output the failure line(s) to the user in plain language. **Do NOT modify artifacts** to pass the gate. **Do NOT continue** to the next phase. Tell the user which phase to re-run.
-5. **Re-entry**: Re-running an earlier phase after downstream phases completed requires explicit user confirmation; downstream phases must be reset to `"pending"`. See `handoff-gates.md` re-entry table.
+5. **Re-entry**: Re-running an earlier phase after downstream phases completed requires explicit user confirmation; downstream phases must be reset to `"pending"`. This is governed by each phase's `_re_entry_guard` frontmatter — see `INTERPRETER.md` § `_re_entry_guard`.
 
 Generate phase additionally loads `references/shared/validate-artifacts.md` before writing `migration-report.html`.
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
@@ -124,8 +124,6 @@ Before handing off to Design:
 
 Load `shared/handoff-gates.md`. **Re-read from disk** before checking.
 
-**Re-entry guard:** If `aws-design.json` exists and `phases.design` is `"completed"`: STOP unless the user explicitly confirms re-running Clarify. Emit `GATE_FAIL | phase=clarify | field=aws-design.json | reason=stale_downstream`.
-
 **Checks (all must PASS):**
 
 1. `preferences.json` exists and parses as valid JSON.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
@@ -13,6 +13,11 @@ _assemble:
 _produces:
   - preferences.json
 _advances_to: design
+_re_entry_guard:
+  _stale_if_completed: design
+  _stale_artifact: aws-design.json
+  _on_reentry: stop_unless_confirmed
+  _on_confirm: reset_downstream_to_pending
 ---
 
 # Phase 2: Clarify Requirements

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
@@ -53,12 +53,6 @@ Verify required artifacts exist in `$MIGRATION_DIR/`:
 
 Load `shared/handoff-gates.md`. **Re-read from disk** every artifact below before checking.
 
-**Re-entry guard:** If `estimation-infra.json` exists AND `phases.estimate` is `"completed"`: STOP unless the user explicitly confirms re-running Design. Emit:
-
-```
-GATE_FAIL | phase=design | field=estimation-infra.json | reason=stale_downstream
-```
-
 **Checks (all must PASS):**
 
 1. `aws-design.json` exists and parses as valid JSON.
@@ -73,7 +67,7 @@ GATE_FAIL | phase=design | field=estimation-infra.json | reason=stale_downstream
 10. No Fir-specific Terraform (ARM/Graviton, CNB) appears anywhere in output.
 11. Route output gates from Step 7 all pass.
 
-**On any FAIL:** Emit `GATE_FAIL | phase=design | field=<path> | reason=<missing|invalid|stale_downstream>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user what failed and how to fix it.
+**On any FAIL:** Emit `GATE_FAIL | phase=design | field=<path> | reason=<missing|invalid>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user what failed and how to fix it.
 
 **On PASS:** Emit `HANDOFF_OK | phase=design | artifacts=aws-design.json`.
 
@@ -134,4 +128,3 @@ All user communication via output messages only.
 | Partial match on Fast-Path Table             | Specialist gate (NOT a match), continue         | Continue `in_progress`        |
 | No services AND no deferred entries produced | Unrecoverable error                             | Revert to `pending` (Rule 4)  |
 | Handoff gate check fails (GATE_FAIL)         | Halt pipeline, surface diagnostic               | Retain `in_progress` (Rule 3) |
-| Downstream artifacts stale (re-entry)        | Halt, emit GATE_FAIL stale_downstream           | Retain `in_progress` (Rule 3) |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
@@ -17,6 +17,11 @@ _assemble:
 _produces:
   - aws-design.json
 _advances_to: estimate
+_re_entry_guard:
+  _stale_if_completed: estimate
+  _stale_artifact: estimation-infra.json
+  _on_reentry: stop_unless_confirmed
+  _on_confirm: reset_downstream_to_pending
 ---
 
 # Phase 3: Design AWS Architecture

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -15,6 +15,11 @@ _assemble:
 _produces:
   - heroku-resource-inventory.json
 _advances_to: clarify
+_re_entry_guard:
+  _stale_if_completed: clarify
+  _stale_artifact: preferences.json
+  _on_reentry: stop_unless_confirmed
+  _on_confirm: reset_downstream_to_pending
 ---
 
 # Phase 1: Discover Heroku Resources
@@ -93,7 +98,7 @@ GATE_FAIL | phase=<target_phase> | field=phases.<active_phase> | reason=invalid
    - The error category (e.g., `no_sources`, `state_corrupted`, `auth_failure`)
    - Actionable guidance on how to resolve
 
-**Rule 5 — Phase re-entry:** See `shared/handoff-gates.md` re-entry table. Re-running a phase after downstream phases completed requires explicit user confirmation; downstream phases must be reset to `"pending"`.
+**Rule 5 — Phase re-entry:** Stale-downstream re-entry is handled by each phase's `_re_entry_guard` frontmatter — see `INTERPRETER.md` § `_re_entry_guard`. Re-running a phase after a downstream phase completed requires explicit user confirmation; on confirmation the downstream phases are reset to `"pending"`.
 
 ---
 
@@ -192,12 +197,6 @@ Verify required artifacts exist in `$MIGRATION_DIR/`:
 
 Load `shared/handoff-gates.md`. **Re-read from disk** every artifact below before checking.
 
-**Re-entry guard:** If `preferences.json` exists AND `phases.clarify` is `"completed"`: STOP unless the user explicitly confirms re-running Discover. Emit:
-
-```
-GATE_FAIL | phase=discover | field=preferences.json | reason=stale_downstream
-```
-
 **Checks (all must PASS):**
 
 1. `heroku-resource-inventory.json` exists with at least one resource entry.
@@ -206,7 +205,7 @@ GATE_FAIL | phase=discover | field=preferences.json | reason=stale_downstream
 4. No forbidden clustering fields present (`cluster_id`, `creation_order_depth`, `edges`, `dependencies`, `must_migrate_together`).
 5. Route output gates from Step 4 all pass.
 
-**On any FAIL:** Emit `GATE_FAIL | phase=discover | field=<path> | reason=<missing|invalid|stale_downstream>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user which sub-discovery to re-run.
+**On any FAIL:** Emit `GATE_FAIL | phase=discover | field=<path> | reason=<missing|invalid>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user which sub-discovery to re-run.
 
 **On PASS:** Emit `HANDOFF_OK | phase=discover | artifacts=<comma-separated list of files verified>`.
 
@@ -270,7 +269,6 @@ All user communication via output messages only.
 | All sub-discoveries produce no resources                       | STOP, surface diagnostic                       | Revert to `pending` (Rule 4)  |
 | `.phase-status.json` invalid JSON                              | STOP, surface diagnostic                       | N/A (state corrupted)         |
 | Handoff gate check fails (GATE_FAIL)                           | Halt pipeline, surface diagnostic              | Retain `in_progress` (Rule 3) |
-| Downstream artifacts stale (re-entry)                          | Halt, emit GATE_FAIL stale_downstream          | Retain `in_progress` (Rule 3) |
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -15,6 +15,11 @@ _assemble:
 _produces:
   - estimation-infra.json
 _advances_to: generate
+_re_entry_guard:
+  _stale_if_completed: generate
+  _stale_artifact: generation-warnings.json
+  _on_reentry: stop_unless_confirmed
+  _on_confirm: reset_downstream_to_pending
 ---
 
 # Phase 4: Estimate AWS Costs

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -253,4 +253,81 @@ _produces:
     const findings = validateFixture(files);
     assert.match(findings.map((f) => f.message).join('\n'), /chain inconsistency/);
   });
+
+  // ---- _re_entry_guard ----
+
+  // discover guards its downstream (clarify); clarify's _produces is 'clarify.json'.
+  const GOOD_GUARD =
+    '_re_entry_guard:\n' +
+    '  _stale_if_completed: clarify\n' +
+    '  _stale_artifact: clarify.json\n' +
+    '  _on_reentry: stop_unless_confirmed\n' +
+    '  _on_confirm: reset_downstream_to_pending';
+
+  function guardOnDiscover(guard: string): Record<string, string> {
+    const files = chainSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', `_advances_to: clarify\n${guard}`);
+    return files;
+  }
+
+  it('accepts a well-formed _re_entry_guard', () => {
+    const findings = validateFixture(guardOnDiscover(GOOD_GUARD));
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects an unknown _re_entry_guard sub-key (typo)', () => {
+    const findings = validateFixture(
+      guardOnDiscover(GOOD_GUARD.replace('_stale_artifact:', '_stale_artifcat:')),
+    );
+    const msg = findings.map((f) => f.message).join('\n');
+    assert.match(msg, /unknown _re_entry_guard sub-key '_stale_artifcat'/);
+  });
+
+  it('rejects a _re_entry_guard missing a required sub-key', () => {
+    const findings = validateFixture(
+      guardOnDiscover(
+        '_re_entry_guard:\n' +
+        '  _stale_if_completed: clarify\n' +
+        '  _stale_artifact: clarify.json\n' +
+        '  _on_reentry: stop_unless_confirmed',
+      ),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /_re_entry_guard missing _on_confirm/);
+  });
+
+  it('rejects a _re_entry_guard with an out-of-vocab enum value', () => {
+    const findings = validateFixture(
+      guardOnDiscover(GOOD_GUARD.replace('stop_unless_confirmed', 'silently_overwrite')),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /_on_reentry 'silently_overwrite' is not a recognized value/);
+  });
+
+  it('rejects a _re_entry_guard whose _stale_if_completed != _advances_to', () => {
+    const findings = validateFixture(
+      guardOnDiscover(GOOD_GUARD.replace('_stale_if_completed: clarify', '_stale_if_completed: feedback')),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /should equal this phase's _advances_to/);
+  });
+
+  it('rejects a _re_entry_guard whose _stale_artifact is not in the downstream _produces (hard fail)', () => {
+    const findings = validateFixture(
+      guardOnDiscover(GOOD_GUARD.replace('_stale_artifact: clarify.json', '_stale_artifact: wrong.json')),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /is not in the _produces of the downstream phase 'clarify'/);
+  });
+
+  it('rejects a _re_entry_guard on a terminal-advancing phase (nothing downstream)', () => {
+    // put a guard on clarify, which _advances_to: complete (a terminal)
+    const files = chainSkill();
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace(
+      '_advances_to: complete',
+      '_advances_to: complete\n_re_entry_guard:\n  _stale_if_completed: complete\n  _stale_artifact: x.json\n  _on_reentry: stop_unless_confirmed\n  _on_confirm: reset_downstream_to_pending',
+    );
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /has a _re_entry_guard but no downstream backbone phase/);
+  });
 });

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -117,6 +117,64 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
 
+  // ---- Re-entry guard checks (INTERPRETER.md § _re_entry_guard) ----
+  // The guard is skill-agnostic structure: a phase's re-run is stale-blocked by the
+  // completion of the phase it advances to. Enforced per-phase; cross-phase artifact
+  // check runs once the downstream phase's frontmatter is present.
+  const guardOnReentry = new Set(["stop_unless_confirmed"]);
+  const guardOnConfirm = new Set(["reset_downstream_to_pending"]);
+  const phasesByName = new Map(skill.phases.map((p) => [p.phase, p] as const));
+  for (const phase of skill.phases) {
+    const g = phase.reEntryGuard;
+    if (!g) continue;
+    const pf = skill.rel(phase.sourceFile);
+
+    // unknown sub-keys (typo catch)
+    for (const k of g.unknownKeys) add(pf, `unknown _re_entry_guard sub-key '${k}'`);
+
+    // required-together: all four sub-keys present
+    if (!g.staleIfCompleted) add(pf, `_re_entry_guard missing _stale_if_completed`);
+    if (!g.staleArtifact) add(pf, `_re_entry_guard missing _stale_artifact`);
+    if (!g.onReentry) add(pf, `_re_entry_guard missing _on_reentry`);
+    if (!g.onConfirm) add(pf, `_re_entry_guard missing _on_confirm`);
+
+    // enum membership
+    if (g.onReentry && !guardOnReentry.has(g.onReentry)) {
+      add(pf, `_re_entry_guard._on_reentry '${g.onReentry}' is not a recognized value (expected: stop_unless_confirmed)`);
+    }
+    if (g.onConfirm && !guardOnConfirm.has(g.onConfirm)) {
+      add(pf, `_re_entry_guard._on_confirm '${g.onConfirm}' is not a recognized value (expected: reset_downstream_to_pending)`);
+    }
+
+    // a terminal-advancing phase (or one with no downstream) must NOT carry a guard
+    if (!phase.advancesTo || TERMINALS.has(phase.advancesTo)) {
+      add(pf, `phase '${phase.phase}' has a _re_entry_guard but no downstream backbone phase (its _advances_to is '${phase.advancesTo ?? "(none)"}') — a guard is meaningless with nothing downstream`);
+    }
+
+    // guard ⟺ advancer: the phase is stale-blocked by the completion of the phase
+    // it advances to. _stale_if_completed SHOULD equal _advances_to.
+    if (g.staleIfCompleted && phase.advancesTo && !TERMINALS.has(phase.advancesTo) &&
+        g.staleIfCompleted !== phase.advancesTo) {
+      add(pf, `_re_entry_guard._stale_if_completed '${g.staleIfCompleted}' should equal this phase's _advances_to '${phase.advancesTo}' (a phase's re-run is stale-blocked by the completion of the phase it advances to)`);
+    }
+
+    // phase-ref resolves: _stale_if_completed names a declared phase (verify only when
+    // that phase has frontmatter — tolerant of partial rollout).
+    if (g.staleIfCompleted && declaredPhases.size > 1 && !declaredPhases.has(g.staleIfCompleted)) {
+      add(pf, `_re_entry_guard._stale_if_completed '${g.staleIfCompleted}' names no declared phase`);
+    }
+
+    // artifact ⟺ downstream _produces (HARD FAIL): _stale_artifact must be one of the
+    // downstream phase's _produces. Checked only when the downstream phase's
+    // frontmatter is present (otherwise UNVERIFIED — partial rollout).
+    if (g.staleIfCompleted && g.staleArtifact) {
+      const downstream = phasesByName.get(g.staleIfCompleted);
+      if (downstream && !downstream.produces.includes(g.staleArtifact)) {
+        add(pf, `_re_entry_guard._stale_artifact '${g.staleArtifact}' is not in the _produces of the downstream phase '${g.staleIfCompleted}' (declared: ${downstream.produces.join(", ") || "(none)"})`);
+      }
+    }
+  }
+
   // ---- Backbone chain-consistency (backbone phases only; checkpoints excluded) ----
   // The backbone is the linear lifecycle wired by _advances_to (forward) and
   // _requires_phase (backward). Checkpoints (_kind: checkpoint) are off-backbone and

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -8,6 +8,7 @@ import type {
   FragmentFrontmatter,
   FragmentRef,
   PhaseFrontmatter,
+  ReEntryGuard,
   Trigger,
 } from "./types.ts";
 import { readFileSync } from "node:fs";
@@ -15,6 +16,10 @@ import { readFileSync } from "node:fs";
 const PHASE_KEYS = new Set([
   "_phase", "_title", "_kind", "_requires_phase", "_init", "_input",
   "_fragments", "_trigger", "_assemble", "_produces", "_advances_to",
+  "_re_entry_guard",
+]);
+const GUARD_KEYS = new Set([
+  "_stale_if_completed", "_stale_artifact", "_on_reentry", "_on_confirm",
 ]);
 const FRAGMENT_KEYS = new Set(["_fragment", "_of_phase", "_contributes"]);
 const ASSEMBLER_KEYS = new Set(["_assemble", "_of_phase", "_reads", "_produces"]);
@@ -80,6 +85,43 @@ function parseFragments(fm: string): FragmentRef[] {
   return out;
 }
 
+/** Extract the indented body lines of a `key:` block (lines more-indented than the key). */
+function indentedBlock(fm: string, key: string): string | null {
+  const lines = fm.split("\n");
+  const idx = lines.findIndex((l) => new RegExp(`^${key}:\\s*$`).test(l));
+  if (idx === -1) return null;
+  const body: string[] = [];
+  for (let i = idx + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (l.trim() === "") continue;
+    if (/^\s/.test(l)) body.push(l);
+    else break; // dedent to column 0 ends the block
+  }
+  return body.join("\n");
+}
+
+/** Parse the nested `_re_entry_guard:` block, or null when the key is absent. */
+function parseReEntryGuard(fm: string): ReEntryGuard | null {
+  const body = indentedBlock(fm, "_re_entry_guard");
+  if (body === null) return null;
+  const sub = (k: string): string | null => {
+    const m = new RegExp(`^\\s*${k}:\\s*(.+)$`, "m").exec(body);
+    return m ? m[1].trim().replace(/^["']|["']$/g, "") : null;
+  };
+  const guardKeys: string[] = [];
+  for (const line of body.split("\n")) {
+    const m = /^\s*(_[a-z_]+):/.exec(line);
+    if (m) guardKeys.push(m[1]);
+  }
+  return {
+    staleIfCompleted: sub("_stale_if_completed"),
+    staleArtifact: sub("_stale_artifact"),
+    onReentry: sub("_on_reentry"),
+    onConfirm: sub("_on_confirm"),
+    unknownKeys: guardKeys.filter((k) => !GUARD_KEYS.has(k)),
+  };
+}
+
 export function parsePhase(path: string, fm: string): PhaseFrontmatter {
   const assembleBlock = /_assemble:\s*\n\s*_file:\s*([^\n]+)/.exec(fm);
   const roleRaw = scalar(fm, "_kind");
@@ -100,6 +142,7 @@ export function parsePhase(path: string, fm: string): PhaseFrontmatter {
     assembleFile: assembleBlock ? assembleBlock[1].trim() : null,
     produces: blockList(fm, "_produces"),
     advancesTo: scalar(fm, "_advances_to"),
+    reEntryGuard: parseReEntryGuard(fm),
     unknownKeys: unknownAmong(fm, PHASE_KEYS),
   };
 }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -18,6 +18,15 @@ export interface FragmentRef {
   file: string; // path relative to the skill's references/ root
 }
 
+/** A phase's stale-downstream re-entry guard (see INTERPRETER.md § _re_entry_guard). */
+export interface ReEntryGuard {
+  staleIfCompleted: string | null; // _stale_if_completed — downstream phase whose completion blocks re-run
+  staleArtifact: string | null; // _stale_artifact — the artifact named in the GATE_FAIL field
+  onReentry: string | null; // _on_reentry — closed enum
+  onConfirm: string | null; // _on_confirm — closed enum
+  unknownKeys: string[]; // sub-keys not in the closed guard vocab
+}
+
 /** The phase orchestrator file's frontmatter. */
 export interface PhaseFrontmatter {
   kind: "phase";
@@ -34,6 +43,7 @@ export interface PhaseFrontmatter {
   assembleFile: string | null; // _assemble._file
   produces: string[];
   advancesTo: string | null;
+  reEntryGuard: ReEntryGuard | null; // _re_entry_guard (backbone phases with a downstream); null when absent
   unknownKeys: string[]; // top-level _keys not in the closed vocab
 }
 


### PR DESCRIPTION
## What

Moves the **stale-downstream re-entry guard** out of per-phase prose into a declarative `_re_entry_guard` frontmatter key, with `INTERPRETER.md` as the single source of truth for enforcement. This is the first frontmatter key that **drives** behavior (vs #91/#98/#99 which described structure).

## Vocab (closed sub-keys, all required when present)

```yaml
_re_entry_guard:
  _stale_if_completed: <downstream phase>    # equals _advances_to
  _stale_artifact:     <downstream artifact> # one of that phase's _produces
  _on_reentry:         stop_unless_confirmed
  _on_confirm:         reset_downstream_to_pending
```

`phase=` and `reason=stale_downstream` are **derived, not stored** — the interpreter reconstructs the `GATE_FAIL` line from `_phase` + the constant reason.

## Changes

- **discover / clarify / design**: prose guard blocks removed, replaced by frontmatter — **pure refactor, same behavior**.
- **estimate**: **net-new guard** added (guards `generate`). ⚠️ **This is the one behavior addition in the PR.** estimate never had a stale-downstream guard — confirmed via git history this was a *pre-existing gap*, not a decomposition regression. Added for a uniform backbone.
- Removed the redundant "Downstream artifacts stale (re-entry)" error-table rows; re-pointed discover Rule 5 + SKILL.md item 5 at `INTERPRETER.md § _re_entry_guard`.
- `shared/handoff-gates.md` **unchanged** — it is a symlink to the gcp-to-aws canonical copy; gcp is prose-driven and is deliberately left untouched.

## Validator

Extended the lean frontmatter validator (`tools/frontmatter-validator/` — types/parse/check) with the `_re_entry_guard` vocab + 6 structural checks: closed sub-vocab, required-together, enum membership, phase-ref resolves, `_stale_if_completed`⟺`_advances_to` consistency, `_stale_artifact`⟺downstream `_produces` (**hard fail**), and terminal-must-not-guard. 7 new `node:test` cases (good + each broken form). Confirms the incremental-extend pattern (#98 precedent) still beats porting the rich DSL validator.

## Verification

- `mise run build` green (lint + types + frontmatter validation + 21/21 tests + fmt:check + all security scans).
- **Cold-validated**: a read-only interpreter enforces the guard reading *only* the frontmatter + INTERPRETER — STOPs with the exact `GATE_FAIL | phase=design | field=estimation-infra.json | reason=stale_downstream` line on a stale downstream, and resets downstream→pending on confirm.

## Scope note

Same-phase **resume** (clarify's "Prior Run Check") is a *different mechanism* and is intentionally deferred to its own follow-up rung.
