### PR TITLE
feat(heroku-to-aws): migrate gate protocol to frontmatter (fixes review findings #1 + #2)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -22,6 +22,9 @@ runs entirely from its prose, as before.
 | `_produces`         | the artifact file(s) the phase writes                                                                                                                                                                                                                                           |
 | `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                    |
 | `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                    |
+| `_preconditions`    | the entry gate — an ordered list of checks that MUST pass before the phase does any work (predecessor completed, single active phase, inputs present/valid). See § Gate protocol.                                                                                               |
+| `_postconditions`   | the completion gate — an ordered list of checks that MUST pass before the phase is marked `completed` and control advances. See § Gate protocol.                                                                                                                                |
+| `_forbids_files`    | a glob list of files/dirs this phase MUST NOT create (scope boundary). See § Gate protocol.                                                                                                                                                                                     |
 
 ### `_trigger` forms
 
@@ -66,6 +69,86 @@ reconstruct the `GATE_FAIL` line from this phase's `_phase` plus the constant
 `stale_downstream` reason. This guard is the single source of truth for
 stale-downstream re-entry; there is no separate per-phase prose or shared-file
 table for it.
+
+## Gate protocol
+
+The LLM runs two gates around each phase, reading them from frontmatter. This is
+heroku-to-aws's own gate contract — phases do NOT load any shared gate file.
+
+### Check kinds (used in `_preconditions` and `_postconditions`)
+
+Each entry is a single check plus an `_on_failure` action (see the `_on_error`
+dictionary below). Closed vocabulary of check kinds:
+
+| Check                        | Arg                       | Passes when                                                    |
+| ---------------------------- | ------------------------- | -------------------------------------------------------------- |
+| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name> == "completed"`            |
+| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                        |
+| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                    |
+| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                           |
+| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts |
+
+`_assert` is the JUDGMENT escape hatch: arithmetic (e.g. the Property-16 total ==
+sum invariant), enum-membership over an artifact's runtime content (e.g.
+`recommendation.path ∈ {...}`), and conditionals (e.g. "if Postgres in inventory
+→ `database_ha` set") are `_assert` prose, NOT structured checks — CI cannot open a
+runtime artifact to verify them, so the interpreter evaluates them. CI validates
+only that the `_assert` form is well-formed, never the predicate's truth (same
+policy as `_when`).
+
+### `_on_error` actions
+
+Every `_on_failure:` names one of these. Each is an effect plus a phase-status
+transition:
+
+| Action              | Effect                                     | Phase status         |
+| ------------------- | ------------------------------------------ | -------------------- |
+| `_warn_and_skip`    | record a warning; skip this item; continue | remain `in_progress` |
+| `_default_and_warn` | apply a documented default; warn; continue | remain `in_progress` |
+| `_halt_and_inform`  | stop; surface a diagnostic to the user     | retain `in_progress` |
+| `_unrecoverable`    | stop; surface an error                     | revert to `pending`  |
+
+### `_preconditions` — the entry gate
+
+Before the phase does ANY work, run each `_preconditions` check in order. On a
+failure, apply that check's `_on_failure` action. A `_halt_and_inform` /
+`_unrecoverable` failure STOPS the phase (it does not proceed to its fragments).
+Only when all preconditions pass does the phase set itself `in_progress` and run.
+
+### `_postconditions` — the completion gate
+
+Before the phase is marked `"completed"` and control advances, **re-read the
+relevant artifacts from disk** (do not trust chat memory), then run each
+`_postconditions` check in order.
+
+- **On any failure:** apply the `_on_failure` action and emit exactly:
+
+  ```
+  GATE_FAIL | phase=<this phase's _phase> | field=<the failing file/field> | reason=<missing|invalid>
+  ```
+
+  Do NOT modify artifacts to force a gate to pass. Do NOT update
+  `.phase-status.json`. Do NOT advance. Tell the user which phase to re-run.
+
+- **On all-pass:** emit exactly:
+
+  ```
+  HANDOFF_OK | phase=<this phase's _phase> | artifacts=<comma-separated files verified>
+  ```
+
+  then update `.phase-status.json` (set this phase `"completed"`, set
+  `current_phase` to `_advances_to`, update the timestamp) in the same turn.
+
+`phase=` is reconstructed from the phase's own `_phase` (not stored in each check).
+The orchestrator (SKILL.md) MUST NOT load the next phase until it sees the
+`HANDOFF_OK` line; a completion message without it is not a valid handoff.
+
+### `_forbids_files` — scope boundary
+
+A glob list of files/directories the phase MUST NOT create. After the phase runs,
+if any path matching a `_forbids_files` glob was written, that is a scope
+violation — treat it as a `_postconditions` failure. This encodes the per-phase
+"do not emit README.md / *.txt / downstream artifacts" boundaries.
 
 ### Backbone vs checkpoint phases
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -102,7 +102,9 @@ This is the execution controller. After completing each phase, consult this tabl
 
 ### Handoff Gate Orchestration (Fail Closed)
 
-Load `references/shared/handoff-gates.md` when executing any phase completion step.
+Each phase's entry and completion gates are declared in its `_preconditions` /
+`_postconditions` frontmatter and enforced per `INTERPRETER.md` § Gate protocol (which
+also defines the `GATE_FAIL` / `HANDOFF_OK` line formats and the `_on_error` actions).
 
 1. **Single `$MIGRATION_DIR`**: Use one run directory for the entire migration. Do not mix artifacts across `.migration/*/` sessions.
 2. **Re-read from disk**: Before each phase (and before each handoff gate), Read required artifacts from `$MIGRATION_DIR/`. Do not rely on chat memory.
@@ -225,7 +227,7 @@ heroku-to-aws/
 │   │
 │   └── shared/                                 # References shared plugin infrastructure
 │       └── (path reference to ../gcp-to-aws/references/shared/)
-│           ├── handoff-gates.md                # Fail-closed phase handoff protocol
+│           ├── handoff-gates.md                # Shared gate protocol (NOT used by heroku-to-aws — heroku's gates live in phase `_preconditions`/`_postconditions` + INTERPRETER.md § Gate protocol)
 │           ├── schema-phase-status.md          # .phase-status.json schema
 │           ├── migration-complexity.md         # Complexity tier definitions (Small/Medium/Large)
 │           ├── schema-estimate-infra.md        # estimation-infra.json schema
@@ -267,9 +269,9 @@ When invoked, the agent **MUST follow this exact sequence**:
 
 4. **Execute ALL steps in order**: Follow every numbered step in the reference file. **Do not skip, optimize, or deviate.**
 
-5. **Validate outputs**: Confirm all required output files exist with correct schema before proceeding. Phase orchestrators run **Completion Handoff Gate** checks per `shared/handoff-gates.md`.
+5. **Validate outputs**: Confirm all required output files exist with correct schema before proceeding. Phase orchestrators run their `_postconditions` completion gate per `INTERPRETER.md` § Gate protocol.
 
-6. **Handoff gate**: Emit `HANDOFF_OK` or `GATE_FAIL` per `shared/handoff-gates.md`. On `GATE_FAIL`, stop — do not update phase status or load the next phase.
+6. **Handoff gate**: Emit `HANDOFF_OK` or `GATE_FAIL` per `INTERPRETER.md` § Gate protocol. On `GATE_FAIL`, stop — do not update phase status or load the next phase.
 
 7. **Update phase status**: Only after `HANDOFF_OK`. Use the Phase Status Update Protocol (read-merge-write) in the same turn as the phase's final output message.
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
@@ -121,21 +121,12 @@ Before handing off to Design:
 
 ## Completion Handoff Gate (Fail Closed)
 
-Load `shared/handoff-gates.md`. **Re-read from disk** before checking.
-
-**Checks (all must PASS):**
-
-1. `preferences.json` exists and parses as valid JSON.
-2. All Validation Checklist items pass.
-3. If `heroku-resource-inventory.json` contains Postgres add-ons → `data.database_ha` is set (non-null).
-4. If `heroku-resource-inventory.json` contains Postgres add-ons → `global.migration_approach` is set (non-null).
-5. If `global.migration_approach` is `interim_cutover_data_first` → `global.target_exit_date` is non-null and a valid future date.
-6. If Fir-generation apps detected → `global.fir_intent` is set (non-null).
-7. If Private Space peering detected and subnet IDs were required → `network.subnet_ids` is non-empty array.
-
-**On any FAIL:** Emit `GATE_FAIL | phase=clarify | field=<path> | reason=missing`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user to answer the missing question or re-run Clarify.
-
-**On PASS:** Emit `HANDOFF_OK | phase=clarify | artifacts=preferences.json`.
+The completion checks are declared in this phase's `_postconditions` frontmatter and
+enforced per `INTERPRETER.md` § Gate protocol: re-read `preferences.json` from disk, run
+the mechanical checks (`_check_file_exists` / `_validate_json`) and the `_assert`
+judgment checks (all Validation Checklist items; the Postgres/interim-cutover/Fir/
+private-space conditionals), then emit `GATE_FAIL` (STOP; do not patch artifacts) or
+`HANDOFF_OK | phase=clarify | artifacts=preferences.json` and advance.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
@@ -18,6 +18,35 @@ _re_entry_guard:
   _stale_artifact: aws-design.json
   _on_reentry: stop_unless_confirmed
   _on_confirm: reset_downstream_to_pending
+_preconditions:
+  - _check_phase_completed: discover
+    _on_failure: _halt_and_inform
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+  - _check_file_exists: heroku-resource-inventory.json
+    _on_failure: _unrecoverable
+  - _validate_json: heroku-resource-inventory.json
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: preferences.json
+    _on_failure: _halt_and_inform
+  - _validate_json: preferences.json
+    _on_failure: _halt_and_inform
+  - _assert: "all Validation Checklist items in clarify-assemble.md pass"
+    _on_failure: _halt_and_inform
+  - _assert: "if heroku-resource-inventory.json contains Postgres add-ons, then data.database_ha and global.migration_approach are both set (non-null)"
+    _on_failure: _halt_and_inform
+  - _assert: "if global.migration_approach is interim_cutover_data_first, then global.target_exit_date is non-null and a valid future date"
+    _on_failure: _halt_and_inform
+  - _assert: "if Fir-generation apps were detected, then global.fir_intent is set (non-null)"
+    _on_failure: _halt_and_inform
+  - _assert: "if Private Space peering was detected and subnet IDs were required, then network.subnet_ids is a non-empty array"
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - "*.txt"
+  - aws-design.json
+  - "terraform/**"
 ---
 
 # Phase 2: Clarify Requirements

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
@@ -51,25 +51,13 @@ Verify required artifacts exist in `$MIGRATION_DIR/`:
 
 ## Completion Handoff Gate (Fail Closed)
 
-Load `shared/handoff-gates.md`. **Re-read from disk** every artifact below before checking.
-
-**Checks (all must PASS):**
-
-1. `aws-design.json` exists and parses as valid JSON.
-2. `aws-design.json` has `phase == "design"` and a valid `timestamp`.
-3. `services[]` array is present (may be empty only if ALL resources deferred to specialist gate).
-4. Every entry in `services[]` has: `service_id`, `source_resource_id`, `heroku_app`, `aws_service`, `confidence`, `aws_config`.
-5. Every entry in `deferred[]` has: `addon_name`, `addon_plan`, `provider`, `reason`, `recommendation`.
-6. `vpc_design` section is present and has a valid `mode` value (`existing_vpc` or `new_vpc`).
-7. If `mode == "existing_vpc"`: `existing_vpc_id` is non-empty.
-8. If `mode == "new_vpc"`: at least 2 subnets present across separate AZs.
-9. `metadata.total_services` matches `services[].length`.
-10. No Fir-specific Terraform (ARM/Graviton, CNB) appears anywhere in output.
-11. Route output gates from Step 7 all pass.
-
-**On any FAIL:** Emit `GATE_FAIL | phase=design | field=<path> | reason=<missing|invalid>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user what failed and how to fix it.
-
-**On PASS:** Emit `HANDOFF_OK | phase=design | artifacts=aws-design.json`.
+The completion checks are declared in this phase's `_postconditions` frontmatter and
+enforced per `INTERPRETER.md` § Gate protocol: re-read `aws-design.json` from disk, run
+the mechanical checks (`_check_file_exists` / `_validate_json`) and the `_assert`
+judgment checks (phase/timestamp/services shape, per-entry required fields, vpc_design
+mode, total_services match, no Fir-specific Terraform), plus the route output gates from
+Step 7, then emit `GATE_FAIL` (STOP; do not patch artifacts) or
+`HANDOFF_OK | phase=design | artifacts=aws-design.json` and advance.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-mapping.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-mapping.md
@@ -21,17 +21,10 @@ _contributes:
 
 ## Step 0: Validate Prerequisites
 
-1. Read `$MIGRATION_DIR/.phase-status.json`. Validate per SKILL.md State Validation rules.
-2. Confirm `phases.clarify == "completed"`. If not → GATE_FAIL (Rule 1).
-3. Confirm no other core phase is `in_progress`. If violated → GATE_FAIL (Rule 2).
-4. Set `phases.design` to `"in_progress"` and `current_phase` to `"design"`. Write `.phase-status.json`.
-5. Read `$MIGRATION_DIR/heroku-resource-inventory.json` from disk.
-6. Read `$MIGRATION_DIR/preferences.json` from disk.
-7. Confirm both files exist and parse as valid JSON. If either is missing or invalid:
-
-```
-GATE_FAIL | phase=design | field=<filename> | reason=missing
-```
+The entry gate (clarify completed, single active phase, inputs present + valid JSON) is
+enforced by this phase's `_preconditions` frontmatter per `INTERPRETER.md` § Gate
+protocol. Once the preconditions pass, set `phases.design` to `"in_progress"` and
+`current_phase` to `"design"` in `.phase-status.json`, then proceed.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
@@ -22,6 +22,36 @@ _re_entry_guard:
   _stale_artifact: estimation-infra.json
   _on_reentry: stop_unless_confirmed
   _on_confirm: reset_downstream_to_pending
+_preconditions:
+  - _check_phase_completed: clarify
+    _on_failure: _halt_and_inform
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+  - _check_file_exists: [heroku-resource-inventory.json, preferences.json]
+    _on_failure: _unrecoverable
+  - _validate_json: [heroku-resource-inventory.json, preferences.json]
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: aws-design.json
+    _on_failure: _halt_and_inform
+  - _validate_json: aws-design.json
+    _on_failure: _halt_and_inform
+  - _assert: "aws-design.json has phase == 'design' and a valid timestamp; services[] is present (empty only if all resources deferred)"
+    _on_failure: _halt_and_inform
+  - _assert: "every services[] entry has service_id, source_resource_id, heroku_app, aws_service, confidence, aws_config; every deferred[] entry has addon_name, addon_plan, provider, reason, recommendation"
+    _on_failure: _halt_and_inform
+  - _assert: "vpc_design is present with a valid mode (existing_vpc or new_vpc); if existing_vpc then existing_vpc_id is non-empty; if new_vpc then at least 2 subnets across separate AZs"
+    _on_failure: _halt_and_inform
+  - _assert: "metadata.total_services matches services[].length"
+    _on_failure: _halt_and_inform
+  - _assert: "no Fir-specific Terraform (ARM/Graviton, CNB) appears anywhere in output"
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - "*.txt"
+  - "terraform/**"
+  - MIGRATION_GUIDE.md
+  - estimation-infra.json
 ---
 
 # Phase 3: Design AWS Architecture

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -20,6 +20,27 @@ _re_entry_guard:
   _stale_artifact: preferences.json
   _on_reentry: stop_unless_confirmed
   _on_confirm: reset_downstream_to_pending
+_preconditions:
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+  - _assert: "at least one .tf file containing a heroku_* resource exists in the workspace"
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: heroku-resource-inventory.json
+    _on_failure: _halt_and_inform
+  - _validate_json: heroku-resource-inventory.json
+    _on_failure: _halt_and_inform
+  - _assert: "heroku-resource-inventory.json has at least one resource entry, and metadata has discovery_timestamp and total_apps_discovered set"
+    _on_failure: _halt_and_inform
+  - _assert: "every resource in resources[] has resource_id, resource_type, heroku_app, and config fields"
+    _on_failure: _halt_and_inform
+  - _assert: "no forbidden clustering fields are present (cluster_id, creation_order_depth, edges, dependencies, must_migrate_together)"
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - discovery-summary.md
+  - "*.txt"
+  - "terraform/**"
 ---
 
 # Phase 1: Discover Heroku Resources
@@ -195,19 +216,13 @@ Verify required artifacts exist in `$MIGRATION_DIR/`:
 
 ## Completion Handoff Gate (Fail Closed)
 
-Load `shared/handoff-gates.md`. **Re-read from disk** every artifact below before checking.
-
-**Checks (all must PASS):**
-
-1. `heroku-resource-inventory.json` exists with at least one resource entry.
-2. Inventory metadata has `discovery_timestamp` and `total_apps_discovered` set.
-3. Every resource in the `resources` array has `resource_id`, `resource_type`, `heroku_app`, and `config` fields.
-4. No forbidden clustering fields present (`cluster_id`, `creation_order_depth`, `edges`, `dependencies`, `must_migrate_together`).
-5. Route output gates from Step 4 all pass.
-
-**On any FAIL:** Emit `GATE_FAIL | phase=discover | field=<path> | reason=<missing|invalid>`. **Do NOT modify artifacts to pass the gate.** **Do NOT update `.phase-status.json`.** Tell the user which sub-discovery to re-run.
-
-**On PASS:** Emit `HANDOFF_OK | phase=discover | artifacts=<comma-separated list of files verified>`.
+The completion checks are declared in this phase's `_postconditions` frontmatter and
+enforced per `INTERPRETER.md` § Gate protocol: re-read `heroku-resource-inventory.json`
+from disk, run the mechanical checks (`_check_file_exists` / `_validate_json`) and the
+`_assert` judgment checks (at least one resource + required metadata, per-resource
+fields, no forbidden clustering fields), plus the route output gates from Step 4, then
+emit `GATE_FAIL` (STOP; do not patch artifacts) or
+`HANDOFF_OK | phase=discover | artifacts=<files verified>` and advance.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
@@ -89,29 +89,16 @@ Write to `$MIGRATION_DIR/estimation-infra.json`.
 
 ## Completion Handoff Gate (Fail Closed)
 
-Load `shared/handoff-gates.md`. **Re-read from disk** before checking.
+The completion checks are declared in this phase's `_postconditions` frontmatter
+and enforced per `INTERPRETER.md` § Gate protocol: **re-read `estimation-infra.json`
+from disk**, run the mechanical checks (`_check_file_exists` / `_validate_json`) and
+the `_assert` judgment checks (recommendation shape, the Property-16 total-invariant,
+every-service-priced, complexity tier), then emit `GATE_FAIL` (do NOT patch artifacts;
+STOP) or `HANDOFF_OK | phase=estimate | artifacts=estimation-infra.json` and advance.
 
-Before returning control to SKILL.md, require:
-
-1. `estimation-infra.json` exists in `$MIGRATION_DIR/`
-2. Valid JSON that passes `shared/schema-estimate-infra.md` validation
-3. `recommendation.path` ∈ `{migrate_optimized, migrate_phased, stay}`
-4. `recommendation.path_label` is non-empty string
-5. `recommendation.migrate_if` and `recommendation.stay_if` are non-empty arrays
-6. `projected_costs.aws_monthly_balanced` is a positive number
-7. Every service in `aws-design.json → services[]` appears in the cost breakdown (or is listed as `"unpriced"` in warnings)
-8. Total equals sum of individual resource costs (excluding unpriced) — **Property 16 invariant**
-9. `complexity_tier` is one of: `"small"`, `"medium"`, `"large"`
-
-**On FAIL:** Emit `GATE_FAIL | phase=estimate | field=<path> | reason=<reason>`. **Do NOT modify artifacts to pass the gate.** STOP.
-
-**On PASS:** Emit `HANDOFF_OK | phase=estimate | artifacts=estimation-infra.json`.
-
-After `HANDOFF_OK`, use the Phase Status Update Protocol (read-merge-write) to update `.phase-status.json`:
-
-- Set `phases.estimate` to `"completed"`
-- Set `current_phase` to `"generate"`
-- Update `last_updated` timestamp
+One check needs this fragment's context: `estimation-infra.json` must also pass
+`shared/schema-estimate-infra.md` validation (the schema shape) — verify that as part
+of the `_validate_json` postcondition.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
@@ -62,17 +62,14 @@ For typical Heroku migrations (Fargate, RDS, Aurora, ElastiCache, ALB, NAT Gatew
 
 ## Step 1: Prerequisites
 
-1. Read `$MIGRATION_DIR/.phase-status.json`. If `phases.design` is not exactly `"completed"`: **STOP**. Output: "Phase 3 (Design) not completed. Run Phase 3 first."
-2. Read `$MIGRATION_DIR/aws-design.json`. If missing or invalid JSON: **STOP**. Output: "Design artifact missing or corrupted. Re-run Phase 3."
-3. Read `$MIGRATION_DIR/preferences.json`. If missing: **STOP**. Output: "Preferences file missing. Re-run Phase 2."
-4. Read `$MIGRATION_DIR/heroku-resource-inventory.json`. Extract `billing_profile` section (may be null/absent).
+The entry gate (design completed, inputs present + valid JSON, non-empty
+`services[]`) is enforced by this phase's `_preconditions` frontmatter per
+`INTERPRETER.md` § Gate protocol — it has already passed before this fragment
+runs. Then:
 
-### Validate Design
+1. Read `$MIGRATION_DIR/heroku-resource-inventory.json`. Extract `billing_profile` section (may be null/absent).
 
-- `services` array must exist and not be empty. If empty: **STOP**. Output: "No services in design. Re-run Phase 3."
-- Each service entry must have `aws_service` and `aws_config` fields. If missing: **STOP**. Output: "Service [service_id] missing aws_service or aws_config. Re-run Phase 3."
-
-If all validations pass, proceed to Part 1.
+Proceed to Part 1.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -20,6 +20,40 @@ _re_entry_guard:
   _stale_artifact: generation-warnings.json
   _on_reentry: stop_unless_confirmed
   _on_confirm: reset_downstream_to_pending
+_preconditions:
+  - _check_phase_completed: design
+    _on_failure: _halt_and_inform
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+  - _check_file_exists: [aws-design.json, preferences.json, heroku-resource-inventory.json]
+    _on_failure: _unrecoverable
+  - _validate_json: [aws-design.json, preferences.json]
+    _on_failure: _unrecoverable
+  - _assert: "aws-design.json services[] exists and is non-empty, and every entry has aws_service and aws_config"
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: estimation-infra.json
+    _on_failure: _halt_and_inform
+  - _validate_json: estimation-infra.json
+    _on_failure: _halt_and_inform
+  - _assert: "recommendation.path is one of {migrate_optimized, migrate_phased, stay} and recommendation.path_label is a non-empty string"
+    _on_failure: _halt_and_inform
+  - _assert: "recommendation.migrate_if and recommendation.stay_if are non-empty arrays"
+    _on_failure: _halt_and_inform
+  - _assert: "projected_costs.aws_monthly_balanced is a positive number"
+    _on_failure: _halt_and_inform
+  - _assert: "every service in aws-design.json services[] appears in the cost breakdown, or is listed as 'unpriced' in warnings"
+    _on_failure: _halt_and_inform
+  - _assert: "the balanced total equals the arithmetic sum of the per-service costs, excluding unpriced (Property-16 invariant)"
+    _on_failure: _halt_and_inform
+  - _assert: "complexity_tier is one of {small, medium, large}"
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - "*.txt"
+  - "terraform/**"
+  - "kubernetes/**"
+  - MIGRATION_GUIDE.md
 ---
 
 # Phase 4: Estimate AWS Costs

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
@@ -14,6 +14,18 @@ _assemble:
 _produces:
   - feedback.json
   - trace.json
+_preconditions:
+  - _check_phase_completed: discover
+    _on_failure: _halt_and_inform
+_postconditions:
+  - _check_file_exists: feedback.json
+    _on_failure: _warn_and_skip
+  - _validate_json: feedback.json
+    _on_failure: _warn_and_skip
+_forbids_files:
+  - README.md
+  - "*.txt"
+  - "terraform/**"
 ---
 
 # Phase 6: Feedback (Optional)

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -45,26 +45,14 @@ Load `shared/validate-artifacts.md`. Verify the complete set of generated artifa
 
 ## Completion Handoff Gate (Fail Closed)
 
-Load `shared/handoff-gates.md`. **Re-read from disk** before checking.
-
-**Checks (all must PASS):**
-
-1. `terraform/main.tf` exists with valid provider configuration
-2. `terraform/variables.tf` exists with at least `aws_region` variable
-3. `terraform/outputs.tf` exists
-4. At least one domain `.tf` file exists beyond core files
-5. `MIGRATION_GUIDE.md` exists with Prerequisites and Verification sections
-6. `README.md` exists with artifact listing
-7. If Postgres in design → `scripts/migrate-postgres.sh` exists
-8. If Redis in design → `scripts/migrate-redis.sh` exists
-9. Every designed service accounted for (generated or in warnings)
-10. If EKS in design → `terraform/eks.tf` exists with cluster + node group resources
-11. If EKS in design → `kubernetes/` directory exists with namespace + deployment manifests
-12. No placeholder `{{VARIABLE}}` in Terraform `.tf` files (those belong in `variables.tf` as proper `var.*` references)
-
-**On any FAIL:** Emit `GATE_FAIL | phase=generate | field=<path> | reason=<missing|invalid>`. STOP.
-
-**On PASS:** Emit `HANDOFF_OK | phase=generate | artifacts=terraform/,MIGRATION_GUIDE.md,README.md`.
+The completion checks are declared in this phase's `_postconditions` frontmatter and
+enforced per `INTERPRETER.md` § Gate protocol: re-read the generated artifacts from
+disk, run the mechanical checks (`_check_file_exists` for the core terraform files +
+MIGRATION_GUIDE.md + README.md) and the `_assert` judgment checks (valid provider /
+aws_region variable, a domain .tf beyond core, guide sections, conditional Postgres/
+Redis migration scripts, conditional EKS terraform + kubernetes manifests, every service
+accounted for, no `{{VARIABLE}}` placeholders), then emit `GATE_FAIL` (STOP) or
+`HANDOFF_OK | phase=generate | artifacts=terraform/,MIGRATION_GUIDE.md,README.md`.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -4,7 +4,6 @@ _of_phase: generate
 _contributes:
   - MIGRATION_GUIDE.md
   - README.md
-  - scripts/ (database migration scripts, conditional on design content)
 ---
 
 # Generate Phase: Documentation and Script Generation

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -2,8 +2,10 @@
 _fragment: terraform
 _of_phase: generate
 _contributes:
-  - terraform/ (all .tf files)
-  - generation-warnings.json (services skipped during terraform generation)
+  - terraform/main.tf
+  - terraform/variables.tf
+  - terraform/outputs.tf
+  - generation-warnings.json
 ---
 
 # Generate Phase: Terraform Configuration Generation

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -20,8 +20,39 @@ _fragments:
 _assemble:
   _file: phases/generate/generate-assemble.md
 _produces:
+  - terraform/main.tf
+  - terraform/variables.tf
+  - terraform/outputs.tf
+  - MIGRATION_GUIDE.md
+  - README.md
   - generation-warnings.json
 _advances_to: complete
+_preconditions:
+  - _check_phase_completed: estimate
+    _on_failure: _halt_and_inform
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+  - _check_file_exists: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
+    _on_failure: _unrecoverable
+  - _validate_json: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, MIGRATION_GUIDE.md, README.md]
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/main.tf has valid provider configuration; terraform/variables.tf declares at least an aws_region variable"
+    _on_failure: _halt_and_inform
+  - _assert: "at least one domain .tf file exists beyond the core files"
+    _on_failure: _halt_and_inform
+  - _assert: "MIGRATION_GUIDE.md has Prerequisites and Verification sections; README.md lists the artifacts"
+    _on_failure: _halt_and_inform
+  - _assert: "if Postgres is in the design, scripts/migrate-postgres.sh exists; if Redis is in the design, scripts/migrate-redis.sh exists"
+    _on_failure: _halt_and_inform
+  - _assert: "if EKS is in the design, terraform/eks.tf exists with cluster + node group resources AND a kubernetes/ directory has namespace + deployment manifests"
+    _on_failure: _halt_and_inform
+  - _assert: "every designed service is accounted for (generated or listed in generation-warnings.json)"
+    _on_failure: _halt_and_inform
+  - _assert: "no placeholder {{VARIABLE}} tokens remain in Terraform .tf files (those belong in variables.tf as var.* references)"
+    _on_failure: _halt_and_inform
 ---
 
 # Phase 5: Generate Migration Artifacts
@@ -41,25 +72,10 @@ _advances_to: complete
 
 ## Step 0: Validate Prerequisites
 
-1. Read `$MIGRATION_DIR/.phase-status.json`. Validate per SKILL.md State Validation rules.
-2. Confirm `phases.estimate == "completed"`. If not:
-
-   ```
-   GATE_FAIL | phase=generate | field=phases.estimate | reason=missing
-   ```
-
-3. Confirm no other core phase is `in_progress`. If violated → GATE_FAIL.
-4. Set `phases.generate` to `"in_progress"` and `current_phase` to `"generate"`. Write `.phase-status.json`.
-5. Read all required artifacts from `$MIGRATION_DIR/`:
-   - `aws-design.json` (REQUIRED)
-   - `estimation-infra.json` (REQUIRED)
-   - `preferences.json` (REQUIRED)
-   - `heroku-resource-inventory.json` (REQUIRED)
-6. Confirm all four files exist and parse as valid JSON. If any missing:
-
-   ```
-   GATE_FAIL | phase=generate | field=<filename> | reason=missing
-   ```
+The entry gate (estimate completed, single active phase, all four inputs present + valid
+JSON) is enforced by this phase's `_preconditions` frontmatter per `INTERPRETER.md`
+§ Gate protocol. Once the preconditions pass, set `phases.generate` to `"in_progress"`
+and `current_phase` to `"generate"` in `.phase-status.json`, then proceed.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -330,4 +330,71 @@ _produces:
     const findings = validateFixture(files);
     assert.match(findings.map((f) => f.message).join('\n'), /has a _re_entry_guard but no downstream backbone phase/);
   });
+
+  // ---- _preconditions / _postconditions / _forbids_files ----
+
+  // Attach a gate block to discover (which _produces discover.json in chainSkill).
+  function gatesOnDiscover(gates: string): Record<string, string> {
+    const files = chainSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', `_advances_to: clarify\n${gates}`);
+    return files;
+  }
+
+  const GOOD_GATES =
+    '_preconditions:\n' +
+    '  - _check_single_active_phase: true\n' +
+    '    _on_failure: _halt_and_inform\n' +
+    '  - _assert: "a heroku_* resource exists"\n' +
+    '    _on_failure: _unrecoverable\n' +
+    '_postconditions:\n' +
+    '  - _check_file_exists: discover.json\n' +
+    '    _on_failure: _halt_and_inform\n' +
+    '  - _assert: "inventory has at least one resource"\n' +
+    '    _on_failure: _halt_and_inform';
+
+  it('accepts well-formed _preconditions / _postconditions', () => {
+    const findings = validateFixture(gatesOnDiscover(GOOD_GATES));
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects an unknown check kind', () => {
+    const findings = validateFixture(
+      gatesOnDiscover(GOOD_GATES.replace('_check_single_active_phase', '_check_vibes')),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /unknown _preconditions check kind '_check_vibes'/);
+  });
+
+  it('rejects an unrecognized _on_failure action', () => {
+    const findings = validateFixture(
+      gatesOnDiscover(GOOD_GATES.replace('_unrecoverable', '_explode')),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /unrecognized _on_failure action '_explode'/);
+  });
+
+  it('rejects a _check_phase_completed naming no declared phase', () => {
+    const findings = validateFixture(
+      gatesOnDiscover(
+        '_preconditions:\n  - _check_phase_completed: nonesuch\n    _on_failure: _halt_and_inform',
+      ),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /_check_phase_completed 'nonesuch' names no declared phase/);
+  });
+
+  it('rejects a _postconditions file-exists not in _produces (finding-#2 cross-check)', () => {
+    const findings = validateFixture(
+      gatesOnDiscover(
+        '_postconditions:\n  - _check_file_exists: not-produced.json\n    _on_failure: _halt_and_inform',
+      ),
+    );
+    assert.match(findings.map((f) => f.message).join('\n'), /_check_file_exists 'not-produced.json' but it is not in this phase's _produces/);
+  });
+
+  it('accepts _forbids_files as a glob list', () => {
+    const findings = validateFixture(
+      gatesOnDiscover('_forbids_files:\n  - README.md\n  - "*.txt"'),
+    );
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
 });

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.ts";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { CHECK_KINDS, ON_ERROR_ACTIONS } from "./parse.ts";
 
 export interface BoundSkill {
   /** absolute path to the skill's `references/` root (where phase _file paths resolve). */
@@ -109,10 +110,18 @@ export function check(skill: BoundSkill): Finding[] {
     if (asm.ofPhase !== phase.phase) {
       add(skill.rel(apath), `_of_phase '${asm.ofPhase || "(missing)"}' != '${phase.phase}'`);
     }
-    // single-creator: everything the phase _produces must be created by the assembler.
+    // single-creator: everything the phase _produces must be declared by exactly one
+    // unit — the assembler's _produces OR a fragment's _contributes. (Most phases have
+    // an assembler-only creator; generate's artifacts are fragment-created, so we union
+    // the fragment contributions.)
+    const contributed = new Set<string>(asm.produces);
+    for (const fr of phase.fragments) {
+      const frag = skill.fragments.get(join(skill.referencesRoot, fr.file));
+      if (frag) for (const art of frag.contributes) contributed.add(art);
+    }
     for (const art of phase.produces) {
-      if (!asm.produces.includes(art)) {
-        add(pf, `phase _produces '${art}' but the assembler does not declare it in _produces (single-creator rule)`);
+      if (!contributed.has(art)) {
+        add(pf, `phase _produces '${art}' but no unit (assembler _produces or a fragment _contributes) declares it (single-creator rule)`);
       }
     }
   }
@@ -171,6 +180,43 @@ export function check(skill: BoundSkill): Finding[] {
       const downstream = phasesByName.get(g.staleIfCompleted);
       if (downstream && !downstream.produces.includes(g.staleArtifact)) {
         add(pf, `_re_entry_guard._stale_artifact '${g.staleArtifact}' is not in the _produces of the downstream phase '${g.staleIfCompleted}' (declared: ${downstream.produces.join(", ") || "(none)"})`);
+      }
+    }
+  }
+
+  // ---- Gate checks: _preconditions / _postconditions / _forbids_files ----
+  // (INTERPRETER.md § Gate protocol.) Structural only: closed check-kind vocab,
+  // _on_failure action membership, phase-ref resolution, and the postcondition⟺
+  // _produces cross-check. _assert bodies are opaque prose (bound, not evaluated).
+  for (const phase of skill.phases) {
+    const pf = skill.rel(phase.sourceFile);
+    const checkList = (items: typeof phase.preconditions, label: string) => {
+      for (const c of items) {
+        if (!CHECK_KINDS.has(c.kind)) {
+          add(pf, `unknown ${label} check kind '${c.kind}' (allowed: ${[...CHECK_KINDS].join(", ")})`);
+        }
+        if (c.onFailure && !ON_ERROR_ACTIONS.has(c.onFailure)) {
+          add(pf, `${label} check '${c.kind}' has an unrecognized _on_failure action '${c.onFailure}' (allowed: ${[...ON_ERROR_ACTIONS].join(", ")})`);
+        }
+        // _check_phase_completed arg SHOULD name a declared phase (partial-rollout tolerant).
+        if (c.kind === "_check_phase_completed" && c.arg[0] && declaredPhases.size > 1 && !declaredPhases.has(c.arg[0])) {
+          add(pf, `${label} _check_phase_completed '${c.arg[0]}' names no declared phase`);
+        }
+      }
+    };
+    checkList(phase.preconditions, "_preconditions");
+    checkList(phase.postconditions, "_postconditions");
+
+    // postcondition file-exists ⟺ _produces (HARD FAIL): a phase can only assert the
+    // existence of a file it declares it produces — forces _produces to be the real
+    // artifact set (guards against a hollow _produces).
+    for (const c of phase.postconditions) {
+      if (c.kind === "_check_file_exists") {
+        for (const f of c.arg) {
+          if (!phase.produces.includes(f)) {
+            add(pf, `_postconditions asserts _check_file_exists '${f}' but it is not in this phase's _produces (declared: ${phase.produces.join(", ") || "(none)"}) — a phase may only gate on artifacts it declares it produces`);
+          }
+        }
       }
     }
   }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -5,6 +5,7 @@
 
 import type {
   AssemblerFrontmatter,
+  CheckItem,
   FragmentFrontmatter,
   FragmentRef,
   PhaseFrontmatter,
@@ -16,7 +17,16 @@ import { readFileSync } from "node:fs";
 const PHASE_KEYS = new Set([
   "_phase", "_title", "_kind", "_requires_phase", "_init", "_input",
   "_fragments", "_trigger", "_assemble", "_produces", "_advances_to",
-  "_re_entry_guard",
+  "_re_entry_guard", "_preconditions", "_postconditions", "_forbids_files",
+]);
+/** The closed vocabulary of check kinds usable in _preconditions/_postconditions. */
+export const CHECK_KINDS = new Set([
+  "_check_phase_completed", "_check_single_active_phase", "_check_file_exists",
+  "_validate_json", "_assert",
+]);
+/** The closed vocabulary of _on_failure / _on_error actions. */
+export const ON_ERROR_ACTIONS = new Set([
+  "_warn_and_skip", "_default_and_warn", "_halt_and_inform", "_unrecoverable",
 ]);
 const GUARD_KEYS = new Set([
   "_stale_if_completed", "_stale_artifact", "_on_reentry", "_on_confirm",
@@ -122,6 +132,49 @@ function parseReEntryGuard(fm: string): ReEntryGuard | null {
   };
 }
 
+/** Parse a `_preconditions` / `_postconditions` list into CheckItems. Each list item
+ * is `- <check_kind>: <arg>` optionally followed by an `_on_failure: <action>` line. */
+function parseChecks(fm: string, key: string): CheckItem[] {
+  const body = indentedBlock(fm, key);
+  if (body === null) return [];
+  const out: CheckItem[] = [];
+  // Split into items on lines beginning (after indent) with `- `.
+  const lines = body.split("\n");
+  let cur: string[] | null = null;
+  const items: string[][] = [];
+  for (const line of lines) {
+    if (/^\s*-\s+/.test(line)) {
+      if (cur) items.push(cur);
+      cur = [line];
+    } else if (cur && line.trim() !== "") {
+      cur.push(line);
+    }
+  }
+  if (cur) items.push(cur);
+
+  for (const item of items) {
+    const joined = item.join("\n");
+    // the check keyword is the first `_<kind>:` after the leading `- `
+    const km = /^\s*-\s+(_[a-z_]+):\s*(.*)$/m.exec(item[0]);
+    if (!km) continue;
+    const kind = km[1];
+    const rawArg = km[2].trim();
+    let arg: string[];
+    if (kind === "_assert") {
+      arg = [rawArg.replace(/^["']|["']$/g, "")]; // opaque prose (bound, not evaluated)
+    } else if (rawArg.startsWith("[")) {
+      arg = rawArg.replace(/^\[|\]$/g, "").split(",").map((s) => s.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+    } else if (rawArg === "" || rawArg === "true") {
+      arg = rawArg === "true" ? ["true"] : [];
+    } else {
+      arg = [rawArg.replace(/^["']|["']$/g, "")];
+    }
+    const om = /_on_failure:\s*(_[a-z_]+)/.exec(joined);
+    out.push({ kind, arg, onFailure: om ? om[1] : null });
+  }
+  return out;
+}
+
 export function parsePhase(path: string, fm: string): PhaseFrontmatter {
   const assembleBlock = /_assemble:\s*\n\s*_file:\s*([^\n]+)/.exec(fm);
   const roleRaw = scalar(fm, "_kind");
@@ -143,6 +196,9 @@ export function parsePhase(path: string, fm: string): PhaseFrontmatter {
     produces: blockList(fm, "_produces"),
     advancesTo: scalar(fm, "_advances_to"),
     reEntryGuard: parseReEntryGuard(fm),
+    preconditions: parseChecks(fm, "_preconditions"),
+    postconditions: parseChecks(fm, "_postconditions"),
+    forbidsFiles: blockList(fm, "_forbids_files"),
     unknownKeys: unknownAmong(fm, PHASE_KEYS),
   };
 }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -27,6 +27,13 @@ export interface ReEntryGuard {
   unknownKeys: string[]; // sub-keys not in the closed guard vocab
 }
 
+/** One check in a `_preconditions` / `_postconditions` list. */
+export interface CheckItem {
+  kind: string; // the check keyword: _check_phase_completed | _check_single_active_phase | _check_file_exists | _validate_json | _assert (or an unknown keyword → flagged)
+  arg: string[]; // normalized args (phase name / filenames / [] for _assert / the assert prose)
+  onFailure: string | null; // _on_failure action name
+}
+
 /** The phase orchestrator file's frontmatter. */
 export interface PhaseFrontmatter {
   kind: "phase";
@@ -44,6 +51,9 @@ export interface PhaseFrontmatter {
   produces: string[];
   advancesTo: string | null;
   reEntryGuard: ReEntryGuard | null; // _re_entry_guard (backbone phases with a downstream); null when absent
+  preconditions: CheckItem[]; // _preconditions (entry gate); empty when absent
+  postconditions: CheckItem[]; // _postconditions (completion gate); empty when absent
+  forbidsFiles: string[]; // _forbids_files globs; empty when absent
   unknownKeys: string[]; // top-level _keys not in the closed vocab
 }
 


### PR DESCRIPTION
## What

Migrates each phase's **entry gate** (Step 0 prerequisites) and **completion gate** (Completion Handoff Gate checks) out of prose into declarative frontmatter, with `INTERPRETER.md § Gate protocol` as the single source of truth. This is the gate half of the handoff-gates rung (re-entry shipped in #100).

## New vocab (`INTERPRETER.md § Gate protocol`)

- **`_preconditions` / `_postconditions`** — ordered lists of checks, each with an `_on_failure` action. Closed CHECK vocabulary:
  - `_check_phase_completed`, `_check_single_active_phase`, `_check_file_exists`, `_validate_json` (mechanical, CI-shaped)
  - `_assert` — the **judgment escape hatch**: arithmetic (Property-16 total==sum), enum-over-artifact-content (`recommendation.path ∈ {...}`), and conditionals ("if Postgres → database_ha set") stay `_assert` prose the LLM evaluates — NOT structured checks. CI can't open a runtime artifact, so it validates only the form (same policy as `_when`).
- **`_on_error` action dictionary** (defined once in INTERPRETER, referenced by name): `_warn_and_skip` / `_default_and_warn` / `_halt_and_inform` / `_unrecoverable`.
- **`_forbids_files`** — scope-boundary "must NOT create" globs.

## Fixes review finding #1 (the reason for the rung)

Heroku phases **no longer `Load shared/handoff-gates.md`** — the gate protocol + `GATE_FAIL`/`HANDOFF_OK` formats now live in INTERPRETER.md. Since heroku no longer references the shared gate file, the gcp-canonical prose **re-entry table** (reached via the symlink) can no longer contradict `_re_entry_guard`. **GCP is untouched** — it keeps its file, its symlink target, and its prose-driven model. Removed the `Load` instruction from every phase completion-gate + Step-0 block and from SKILL.md.

## Fixes review finding #2 (byproduct)

`generate._produces` was a hollow `[generation-warnings.json]` (a conditional side-file) while the phase actually writes `terraform/*.tf` + `MIGRATION_GUIDE.md` + `README.md`. Now `_produces` names the real artifact set; the generate fragments' `_contributes` were normalized to exact filenames; and the single-creator check was generalized to union fragment `_contributes` with assembler `_produces` (generate's artifacts are fragment-created, not assembler-created).

## Validator (extended, not ported)

Added `_preconditions`/`_postconditions`/`_forbids_files` to types/parse/check. New checks: closed check-kind vocab, `_on_failure` action membership, `_check_phase_completed` phase-ref resolution, and a **hard-fail cross-check** that every `_postconditions._check_file_exists` file is in the phase's `_produces` (locks finding #2 fixed). +6 `node:test` cases (27 total).

## Verification

- `mise run build` green (frontmatter validation, tsc, 27/27 tests, fmt:check, all security scans).
- **Cold-validated twice** (read-only interpreter, frontmatter + INTERPRETER only, no shared gate file present):
  - *estimate* — entry gate halts on design-incomplete; completion gate enforces Property-16 as an `_assert` judgment, emits `GATE_FAIL`, does not advance or patch the artifact; all-pass emits `HANDOFF_OK` and advances.
  - *generate* — reads `_produces` as the real deliverables, splits mechanical vs `_assert` correctly, advances to `complete`.
  - Neither run looked for or complained about a missing `shared/handoff-gates.md`.

## Scope

20 files, all heroku-to-aws + the shared validator. Zero gcp changes.
