### PR TITLE
refactor(migration-to-aws): single-home .phase-status.json schema as a neutral JSON Schema

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/INTERPRETER.md
@@ -315,10 +315,13 @@ out as a per-phase "initialize" step.
 
    This prevents accidental commits of migration artifacts.
 
-4. Write `.phase-status.json` per the schema in `shared/schema-phase-status.md`.
-   Set `migration_id` to `[MMDD-HHMM]`, `last_updated` to the current ISO 8601
-   timestamp, every phase to `"pending"` EXCEPT this `_init` phase which is
-   `"in_progress"`, and `current_phase` to this `_init` phase.
+4. Write `.phase-status.json` per the schema
+   `../shared/state/phase-status.schema.json`. Seed `phases` with ONE entry per
+   phase the skill declares (its phase files), all `"pending"` EXCEPT this `_init`
+   phase which is `"in_progress"`; set `migration_id` to `[MMDD-HHMM]`,
+   `last_updated` to the current ISO 8601 timestamp, and `current_phase` to this
+   `_init` phase. (The schema does not enumerate phase names — the valid names are
+   the skill's declared phases.)
 
 5. Confirm both `.migration/.gitignore` and `.phase-status.json` exist before
    running the phase's fragments.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -74,31 +74,12 @@ Clarify.
 
 ## State Management
 
-Migration state lives in `$MIGRATION_DIR` (`.migration/[MMDD-HHMM]/`), created by Phase 1 and persisted across invocations.
-
-**.phase-status.json schema:**
-
-```json
-{
-  "migration_id": "0315-1030",
-  "last_updated": "2026-03-15T10:30:00Z",
-  "current_phase": "discover",
-  "phases": {
-    "discover": "in_progress",
-    "clarify": "pending",
-    "design": "pending",
-    "estimate": "pending",
-    "generate": "pending",
-    "feedback": "pending"
-  }
-}
-```
-
-**Status values:** `"pending"` → `"in_progress"` → `"completed"`. Never goes backward.
-For core phases (discover, clarify, design, estimate, generate), at most one phase may be `"in_progress"` at any time.
-`current_phase` is optional but recommended; when present it is authoritative.
-
-The `.migration/` directory is automatically protected by a `.gitignore` file created in Phase 1. State reads, validation, and the read-merge-write update protocol are defined in `INTERPRETER.md` § The interpreter loop.
+Migration state lives in `$MIGRATION_DIR` (`.migration/[MMDD-HHMM]/`), created on
+the first phase and persisted across invocations. The state file is
+`.phase-status.json`; its shape is defined by
+`../shared/state/phase-status.schema.json`, and how it is created, validated, and
+updated across the lifecycle is defined in `INTERPRETER.md` § The interpreter loop.
+The `.migration/` directory is protected by a `.gitignore` created at init.
 
 ---
 
@@ -147,7 +128,6 @@ heroku-to-aws/
 │   └── shared/                                 # References shared plugin infrastructure
 │       └── (path reference to ../gcp-to-aws/references/shared/)
 │           ├── handoff-gates.md                # Shared gate protocol (NOT used by heroku-to-aws — heroku's gates live in phase `_preconditions`/`_postconditions` + INTERPRETER.md § Gate protocol)
-│           ├── schema-phase-status.md          # .phase-status.json schema
 │           ├── migration-complexity.md         # Complexity tier definitions (Small/Medium/Large)
 │           ├── schema-estimate-infra.md        # estimation-infra.json schema
 │           └── validate-artifacts.md           # Pre-report validation

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
@@ -11,7 +11,6 @@ The heroku-to-aws skill reuses these shared files from the gcp-to-aws sibling sk
 | File                       | Purpose                                                     |
 | -------------------------- | ----------------------------------------------------------- |
 | `handoff-gates.md`         | Fail-closed phase handoff protocol (HANDOFF_OK / GATE_FAIL) |
-| `schema-phase-status.md`   | `.phase-status.json` schema (canonical reference)           |
 | `migration-complexity.md`  | Complexity tier definitions (Small/Medium/Large)            |
 | `schema-estimate-infra.md` | `estimation-infra.json` schema                              |
 | `validate-artifacts.md`    | Pre-report validation (Generate Step 0; read-only)          |
@@ -25,3 +24,8 @@ migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/<file>
 ```
 
 This avoids file duplication while maintaining consistent behavior across skills.
+
+> **Note:** the `.phase-status.json` schema is no longer here. It is defined once,
+> as a real JSON Schema, at `../../shared/state/phase-status.schema.json` (a
+> plugin-neutral home, not owned by any single skill), and referenced by
+> `INTERPRETER.md` § The interpreter loop.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/schema-phase-status.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/schema-phase-status.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/schema-phase-status.md

--- a/migrate/plugins/migration-to-aws/skills/shared/state/phase-status.schema.json
+++ b/migrate/plugins/migration-to-aws/skills/shared/state/phase-status.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://awslabs.github.io/startups/migration-to-aws/state/phase-status.schema.json",
+  "title": ".phase-status.json",
+  "description": "Canonical schema for the shared migration state file (.phase-status.json) that DSL-driven migration skills read and advance. The valid phase NAMES are NOT enumerated here — they are whatever phases the skill declares (its phase files). This schema is skill-agnostic: adding a phase to a skill requires no change to this file.",
+  "type": "object",
+  "required": ["migration_id", "last_updated", "phases"],
+  "additionalProperties": false,
+  "properties": {
+    "migration_id": {
+      "type": "string",
+      "description": "Matches the $MIGRATION_DIR folder name (e.g. 0226-1430). Set at creation; never changes."
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp; updated after each phase-status change."
+    },
+    "current_phase": {
+      "type": "string",
+      "description": "The phase to run next: a declared phase name, or the 'complete' terminal. Optional but recommended; when present it is authoritative for phase selection."
+    },
+    "phases": {
+      "type": "object",
+      "description": "One entry per phase the skill declares (backbone and checkpoint). Keys are the skill's phase names — this schema does not enumerate them.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["pending", "in_progress", "completed"],
+        "description": "Phase status. Progresses pending -> in_progress -> completed and never goes backward, except a confirmed re-entry reset (see INTERPRETER.md § _re_entry_guard). At most one backbone phase is in_progress at a time."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Gives the `.phase-status.json` schema one canonical home as a real, machine-checkable **JSON Schema** in a plugin-neutral location, replacing three drifting copies.

**No behavior change** to the migration flow. `gcp-to-aws` untouched.

## Why

The schema lived in three places:
- an inline JSON block in heroku's `SKILL.md`,
- a prose reference in `INTERPRETER.md` `_init`,
- a **symlink** from heroku into `gcp-to-aws`'s shared prose copy.

And the copies had **drifted** — the gcp-canonical one omits `current_phase`, which the DSL interpreter routes on. Three hand-maintained copies of a schema is exactly the drift this DSL work exists to remove.

## Changes

- **NEW `skills/shared/state/phase-status.schema.json`** — a plugin-neutral draft-07 JSON Schema (not owned by any single skill). It is **phase-name-agnostic**: `phases` is an open `<name> → status` map with no enumerated phase names, so a skill can add a phase without touching the schema. Includes `current_phase`. This is the canonical DSL state-schema standard other skills author to.
- **`INTERPRETER.md` `_init`** now writes `.phase-status.json` per `../shared/state/phase-status.schema.json`, seeding `phases` with one entry per phase the **skill declares** (derived from its phase files, not a hardcoded list).
- **`SKILL.md` State Management** — dropped the inline schema block + the prose duplicating INTERPRETER (status values, single-active, `current_phase`); it now points at the schema + INTERPRETER.
- **heroku no longer symlinks gcp for this schema** — removed `references/shared/schema-phase-status.md` (symlink) and its README/file-tree rows.

## gcp-to-aws

Untouched — its own schema file and references are unchanged. Refactoring gcp onto this standard is a separate, later effort.

## Verification

- JSON valid; `mise run build` green (frontmatter validator, markdownlint, dprint, security suite).
- Read-only interpreter trace confirms `_init` resolves the relocated schema and derives the phase set from the skill's declared phases (proving a new skill can add a phase without editing the schema).

## Follow-up

A subsequent PR (PR-3b) will detach heroku's remaining 4 gcp symlinks (handoff-gates, migration-complexity, schema-estimate-infra, validate-artifacts) into typed knowledge/fragment homes under the plugin.