### PR TITLE
feat(heroku-to-aws): declare _knowledge data deps + validate _input resolution

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
@@ -5,6 +5,13 @@ _requires_phase: clarify
 _input:
   - heroku-resource-inventory.json
   - preferences.json
+_knowledge:
+  - { file: knowledge/design/dyno-fargate-sizing.json, _when: "inventory has a formation AND design_constraints.kubernetes.value is ecs-fargate or absent" }
+  - { file: knowledge/design/eks-pod-sizing.json, _when: "inventory has a formation AND design_constraints.kubernetes.value is eks-managed or eks-or-ecs" }
+  - { file: knowledge/design/postgres-rds-sizing.json, _when: "inventory has a heroku-postgresql addon" }
+  - { file: knowledge/design/redis-elasticache-sizing.json, _when: "inventory has a heroku-redis addon" }
+  - { file: knowledge/design/kafka-msk-sizing.json, _when: "inventory has a heroku-kafka addon" }
+  - { file: knowledge/design/fast-path-addons.json, _when: "inventory has a non-core addon (not postgresql/redis/kafka)" }
 _fragments:
   - _id: mapping-engine
     _trigger: { _always: true }

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -6,6 +6,9 @@ _input:
   - aws-design.json
   - preferences.json
   - heroku-resource-inventory.json
+_knowledge:
+  - { file: knowledge/estimate/estimate-defaults.json }
+  - { file: ../shared/pricing/aws-infra-pricing.json }
 _fragments:
   - _id: cost-engine
     _trigger: { _always: true }

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -397,4 +397,57 @@ _produces:
     );
     assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
   });
+
+  // ---- _knowledge + _input resolution ----
+
+  it('accepts _knowledge whose file resolves on disk', () => {
+    const files = chainSkill();
+    files['knowledge/design/sizing.json'] = '{}';
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', '_advances_to: clarify\n_knowledge:\n  - { file: knowledge/design/sizing.json }');
+    const findings = validateFixture(files);
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects a _knowledge file that does not resolve', () => {
+    const files = chainSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', '_advances_to: clarify\n_knowledge:\n  - { file: knowledge/design/MISSING.json }');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /_knowledge file does not resolve: knowledge\/design\/MISSING\.json/);
+  });
+
+  it('accepts a _knowledge _when (opaque, not evaluated)', () => {
+    const files = chainSkill();
+    files['knowledge/x.json'] = '{}';
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', '_advances_to: clarify\n_knowledge:\n  - { file: knowledge/x.json, _when: "inventory has a formation" }');
+    const findings = validateFixture(files);
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('accepts _input resolving to an upstream _produces (and the workspace literal)', () => {
+    // chainSkill: discover _input workspace (add it), clarify reads discover.json
+    const files = chainSkill();
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_init: true', '_init: true\n_input: workspace');
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_requires_phase: discover\n_input:\n  - discover.json');
+    const findings = validateFixture(files);
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects an _input artifact produced by no phase', () => {
+    const files = chainSkill();
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_requires_phase: discover\n_input:\n  - nonexistent-artifact.json');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /_input 'nonexistent-artifact\.json' is not produced by any declared phase/);
+  });
 });

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -272,5 +272,34 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
 
