### PR TITLE
fix(heroku-to-aws): single-creator uniqueness + honest _stale_artifact + normalize _contributes (round-2 review)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-eks.md
@@ -2,7 +2,7 @@
 _fragment: eks-mapping
 _of_phase: design
 _contributes:
-  - aws-design.json (EKS pods + eks_cluster aggregate for all formations, when EKS is selected)
+  - aws-design.json
 ---
 
 # EKS Design Branch

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-mapping.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-mapping.md
@@ -2,7 +2,7 @@
 _fragment: mapping-engine
 _of_phase: design
 _contributes:
-  - aws-design.json (services, deferred, warnings, vpc_design, Fir notation, metadata; created here, finalized by the assembler)
+  - aws-design.json
 ---
 
 # Design Phase: Mapping Engine

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -20,7 +20,7 @@ _produces:
 _advances_to: generate
 _re_entry_guard:
   _stale_if_completed: generate
-  _stale_artifact: generation-warnings.json
+  _stale_artifact: MIGRATION_GUIDE.md
   _on_reentry: stop_unless_confirmed
   _on_confirm: reset_downstream_to_pending
 _preconditions:

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -2,8 +2,8 @@
 _fragment: eks-generate
 _of_phase: generate
 _contributes:
-  - terraform/eks.tf (EKS cluster + node groups, when EKS in design)
-  - kubernetes/ (namespace + deployment + service manifests, when EKS in design)
+  - terraform/eks.tf
+  - kubernetes/
 ---
 
 # EKS Generate Phase

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -5,7 +5,6 @@ _contributes:
   - terraform/main.tf
   - terraform/variables.tf
   - terraform/outputs.tf
-  - generation-warnings.json
 ---
 
 # Generate Phase: Terraform Configuration Generation

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -142,6 +142,34 @@ describe('frontmatter-validator', () => {
     assert.match(findings.map((f) => f.message).join('\n'), /single-creator rule/);
   });
 
