### PR TITLE
refactor(heroku-to-aws): drop cross-session mid-batch resume from clarify

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
@@ -20,7 +20,7 @@ _produces:
 
 ## Step 4: Assemble and Write preferences.json
 
-Assemble all interpreted answers into the final `$MIGRATION_DIR/preferences.json`. If `preferences-draft.json` exists, use it as the base — merge in the final batch's answers, remove draft-specific metadata fields (`draft`, `batches_completed`, `batches_remaining`), and set timestamp to current time.
+Assemble all interpreted answers into the final `$MIGRATION_DIR/preferences.json` from the current session's answers. Set `metadata.timestamp` to the current time.
 
 Write `$MIGRATION_DIR/preferences.json`:
 
@@ -90,7 +90,7 @@ Write `$MIGRATION_DIR/preferences.json`:
 6. `network.existing_vpc_id` and `network.subnet_ids` are `null`/empty when no Private Space peering exists.
 7. `data.database_ha`, `data.redis_ha`, `data.kafka_retention_days` are omitted entirely when those services are not present in the inventory.
 
-After writing `preferences.json`, delete `$MIGRATION_DIR/preferences-draft.json` if it exists.
+After writing `preferences.json`, delete any stale `$MIGRATION_DIR/preferences-draft.json` left by an older skill version (drafts are no longer written or consumed).
 
 ---
 
@@ -116,7 +116,6 @@ Before handing off to Design:
 - [ ] `metadata.clarify_mode` is set to `"fast_path"` or `"full"`
 - [ ] Only keys with non-null values are present
 - [ ] Output is valid JSON
-- [ ] `preferences-draft.json` has been deleted (if it existed)
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-interview.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-interview.md
@@ -3,7 +3,6 @@ _fragment: interview
 _of_phase: clarify
 _contributes:
   - preferences.json (interpreted answers; created here, finalized by the assembler)
-  - preferences-draft.json (intermediate per-batch progress)
 ---
 
 # Clarify Phase: Adaptive Interview
@@ -32,17 +31,9 @@ Check `$MIGRATION_DIR/` for existing state:
 - If A: Skip to Validation Checklist with the existing `preferences.json`.
 - If B: Delete `preferences.json`, continue to Step 1.
 
-**Case 2 — Draft preferences exist** (`preferences-draft.json` present, no `preferences.json`):
-
-> "I found a partial set of answers from a previous session ([N] of [total] batches completed). Would you like to:"
->
-> A) Resume from where you left off — I'll pick up the remaining questions
-> B) Start fresh and re-answer all questions
-
-- If A: Load the draft, read `metadata.batches_completed` to determine which batches are done, skip completed batches when entering Step 3.
-- If B: Delete `preferences-draft.json`, continue to Step 1.
-
-**Case 3 — No prior state**: Continue to Step 1.
+**Case 2 — No prior state**: Continue to Step 1. (If a stale
+`preferences-draft.json` from an older skill version is present, delete it — the
+interview no longer resumes from drafts; it always runs to completion in one pass.)
 
 ---
 
@@ -162,7 +153,7 @@ Record the ordered list of active batches and count questions per batch after fi
 
 ### Batch Loop
 
-For each active batch, execute steps 3a–3d:
+For each active batch, execute steps 3a–3c:
 
 #### 3a. Present Batch
 
@@ -244,31 +235,6 @@ Re-prompt Q9 until valid input is provided.
 > "Invalid VPC ID format. Expected format: `vpc-xxxxxxxxxxxxxxxxx` (vpc- followed by 17 hexadecimal characters). Please provide your existing AWS VPC ID."
 
 Re-prompt Q9b until valid input is provided.
-
-#### 3d. Save Draft
-
-**If more batches remain** after this one: Write (or update) `$MIGRATION_DIR/preferences-draft.json` with all answers collected so far:
-
-```json
-{
-  "metadata": {
-    "draft": true,
-    "batches_completed": ["global"],
-    "batches_remaining": ["data_network", "operational"],
-    "timestamp": "<ISO timestamp>"
-  },
-  "global": { ... },
-  "data": { ... },
-  "network": { ... },
-  "operational": { ... }
-}
-```
-
-Batch name values: `"global"`, `"data_network"`, `"operational"`.
-
-Return to **3a** for the next batch.
-
-**If this was the last active batch**: Do not write a draft — proceed to Step 4 (the assembler, `clarify-assemble.md`).
 
 ---
 


### PR DESCRIPTION
## What

Removes the **cross-session mid-batch resume** mechanism (`preferences-draft.json`) from the clarify interview. ⚠️ **This is a UX feature removal, not a refactor** — flagged intentionally.

## Why

clarify is the *only* phase with resumable partial state, and it exists solely because clarify batches its questions. The draft was a durable cross-session mechanism (write + read + assembler-merge, threaded across two files) guarding an interruption that rarely happens — a user completes the ~minutes-long interview in one sitting. Removing it:

- eliminates a whole class of persistent state-handling, and
- removes a **latent correctness hazard**: the assembler previously *silently merged a stale draft onto fresh answers*, which could resurrect answers a user thought they'd discarded.

## Removed (the full three-part thread — no half-removal landmine)

- interview **Step 3d "Save Draft"** (per-batch write) — gone; the interview always runs to completion in one pass.
- interview **Step 0 Case 2** (resume-from-draft prompt) — gone; Case 3 renumbered to Case 2.
- interview `_contributes: preferences-draft.json` — gone.
- assembler **draft-merge clause** — gone (removes the stale-merge hazard); the assembler now builds `preferences.json` purely from the current session.
- assembler + validation-checklist **draft-delete items** — replaced by a defensive one-line cleanup of any *stale* draft left by an older skill version (inert legacy file).

## Behavior after

Abandon mid-clarify → **no draft is written** → next run finds no `preferences.json` and no draft → starts the interview fresh. No orphaned file, no silent merge.

**Unchanged:** completed-preferences reuse (Prior Run Check Case 1 — "reuse existing `preferences.json` or start fresh?"). That is legitimately clarify-specific: only clarify's regeneration cost is borne by the *user* (re-answering questions), so only clarify prompts. Other phases silently regenerate.

## Scope

No frontmatter/vocab change. `_re_entry_guard` (stale-downstream, #100) is a separate, unrelated mechanism and is untouched. 2 files, clarify-only, net −35 lines. `mise run build` green (frontmatter validation, 21/21 tests, fmt:check, security scans).
