### PR TITLE
refactor(heroku-to-aws): consolidate the interpreter loop into INTERPRETER.md (skill-agnostic)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -275,12 +275,13 @@ Each fragment file (named by a phase's `_fragments[]._file`) carries its own fro
 
 The assembler file (named by a phase's `_assemble._file`) carries:
 
-| Key         | Meaning                                                                                       |
-| ----------- | --------------------------------------------------------------------------------------------- |
-| `_assemble` | the assembler's id                                                                            |
-| `_of_phase` | the phase this assembler belongs to                                                           |
-| `_reads`    | the fragment contributions it combines                                                        |
-| `_produces` | the artifact file(s) it creates — the assembler is the single creator of the phase's artifact |
+| Key          | Meaning                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `_assemble`  | the assembler's id                                                                                                         |
+| `_of_phase`  | the phase this assembler belongs to                                                                                        |
+| `_reads`     | the fragment contributions it combines                                                                                     |
+| `_knowledge` | reference/data files it loads (same shape as a phase's `_knowledge`: `{ file, _when? }`); each `file` must resolve on disk |
+| `_produces`  | the artifact file(s) it creates — the assembler is the single creator of the phase's artifact                              |
 
 ## `_init: true` — establish migration state
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -7,6 +7,87 @@ first and act on the keys below, then execute the phase's prose body.
 Frontmatter is being introduced phase-by-phase. A phase file with no frontmatter
 runs entirely from its prose, as before.
 
+## The interpreter loop
+
+This is the execution controller — how you drive a migration from invocation to
+completion. It is skill-agnostic: the phase set, ordering, and per-phase behavior
+are all DERIVED from the phase files' frontmatter (never hardcoded here).
+
+**On each invocation:**
+
+1. **Load state.** Find the run directory under `.migration/` and read its
+   `.phase-status.json`. If none exists, the first backbone phase runs and
+   establishes state via `_init` (see § `_init`).
+2. **Determine the current phase (deterministic):**
+   - If `current_phase` is present in `.phase-status.json`, use it (it is
+     authoritative).
+   - Otherwise walk the backbone in order (see § Backbone vs checkpoint) and pick
+     the FIRST phase whose `phases.<phase>` is not `"completed"`. If all backbone
+     phases are `"completed"`, the state is the terminal (`complete`).
+3. **Validate state before proceeding.** See § State-file validation below. STOP
+   on any inconsistency rather than guessing.
+4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
+   `references/phases/<phase>/<phase>.md`. Load it in full and read its
+   frontmatter first.
+5. **Run the phase.** Run its `_preconditions` entry gate (§ Gate protocol); if it
+   passes, set the phase `in_progress`, run its `_fragments` (each when its
+   `_trigger` fires) then its `_assemble`; then run its `_postconditions`
+   completion gate.
+6. **Advance only on `HANDOFF_OK`.** A phase is complete ONLY when its completion
+   gate emits the `HANDOFF_OK` line (§ Gate protocol). On `GATE_FAIL`, STOP — do
+   not update `.phase-status.json`, do not load the next phase; tell the user
+   which phase to re-run. Never load the next phase from a completion message that
+   lacks `HANDOFF_OK`.
+7. **Update state.** After `HANDOFF_OK`, apply the phase-status update protocol
+   below, then load the next phase — the current phase's `_advances_to` — and
+   repeat from step 4. When `_advances_to` is a terminal (`complete`), the
+   migration is complete.
+
+Checkpoint phases (§ Backbone vs checkpoint) are OFF this loop — they are entered
+by their own `_trigger` at a point the skill's orchestrator (SKILL.md) chooses,
+and return control without changing `current_phase`.
+
+### State discipline
+
+- **Single run directory.** Use ONE `$MIGRATION_DIR` (`.migration/[MMDD-HHMM]/`)
+  for the entire migration; do not mix artifacts across `.migration/*/` sessions.
+- **Re-read from disk.** Before each phase and before each gate, read the required
+  artifacts from `$MIGRATION_DIR/`. Do not rely on chat memory.
+
+### Phase-status update protocol (read-merge-write)
+
+Update `.phase-status.json` with read-merge-write, never a blind overwrite:
+
+1. Read the current file before every update.
+2. Change only the phase key(s) being advanced and `last_updated`.
+3. Leave prior completed phases unchanged.
+4. Set `current_phase` to the next phase (the completed phase's `_advances_to`),
+   or the terminal (`complete`) when the backbone is exhausted.
+5. Write the full file in the same turn as the phase's final output message.
+
+Status values progress `"pending"` → `"in_progress"` → `"completed"` and never go
+backward (except a confirmed re-entry reset — see § `_re_entry_guard`). At most one
+backbone phase is `"in_progress"` at a time.
+
+### State-file validation
+
+When reading `.phase-status.json`, STOP (surface the diagnostic, do not proceed or
+guess) on any of:
+
+1. **Multiple run directories** under `.migration/`: list them with their phase
+   status and ask `[A] Resume latest / [B] Start fresh / [C] Cancel`.
+2. **Invalid JSON:** "State file corrupted (invalid JSON). Delete the file and
+   restart the current phase."
+3. **Unrecognized phase name** in `phases` (not a phase the skill declares).
+4. **Unrecognized status** (not `pending` / `in_progress` / `completed`).
+5. **Invalid `current_phase`** (present but not a declared phase or the terminal).
+6. **Out-of-order completion:** a later backbone phase is `"completed"` while an
+   earlier one is not — "Inconsistent phase ordering detected. Reconcile
+   `.phase-status.json` before resuming."
+
+(The single-active-phase invariant is enforced structurally by the first phase's
+`_preconditions._check_single_active_phase`; see § Gate protocol.)
+
 ## Phase frontmatter keys
 
 | Key                 | Meaning                                                                                                                                                                                                                                                                         |
@@ -154,8 +235,11 @@ violation — treat it as a `_postconditions` failure. This encodes the per-phas
 
 A **backbone** phase (the default) is a step on the linear lifecycle: it is
 advanced into by its predecessor's `_advances_to`, and it advances to the next
-phase (or the `complete` terminal). The backbone is
-`discover → clarify → design → estimate → generate → complete`.
+phase (or the `complete` terminal). The backbone is the chain of backbone phases
+wired by `_advances_to` (forward) and `_requires_phase` (backward), from the first
+phase (no `_requires_phase`) to the one whose `_advances_to` is the terminal
+`complete`. The interpreter derives this chain from the phase frontmatter; it is
+not hardcoded.
 
 A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
@@ -173,6 +257,11 @@ presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
 user engaged). Do not conflate "checkpoint resolved" with "user participated."
 
 ## Fragment unit keys
+
+A phase has 1..N fragments and exactly one assembler. A fragment does one unit of
+work and writes its own contribution; fragments are independent (none reads
+another's output). The assembler runs last and combines/validates the fragments'
+contributions into the phase's artifact(s).
 
 Each fragment file (named by a phase's `_fragments[]._file`) carries its own frontmatter:
 
@@ -205,10 +294,10 @@ out as a per-phase "initialize" step.
      - `[B] Fresh: Create new migration run`
      - `[C] Cancel`
    - **If resuming:** set `$MIGRATION_DIR` to the selected run's directory. Read
-     its `.phase-status.json` and validate it per the State Machine in `SKILL.md`.
-     If the `_init` phase is already `completed`, apply the re-entry rules (see
-     the phase's `_re_entry_guard` frontmatter and § `_re_entry_guard` above)
-     before proceeding.
+     its `.phase-status.json` and validate it per § The interpreter loop
+     (State-file validation). If the `_init` phase is already `completed`, apply
+     the re-entry rules (see the phase's `_re_entry_guard` frontmatter and
+     § `_re_entry_guard` above) before proceeding.
    - **If fresh, or no existing runs:** continue to step 2.
 
 2. Create `.migration/[MMDD-HHMM]/` (e.g. `.migration/0315-1030/`) using the
@@ -225,24 +314,10 @@ out as a per-phase "initialize" step.
 
    This prevents accidental commits of migration artifacts.
 
-4. Write `.phase-status.json` with the exact schema (schema reference:
-   `shared/schema-phase-status.md`):
-
-   ```json
-   {
-     "migration_id": "[MMDD-HHMM]",
-     "last_updated": "[ISO 8601 timestamp]",
-     "current_phase": "discover",
-     "phases": {
-       "discover": "in_progress",
-       "clarify": "pending",
-       "design": "pending",
-       "estimate": "pending",
-       "generate": "pending",
-       "feedback": "pending"
-     }
-   }
-   ```
+4. Write `.phase-status.json` per the schema in `shared/schema-phase-status.md`.
+   Set `migration_id` to `[MMDD-HHMM]`, `last_updated` to the current ISO 8601
+   timestamp, every phase to `"pending"` EXCEPT this `_init` phase which is
+   `"in_progress"`, and `current_phase` to this `_init` phase.
 
 5. Confirm both `.migration/.gitignore` and `.phase-status.json` exist before
    running the phase's fragments.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -64,15 +64,11 @@ phase's `_preconditions` / fragments / `_assemble` / `_postconditions`, advances
 gates are all derived from the phase files' frontmatter and `INTERPRETER.md` — they
 are not restated here.
 
-**Clarify is a mandatory gate (heroku policy).** Design, Estimate, and Generate
-each declare `_requires_phase: clarify` (enforced by their `_preconditions`), so
-the interpreter will not enter them until Clarify is `"completed"`. A
-`preferences.json` file alone is not proof Clarify ran. If the user asks to skip
-Clarify or jump straight to Design/Estimate/Generate, refuse briefly and run
-Clarify first — there is no exception for "quick" or "obvious" migrations.
-
-The Generate phase additionally loads `references/shared/validate-artifacts.md`
-before writing `migration-report.html`.
+**Clarify is mandatory (heroku policy).** Do not skip Clarify or jump straight to
+Design, Estimate, or Generate even if the user asks — there is no exception for
+"quick" or "obvious" migrations. A `preferences.json` that was not produced by an
+actual Clarify run does not count. If asked to skip, refuse briefly and run
+Clarify.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -29,11 +29,14 @@ description: "Migrate workloads from Heroku to AWS. Triggers on: migrate from He
 
 ## Phase Structure (frontmatter)
 
-A phase orchestrator file (e.g. `references/phases/discover/discover.md`) may carry a small YAML frontmatter block that names how the phase is composed — its inputs, the **fragments** it runs (each with a trigger), the **assembler** that combines their outputs, what it produces, and what it requires/advances-to. `INTERPRETER.md` is the contract: it lists every frontmatter key and how to act on it (including `_init`, which establishes migration state on the first phase).
+Phase and unit files carry a YAML frontmatter block that declares how the phase is
+composed — its inputs, the fragments it runs, the assembler that combines them,
+what it produces, its gates, and what it requires/advances-to. `INTERPRETER.md` is
+the contract: it defines every frontmatter key, the fragment/assembler model, and
+the interpreter loop. Read it first, then execute a phase file's prose body.
 
-**Fragment vs assembler:** a **fragment** does one unit of work and writes its own contribution; fragments are independent (none reads another's output). The **assembler** runs last and combines/validates the fragments' outputs into the phase's final artifact. A phase has 1..N fragments and exactly one assembler.
-
-When a phase file has frontmatter, read it (and `INTERPRETER.md`) first, then execute the phase body. Frontmatter is being introduced phase-by-phase; phases without it run from their prose as before.
+Frontmatter is being introduced phase-by-phase; a phase file without it runs from
+its prose as before.
 
 ---
 
@@ -52,61 +55,24 @@ When adding new reference files, verify the phase's total loaded instructions re
 
 ---
 
-## State Machine
+## Execution
 
-This is the execution controller. After completing each phase, consult this table to determine the next action.
+This skill is driven by the interpreter loop in `INTERPRETER.md` (§ The interpreter
+loop): it reads `.phase-status.json`, determines the current phase, runs each
+phase's `_preconditions` / fragments / `_assemble` / `_postconditions`, advances on
+`HANDOFF_OK` via `_advances_to`, and validates state. The phase set, ordering, and
+gates are all derived from the phase files' frontmatter and `INTERPRETER.md` — they
+are not restated here.
 
-| Current State | Condition                                                             | Next Action                                                                            |
-| ------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `discover`    | `phases.discover != "completed"`                                      | Load `references/phases/discover/discover.md`                                          |
-| `clarify`     | `phases.discover == "completed"` AND `phases.clarify != "completed"`  | Load `references/phases/clarify/clarify.md`                                            |
-| `design`      | `phases.clarify == "completed"` AND `phases.design != "completed"`    | Load `references/phases/design/design.md`                                              |
-| `estimate`    | `phases.design == "completed"` AND `phases.estimate != "completed"`   | Load `references/phases/estimate/estimate.md`                                          |
-| `generate`    | `phases.estimate == "completed"` AND `phases.generate != "completed"` | Load `references/phases/generate/generate.md`                                          |
-| `complete`    | `phases.generate == "completed"` AND `phases.feedback == "pending"`   | Set `phases.feedback` to `"completed"` (user had two chances), then migration complete |
-| `complete`    | `phases.generate == "completed"` AND `phases.feedback == "completed"` | Migration planning complete                                                            |
+**Clarify is a mandatory gate (heroku policy).** Design, Estimate, and Generate
+each declare `_requires_phase: clarify` (enforced by their `_preconditions`), so
+the interpreter will not enter them until Clarify is `"completed"`. A
+`preferences.json` file alone is not proof Clarify ran. If the user asks to skip
+Clarify or jump straight to Design/Estimate/Generate, refuse briefly and run
+Clarify first — there is no exception for "quick" or "obvious" migrations.
 
-**How to determine current state (deterministic):**
-
-1. Read `$MIGRATION_DIR/.phase-status.json`
-2. If `current_phase` exists, use it (must match one of: discover, clarify, design, estimate, generate, complete)
-3. Otherwise use ordered phase evaluation: `discover` → `clarify` → `design` → `estimate` → `generate`
-4. Pick the **first** phase in that order where `phases.<phase> != "completed"`; if none, state is `complete`
-
-**Phase gate checks**: If prior phase incomplete, do not advance (e.g., cannot enter estimate without completed design).
-
-**Clarify is mandatory:** Do not load `references/phases/design/design.md`, `references/phases/estimate/estimate.md`, or `references/phases/generate/generate.md` unless `$MIGRATION_DIR/.phase-status.json` exists and `phases.clarify` is exactly `"completed"`. A `preferences.json` file alone is **not** sufficient proof that Clarify ran. If the user asks to skip Clarify or jump straight to Design, cost estimate, or artifact generation, refuse briefly, then load `references/phases/clarify/clarify.md` and run Phase 2. There is no exception for "quick" or "obvious" migrations.
-
-**Feedback checkpoints**: Feedback is offered once after Estimate (combined with plan sharing). See the **Feedback Checkpoints** section below for details.
-
-### Handoff Gate Orchestration (Fail Closed)
-
-Each phase's entry and completion gates are declared in its `_preconditions` /
-`_postconditions` frontmatter and enforced per `INTERPRETER.md` § Gate protocol (which
-also defines the `GATE_FAIL` / `HANDOFF_OK` line formats and the `_on_error` actions).
-
-1. **Single `$MIGRATION_DIR`**: Use one run directory for the entire migration. Do not mix artifacts across `.migration/*/` sessions.
-2. **Re-read from disk**: Before each phase (and before each handoff gate), Read required artifacts from `$MIGRATION_DIR/`. Do not rely on chat memory.
-3. **Advance only on `HANDOFF_OK`**: A phase is complete only when its orchestrator emits `HANDOFF_OK | phase=<name> | artifacts=...`. Do not load the next phase without it.
-4. **On `GATE_FAIL`**: Output the failure line(s) to the user in plain language. **Do NOT modify artifacts** to pass the gate. **Do NOT continue** to the next phase. Tell the user which phase to re-run.
-   The per-phase entry/completion gates, the `HANDOFF_OK` / `GATE_FAIL` protocol, the `_on_error` actions, and stale-downstream re-entry are all defined by each phase's frontmatter (`_preconditions` / `_postconditions` / `_re_entry_guard`) and `INTERPRETER.md` § Gate protocol and § `_re_entry_guard`. Do not restate them here.
-
-Generate phase additionally loads `references/shared/validate-artifacts.md` before writing `migration-report.html`.
-
----
-
-## State Validation
-
-When reading `$MIGRATION_DIR/.phase-status.json`, validate before proceeding:
-
-1. **Multiple sessions**: If multiple directories exist under `.migration/`, list them with their phase status and ask: [A] Resume latest, [B] Start fresh, [C] Cancel.
-2. **Invalid JSON**: If `.phase-status.json` fails to parse, STOP. Output: "State file corrupted (invalid JSON). Delete the file and restart the current phase."
-3. **Unrecognized phase**: If `phases` object contains a phase not in {discover, clarify, design, estimate, generate, feedback}, STOP. Output: "Unrecognized phase: [value]. Valid phases: discover, clarify, design, estimate, generate, feedback."
-4. **Unrecognized status**: If any `phases.*` value is not in {pending, in_progress, completed}, STOP. Output: "Unrecognized status: [value]. Valid values: pending, in_progress, completed."
-5. **Invalid `current_phase`** (if present): If `current_phase` is not in {discover, clarify, design, estimate, generate, complete}, STOP. Output: "Unrecognized current_phase: [value]. Valid values: discover, clarify, design, estimate, generate, complete."
-6. **Out-of-order completion**: For ordered phases [discover, clarify, design, estimate, generate], if any later phase is `"completed"` while an earlier phase is not `"completed"`, STOP. Output: "Inconsistent phase ordering detected. Reconcile `.phase-status.json` before resuming."
-
-(The single-active-phase invariant is enforced by discover's `_preconditions._check_single_active_phase`; see `INTERPRETER.md` § Gate protocol.)
+The Generate phase additionally loads `references/shared/validate-artifacts.md`
+before writing `migration-report.html`.
 
 ---
 
@@ -136,17 +102,7 @@ Migration state lives in `$MIGRATION_DIR` (`.migration/[MMDD-HHMM]/`), created b
 For core phases (discover, clarify, design, estimate, generate), at most one phase may be `"in_progress"` at any time.
 `current_phase` is optional but recommended; when present it is authoritative.
 
-The `.migration/` directory is automatically protected by a `.gitignore` file created in Phase 1.
-
-### Phase Status Update Protocol
-
-Use **read-merge-write** updates for `.phase-status.json`:
-
-1. Read the current file before every update.
-2. Change only the phase keys being advanced and `last_updated`.
-3. Keep prior completed phases unchanged.
-4. Set `current_phase` to the next deterministic phase (or `complete` after generate).
-5. Write the full file in the same turn as your final phase work message.
+The `.migration/` directory is automatically protected by a `.gitignore` file created in Phase 1. State reads, validation, and the read-merge-write update protocol are defined in `INTERPRETER.md` § The interpreter loop.
 
 ---
 
@@ -164,7 +120,7 @@ Use **read-merge-write** updates for `.phase-status.json`:
 
 ```
 heroku-to-aws/
-├── SKILL.md                                    ← You are here (orchestrator + state machine)
+├── SKILL.md                                    ← You are here (skill entry point)
 │
 ├── references/
 │   ├── phases/
@@ -218,78 +174,59 @@ heroku-to-aws/
 - **Cost currency**: USD
 - **Timeline assumption**: 2-16 weeks depending on migration complexity — small (2-6 weeks), medium (6-12 weeks), large (12-18 weeks). See `references/shared/migration-complexity.md` for tier definitions.
 
-## Workflow Execution
+## Feedback & Sharing Checkpoints
 
-When invoked, the agent **MUST follow this exact sequence**:
+The interpreter loop (`INTERPRETER.md` § The interpreter loop) drives phase
+sequencing, gates, and state. This section defines only the heroku-specific
+checkpoint orchestration: WHERE the optional `feedback` checkpoint and plan-share
+are offered (a checkpoint's placement is orchestration prose, not part of the
+phase contract).
 
-1. **Load phase status**: Read `.phase-status.json` from `.migration/*/`.
-   - If missing: Initialize for Phase 1 (Discover)
-   - If exists: Determine current phase using deterministic rules in **State Machine**
+- **After Discover**: No prompt. Proceed directly to Clarify.
 
-2. **Determine phase to execute**:
-   - If `current_phase` exists: execute that phase.
-   - Otherwise execute the first non-completed phase in ordered list: discover → clarify → design → estimate → generate.
-   - If all ordered phases are completed: migration is complete (with feedback finalization rule).
+- **After Estimate** (if `phases.feedback` is `"pending"`): Output to user:
 
-3. **Read phase reference**: Load the full reference file for the target phase.
+  ```
+  ─── Share Your Migration Plan ───
 
-4. **Execute ALL steps in order**: Follow every numbered step in the reference file. **Do not skip, optimize, or deviate.**
+  This link encodes your migration profile for partner matching:
+  ✓ Included: Clarify answers, estimated costs, recommendation path,
+    detected Heroku services, resource names, and workload types.
+  ✗ Excluded: Source code, local file paths, credentials, API tokens,
+    config-var values, and environment secrets.
 
-5. **Validate outputs**: Confirm all required output files exist with correct schema before proceeding. Phase orchestrators run their `_postconditions` completion gate per `INTERPRETER.md` § Gate protocol.
+  The link uses a URL fragment (#) — no data is sent to any server
+  when you click it. The landing page decodes everything client-side.
 
-6. **Handoff gate**: Emit `HANDOFF_OK` or `GATE_FAIL` per `INTERPRETER.md` § Gate protocol. On `GATE_FAIL`, stop — do not update phase status or load the next phase.
+  [A] Send feedback & share plan
+  [B] Send feedback only
+  [C] No thanks, continue to Generate
+  ```
 
-7. **Update phase status**: Only after `HANDOFF_OK`. Use the Phase Status Update Protocol (read-merge-write) in the same turn as the phase's final output message.
+  - If user picks **A** → Load `references/phases/feedback/feedback.md`, execute it. Then generate share link. Set `phases.feedback` to `"completed"`. Continue to Generate.
+  - If user picks **B** → Load `references/phases/feedback/feedback.md`, execute it. Set `phases.feedback` to `"completed"`. Continue to Generate.
+  - If user picks **C** → Set `phases.feedback` to `"completed"`. Continue to Generate.
 
-8. **Feedback and sharing checkpoints**: After Estimate completes, offer feedback and/or plan sharing. This runs **before** advancing to Generate.
+- **After Generate**: Share-only prompt (no feedback re-ask):
 
-   - **After Discover**: No prompt. Proceed directly to Clarify.
+  ```
+  ─── Share Your Completed Plan ───
 
-   - **After Estimate** (if `phases.feedback` is `"pending"`): Output to user:
+  This link encodes your migration profile for partner matching:
+  ✓ Included: Clarify answers, estimated costs, recommendation path,
+    detected Heroku services, resource names, and workload types.
+  ✗ Excluded: Source code, local file paths, credentials, API tokens,
+    config-var values, and environment secrets.
 
-     ```
-     ─── Share Your Migration Plan ───
+  The link uses a URL fragment (#) — no data is sent to any server
+  when you click it. The landing page decodes everything client-side.
 
-     This link encodes your migration profile for partner matching:
-     ✓ Included: Clarify answers, estimated costs, recommendation path,
-       detected Heroku services, resource names, and workload types.
-     ✗ Excluded: Source code, local file paths, credentials, API tokens,
-       config-var values, and environment secrets.
+  [A] Share completed plan
+  [B] No thanks, finish
+  ```
 
-     The link uses a URL fragment (#) — no data is sent to any server
-     when you click it. The landing page decodes everything client-side.
+  - If user picks **A** → Generate share link. Mark migration complete.
+  - If user picks **B** → Mark migration complete.
+  - If `phases.feedback` is still `"pending"`, set it to `"completed"` regardless of choice.
 
-     [A] Send feedback & share plan
-     [B] Send feedback only
-     [C] No thanks, continue to Generate
-     ```
-
-     - If user picks **A** → Load `references/phases/feedback/feedback.md`, execute it. Then generate share link. Set `phases.feedback` to `"completed"`. Continue to Generate.
-     - If user picks **B** → Load `references/phases/feedback/feedback.md`, execute it. Set `phases.feedback` to `"completed"`. Continue to Generate.
-     - If user picks **C** → Set `phases.feedback` to `"completed"`. Continue to Generate.
-
-   - **After Generate**: Share-only prompt (no feedback re-ask):
-
-     ```
-     ─── Share Your Completed Plan ───
-
-     This link encodes your migration profile for partner matching:
-     ✓ Included: Clarify answers, estimated costs, recommendation path,
-       detected Heroku services, resource names, and workload types.
-     ✗ Excluded: Source code, local file paths, credentials, API tokens,
-       config-var values, and environment secrets.
-
-     The link uses a URL fragment (#) — no data is sent to any server
-     when you click it. The landing page decodes everything client-side.
-
-     [A] Share completed plan
-     [B] No thanks, finish
-     ```
-
-     - If user picks **A** → Generate share link. Mark migration complete.
-     - If user picks **B** → Mark migration complete.
-     - If `phases.feedback` is still `"pending"`, set it to `"completed"` regardless of choice.
-
-9. **Display summary**: Show user what was accomplished, highlight next phase, or confirm migration completion.
-
-**Critical constraint**: Agent must strictly adhere to the reference file's workflow. If unable to complete a step, stop and report the specific issue. Do not fabricate or infer data.
+**Critical constraint**: Follow each phase reference file's workflow exactly. If unable to complete a step, stop and report the specific issue. Do not fabricate or infer data.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
@@ -132,7 +132,7 @@ private-space conditionals), then emit `GATE_FAIL` (STOP; do not patch artifacts
 
 ## Step 5: Update Phase Status
 
-Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the Phase Status Update Protocol (read-merge-write) to update `.phase-status.json`:
+Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop) to update `.phase-status.json`:
 
 - Set `phases.clarify` to `"completed"`
 - Set `current_phase` to `"design"`

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design-assemble.md
@@ -63,7 +63,7 @@ Step 7, then emit `GATE_FAIL` (STOP; do not patch artifacts) or
 
 ## Step 8: Update Phase Status
 
-Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the Phase Status Update Protocol (read-merge-write) to update `.phase-status.json`:
+Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop) to update `.phase-status.json`:
 
 1. Read current `.phase-status.json` from disk.
 2. Set `phases.design` to `"completed"`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -228,7 +228,7 @@ emit `GATE_FAIL` (STOP; do not patch artifacts) or
 
 ## Step 5: Update Phase Status
 
-Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the Phase Status Update Protocol (read-merge-write) to update `.phase-status.json`:
+Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop) to update `.phase-status.json`:
 
 1. Read current `.phase-status.json` from disk.
 2. Set `phases.discover` to `"completed"`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
@@ -41,7 +41,7 @@ Collects user feedback and generates a shareable migration plan link. Reuses the
 - **feedback-collect.md** → the collection work: detect IDE/version, build the anonymized trace, present the survey link, optionally generate a share link, and write `feedback.json`.
 - **feedback-assemble.md** → the assembler: output gate, phase-status update, and marking the migration complete.
 
-This is an **optional checkpoint phase** (`_kind: checkpoint`), not a step on the linear backbone. It is entered only when the user opts in at a feedback checkpoint (its `_trigger`), and it returns control to the flow rather than advancing a `current_phase` — so it has no `_advances_to`. SKILL.md decides where the feedback checkpoint is offered (see the Feedback Checkpoints section there).
+This is an **optional checkpoint phase** (`_kind: checkpoint`), not a step on the linear backbone. It is entered only when the user opts in at a feedback checkpoint (its `_trigger`), and it returns control to the flow rather than advancing a `current_phase` — so it has no `_advances_to`. SKILL.md decides where the feedback checkpoint is offered (see the Feedback & Sharing Checkpoints section there).
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -58,7 +58,7 @@ accounted for, no `{{VARIABLE}}` placeholders), then emit `GATE_FAIL` (STOP) or
 
 ## Step 4: Update Phase Status
 
-Only after `HANDOFF_OK`. Use the Phase Status Update Protocol (read-merge-write):
+Only after `HANDOFF_OK`. Use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop):
 
 1. Read current `.phase-status.json` from disk.
 2. Set `phases.generate` to `"completed"`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -5,6 +5,8 @@ _reads:
   - terraform (fragment contribution)
   - docs (fragment contribution)
   - eks-generate (fragment contribution, when EKS in design)
+_knowledge:
+  - { file: references/shared/validate-artifacts.md }
 _produces:
   - generation-warnings.json
 ---
@@ -21,7 +23,8 @@ _produces:
 
 ## Step 3: Validate Complete Artifact Set
 
-Load `shared/validate-artifacts.md`. Verify the complete set of generated artifacts:
+Load the validation reference declared in `_knowledge`
+(`references/shared/validate-artifacts.md`). Verify the complete set of generated artifacts:
 
 1. `terraform/main.tf` — provider configuration
 2. `terraform/variables.tf` — input variables

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -457,6 +457,25 @@ _produces:
     assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
   });
 
+  it('accepts an assembler _knowledge whose file resolves on disk', () => {
+    const files = goodSkill();
+    files['references/shared/ref.md'] = '# ref';
+    files['references/phases/discover/discover-assemble.md'] = files[
+      'references/phases/discover/discover-assemble.md'
+    ].replace('_produces:\n  - inventory.json', '_knowledge:\n  - { file: references/shared/ref.md }\n_produces:\n  - inventory.json');
+    const findings = validateFixture(files);
+    assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects an assembler _knowledge file that does not resolve', () => {
+    const files = goodSkill();
+    files['references/phases/discover/discover-assemble.md'] = files[
+      'references/phases/discover/discover-assemble.md'
+    ].replace('_produces:\n  - inventory.json', '_knowledge:\n  - { file: references/shared/MISSING.md }\n_produces:\n  - inventory.json');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /_knowledge file does not resolve: references\/shared\/MISSING\.md/);
+  });
+
   it('accepts _input resolving to an upstream _produces (and the workspace literal)', () => {
     // chainSkill: discover _input workspace (add it), clarify reads discover.json
     const files = chainSkill();

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -288,6 +288,15 @@ export function check(skill: BoundSkill): Finding[] {
   const INPUT_LITERALS = new Set(["workspace"]);
   const isGlob = (s: string) => /[*?{]/.test(s);
 
+  // assembler _knowledge files must resolve on disk too (relative to the skill root).
+  for (const asm of skill.assemblers.values()) {
+    for (const k of asm.knowledge) {
+      if (!existsSync(join(skillRoot, k.file))) {
+        add(skill.rel(asm.sourceFile), `_knowledge file does not resolve: ${k.file}`);
+      }
+    }
+  }
+
   for (const phase of skill.phases) {
     const pf = skill.rel(phase.sourceFile);
 

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -34,7 +34,7 @@ const GUARD_KEYS = new Set([
   "_stale_if_completed", "_stale_artifact", "_on_reentry", "_on_confirm",
 ]);
 const FRAGMENT_KEYS = new Set(["_fragment", "_of_phase", "_contributes"]);
-const ASSEMBLER_KEYS = new Set(["_assemble", "_of_phase", "_reads", "_produces"]);
+const ASSEMBLER_KEYS = new Set(["_assemble", "_of_phase", "_reads", "_produces", "_knowledge"]);
 
 /** Return the frontmatter block text (between the leading `---` fences), or null. */
 export function extractFrontmatter(path: string): string | null {
@@ -254,6 +254,7 @@ export function parseAssembler(path: string, fm: string): AssemblerFrontmatter {
     ofPhase: scalar(fm, "_of_phase"),
     reads: blockList(fm, "_reads"),
     produces: blockList(fm, "_produces"),
+    knowledge: parseKnowledge(fm),
     unknownKeys: unknownAmong(fm, ASSEMBLER_KEYS),
   };
 }

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -83,6 +83,7 @@ export interface AssemblerFrontmatter {
   ofPhase: string | null;
   reads: string[];
   produces: string[];
+  knowledge: KnowledgeRef[]; // _knowledge reference/data deps; empty when absent
   unknownKeys: string[];
 }
 


### PR DESCRIPTION
## What

Moves the execution-controller logic (state read, phase determination, gate orchestration, advancement, state-file validation, phase-status update protocol) out of `SKILL.md` and into `INTERPRETER.md` as the single source of truth, and makes it **skill-agnostic** (no hardcoded phase names; backbone derived from `_advances_to`/`_requires_phase`; orchestrator files found by the `references/phases/<phase>/<phase>.md` convention).

**No behavior change.** `gcp-to-aws` untouched.

## Why

The loop lived as prose in `SKILL.md` *and* was partly restated in `INTERPRETER.md` — which even pointed back at "the State Machine in SKILL.md". A circular, duplicated contract. Consolidating it removes the duplication and lets the contract be reused by any DSL-driven migration skill, not just heroku.

## Changes

**`INTERPRETER.md`**
- New **"The interpreter loop"** section: startup → deterministic current-phase selection → load-by-convention → gates → advance only on `HANDOFF_OK` → state read/validate/update. Absorbs SKILL.md's "how to determine current state", Workflow Execution 1–7/9, Handoff items 1–2, State Validation, and the Phase Status Update Protocol.
- De-heroku'd: Backbone section no longer hardcodes the phase chain; `_init` no longer says "validate per the State Machine in SKILL.md" and no longer inlines a heroku-specific `.phase-status.json` example.

**`SKILL.md`**
- State Machine / Handoff Gate Orchestration / State Validation / Workflow Execution → collapsed to a short **"Execution"** pointer to INTERPRETER, keeping only heroku doctrine (Clarify is a mandatory gate).
- Workflow Execution → trimmed to **"Feedback & Sharing Checkpoints"** (the one piece INTERPRETER designates as skill orchestration: *where* the optional feedback checkpoint is offered).

**Phase files** — repointed the "Phase Status Update Protocol" / "Feedback Checkpoints" references to their new homes (self-contained steps unchanged).

## Verification

- `mise run build` green (validator, markdownlint, dprint, security suite).
- Read-only interpreter trace against a sample Heroku repo confirms the full loop — startup/`_init`, routing, entry/completion gates, `HANDOFF_OK` advancement, state update — runs from `INTERPRETER.md` + phase frontmatter alone, with `SKILL.md` contributing only doctrine + feedback-checkpoint placement.

## Depends on

Builds on #107 (retire redundant orchestration prose). Part of an ongoing effort to make the DSL contract skill-agnostic; a follow-up will relocate `INTERPRETER.md` to a plugin-shared location and single-home the `.phase-status.json` schema.