+  // ---- _knowledge (JSON data deps resolve) + _input (resolves to an upstream _produces) ----
+  const skillRoot = join(skill.referencesRoot, "..");
+  // every artifact any declared phase produces (for _input resolution)
+  const allProduced = new Set<string>();
+  for (const p of skill.phases) for (const art of p.produces) allProduced.add(art);
+  const INPUT_LITERALS = new Set(["workspace"]);
+  const isGlob = (s: string) => /[*?{]/.test(s);
+
+  for (const phase of skill.phases) {
+    const pf = skill.rel(phase.sourceFile);
+
+    // _knowledge files must resolve on disk (relative to the skill root). _when opaque.
+    for (const k of phase.knowledge) {
+      if (!existsSync(join(skillRoot, k.file))) {
+        add(pf, `_knowledge file does not resolve: ${k.file}`);
+      }
+    }
+
+    // _input resolution: each entry is 'workspace', a glob (e.g. the phase-status file),
+    // or an artifact produced by some declared phase. Enforce the produced-by check only
+    // once >1 phase declares frontmatter (partial-rollout tolerant).
+    for (const inp of phase.input) {
+      if (INPUT_LITERALS.has(inp) || isGlob(inp)) continue;
+      if (declaredPhases.size > 1 && !allProduced.has(inp)) {
+        add(pf, `_input '${inp}' is not produced by any declared phase (no phase declares it in _produces)`);
+      }
+    }
+  }
+
   return findings;
 }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -8,6 +8,7 @@ import type {
   CheckItem,
   FragmentFrontmatter,
   FragmentRef,
+  KnowledgeRef,
   PhaseFrontmatter,
   ReEntryGuard,
   Trigger,
@@ -18,6 +19,7 @@ const PHASE_KEYS = new Set([
   "_phase", "_title", "_kind", "_requires_phase", "_init", "_input",
   "_fragments", "_trigger", "_assemble", "_produces", "_advances_to",
   "_re_entry_guard", "_preconditions", "_postconditions", "_forbids_files",
+  "_knowledge",
 ]);
 /** The closed vocabulary of check kinds usable in _preconditions/_postconditions. */
 export const CHECK_KINDS = new Set([
@@ -110,6 +112,34 @@ function indentedBlock(fm: string, key: string): string | null {
   return body.join("\n");
 }
 
+/** Parse `_input`: either a scalar (`workspace` / a quoted glob) or a block list. */
+function parseInput(fm: string): string[] {
+  // Block form first: `_input:` followed by newline + `- ` items.
+  const block = blockList(fm, "_input");
+  if (block.length) return block;
+  // Scalar form: `_input: <value>` on the same line.
+  const m = /^_input:[ \t]*(\S.*)$/m.exec(fm);
+  if (m) return [m[1].trim().replace(/^["']|["']$/g, "")];
+  return [];
+}
+
+/** Parse `_knowledge`: a list of inline `{ file: <path>, _when: <prose> }` maps. */
+function parseKnowledge(fm: string): KnowledgeRef[] {
+  const body = indentedBlock(fm, "_knowledge");
+  if (body === null) return [];
+  const out: KnowledgeRef[] = [];
+  for (const line of body.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("-")) continue;
+    const fm2 = /file:\s*([^,}]+)/.exec(t);
+    if (!fm2) continue;
+    const file = fm2[1].trim().replace(/^["']|["']$/g, "");
+    const wm = /_when:\s*["']?([^"'}]+)["']?/.exec(t);
+    out.push({ file, when: wm ? wm[1].trim() : null });
+  }
+  return out;
+}
+
 /** Parse the nested `_re_entry_guard:` block, or null when the key is absent. */
 function parseReEntryGuard(fm: string): ReEntryGuard | null {
   const body = indentedBlock(fm, "_re_entry_guard");
@@ -199,6 +229,8 @@ export function parsePhase(path: string, fm: string): PhaseFrontmatter {
     preconditions: parseChecks(fm, "_preconditions"),
     postconditions: parseChecks(fm, "_postconditions"),
     forbidsFiles: blockList(fm, "_forbids_files"),
+    input: parseInput(fm),
+    knowledge: parseKnowledge(fm),
     unknownKeys: unknownAmong(fm, PHASE_KEYS),
   };
 }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -34,6 +34,12 @@ export interface CheckItem {
   onFailure: string | null; // _on_failure action name
 }
 
+/** One entry in a phase's `_knowledge` list (a JSON data dependency). */
+export interface KnowledgeRef {
+  file: string; // path relative to the skill root
+  when: string | null; // optional opaque prose condition (bound, not evaluated by CI)
+}
+
 /** The phase orchestrator file's frontmatter. */
 export interface PhaseFrontmatter {
   kind: "phase";
@@ -54,6 +60,8 @@ export interface PhaseFrontmatter {
   preconditions: CheckItem[]; // _preconditions (entry gate); empty when absent
   postconditions: CheckItem[]; // _postconditions (completion gate); empty when absent
   forbidsFiles: string[]; // _forbids_files globs; empty when absent
+  input: string[]; // _input entries (artifacts / 'workspace' / a glob)
+  knowledge: KnowledgeRef[]; // _knowledge JSON data deps; empty when absent
   unknownKeys: string[]; // top-level _keys not in the closed vocab
 }
 


### PR DESCRIPTION
## What

Annotates each phase's JSON data dependencies as `_knowledge` frontmatter, and makes the validator **check** both `_knowledge` (files resolve on disk) and `_input` (artifacts resolve to an upstream phase's `_produces`). Annotate-only — no runtime behavior change.

## `_knowledge`

Shape: `_knowledge: [{ file, _when? }]` — data files only; `_when` is opaque prose (bound, not evaluated by CI — same policy as fragment `_when` / `_assert`). Added to the two phases whose data is already extracted to JSON on `main`:

- **design** — the six `knowledge/design/*-sizing` / `fast-path` JSONs, each with an addon-conditional `_when` (e.g. `postgres-rds-sizing.json` when a `heroku-postgresql` addon exists).
- **estimate** — `knowledge/estimate/estimate-defaults.json` + `../shared/pricing/aws-infra-pricing.json`.

discover / clarify / generate / feedback declare **no** `_knowledge` — their data is still inline prose on `main`. (Honest: don't declare files that don't exist. Those become `_knowledge` candidates if/when their data is extracted — a future rung.)

## Closes the review's "`_input` is dead weight" finding

`_input` was declared on every phase but read/checked by nothing. Now every `_input` entry must be `workspace`, a glob (feedback's phase-status file), or an artifact in some declared phase's `_produces` — catching a phase reading an artifact no phase produces (typo/rename). Verified coherent against the whole chain (clarify←discover, design←discover+clarify, estimate←design+clarify+discover, generate←all upstream).

Also fixed an `_input` parse bug uncovered here: a block-form `_input` was being mis-read as a scalar because the scalar regex's `\s` crossed the newline.

## Validator

`_knowledge` in `PHASE_KEYS`; parse `{ file, _when }`; each `file` must resolve on disk relative to the **skill root** (handles the `../shared/...` climb out of the skill dir). +5 `node:test` cases (26 total). `mise run build` green.

## Scope

6 files (design + estimate frontmatter, validator, tests). Zero gcp changes. **Independent of #103** (gate migration) — merges in either order.