+  it('rejects an artifact created by two fragments with no assembler owner (ambiguous creator)', () => {
+    const files = goodSkill();
+    // add a second fragment; both fragments create doc.json; doc.json is in _produces
+    // but NOT in the assembler _produces → two fragment creators, no assembler owner.
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ]
+      .replace(
+        '    _file: phases/discover/discover-terraform.md',
+        '    _file: phases/discover/discover-terraform.md\n  - _id: docs\n    _trigger: { _always: true }\n    _file: phases/discover/discover-docs.md',
+      )
+      .replace('  - inventory.json\n_advances_to', '  - inventory.json\n  - doc.json\n_advances_to');
+    files['references/phases/discover/discover-terraform.md'] = files[
+      'references/phases/discover/discover-terraform.md'
+    ].replace('  - inventory.json (resource entries)', '  - doc.json');
+    files['references/phases/discover/discover-docs.md'] =
+`---
+_fragment: docs
+_of_phase: discover
+_contributes:
+  - doc.json
+---
+# Docs fragment
+`;
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /ambiguous creator/);
+  });
+
   it('does NOT fail an _advances_to that points at a phase without frontmatter (partial rollout)', () => {
     const findings = validateFixture(goodSkill());
     assert.ok(

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -110,18 +110,26 @@ export function check(skill: BoundSkill): Finding[] {
     if (asm.ofPhase !== phase.phase) {
       add(skill.rel(apath), `_of_phase '${asm.ofPhase || "(missing)"}' != '${phase.phase}'`);
     }
-    // single-creator: everything the phase _produces must be declared by exactly one
-    // unit — the assembler's _produces OR a fragment's _contributes. (Most phases have
-    // an assembler-only creator; generate's artifacts are fragment-created, so we union
-    // the fragment contributions.)
-    const contributed = new Set<string>(asm.produces);
+    // single-creator (creates-vs-contributes model, INTERPRETER § assembler): each
+    // phase _produces artifact must have exactly ONE creator.
+    //   - If the assembler _produces it → the assembler is the creator; fragments that
+    //     also name it in _contributes are CONTENT-contributors (allowed, no conflict).
+    //   - Otherwise exactly one fragment must _contributes it (that fragment is the
+    //     creator). Zero → uncreated; two+ fragments → ambiguous creator.
+    const fragCreators = new Map<string, string[]>(); // artifact -> fragment ids declaring it
     for (const fr of phase.fragments) {
       const frag = skill.fragments.get(join(skill.referencesRoot, fr.file));
-      if (frag) for (const art of frag.contributes) contributed.add(art);
+      if (frag) for (const art of frag.contributes) {
+        (fragCreators.get(art) ?? fragCreators.set(art, []).get(art)!).push(fr.id);
+      }
     }
     for (const art of phase.produces) {
-      if (!contributed.has(art)) {
-        add(pf, `phase _produces '${art}' but no unit (assembler _produces or a fragment _contributes) declares it (single-creator rule)`);
+      if (asm.produces.includes(art)) continue; // assembler is the creator; fragments contribute
+      const fcs = fragCreators.get(art) ?? [];
+      if (fcs.length === 0) {
+        add(pf, `phase _produces '${art}' but no unit creates it (not in the assembler _produces, and no fragment _contributes it) — single-creator rule`);
+      } else if (fcs.length > 1) {
+        add(pf, `phase _produces '${art}' is declared by multiple fragments (${fcs.join(", ")}) with no assembler owner — ambiguous creator (single-creator rule)`);
       }
     }
   }


### PR DESCRIPTION
## What

Addresses three findings from the round-2 independent grammar review.

### N1 — single-creator tested *coverage*, not *uniqueness*

The #103 union check ("assembler `_produces` ∪ fragment `_contributes` covers `_produces`") passed green even when an artifact had **two** declarers — `generation-warnings.json` was in BOTH `generate-terraform._contributes` AND `generate-assemble._produces`. The check named "single-creator" couldn't catch a double-declarer.

Reworked it around an explicit **creates-vs-contributes** model (matches INTERPRETER's "the assembler is the single creator"):
- If the assembler `_produces` an artifact → the assembler is its creator; fragments naming it in `_contributes` are **content-contributors** (allowed, no conflict).
- Otherwise exactly one fragment must create it. Zero → uncreated; **two+ fragments with no assembler owner → ambiguous creator (now flagged).**

Dropped `generation-warnings.json` from `generate-terraform._contributes` (the assembler owns it). +1 `node:test` for the two-fragment ambiguous case (33 total).

### Finding 3 — `_stale_artifact` pointed at a conditional file

`estimate._re_entry_guard._stale_artifact` was `generation-warnings.json`, which generate writes only *"if any services were skipped"* — so on the common path the emitted `GATE_FAIL` named a file not on disk. #104 made `generate._produces` honest, so switched `_stale_artifact` to `MIGRATION_GUIDE.md` (a file generate **always** writes). The stale-downstream diagnostic now points at something real.

### N4 — normalized decorated `_contributes`

`design-mapping` / `design-eks` / `generate-eks` used prose-decorated entries (e.g. `terraform/eks.tf (EKS cluster..., when EKS in design)`). The single-creator check does exact string matching; the decorated form was a latent trap that would silently fail a match if those artifacts were ever added to `_produces`. Normalized to bare filenames.

## Deferred (surfaced by the review, tracked in HANDOFF)

- **Finding-1 residual** — the dead re-entry table in the gcp-canonical shared file (heroku symlinks it but no longer loads it; now inert, not contradicting). The annotation fix touches gcp, so handled separately per "don't change how gcp works today."
- **N3** — the conditional-artifact-in-`_produces` design question (EKS outputs are produced-but-undeclared, gated by prose `_assert`). A vocab decision (`_produces` entry gaining a `_when`?), scoped separately.

## Verification

`mise run build` green (frontmatter validation, tsc, 33/33 tests, fmt:check, security). No behavior change — validator + frontmatter data only. 7 files, all heroku-to-aws + validator, zero gcp changes.
