### PR TITLE
refactor(heroku-to-aws): detach from gcp-to-aws (remove shared symlinks)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -125,12 +125,10 @@ heroku-to-aws/
 │   │   ├── redis-plan-table.md                 # Redis plan → ElastiCache sizing
 │   │   └── kafka-plan-table.md                 # Kafka plan → MSK sizing
 │   │
-│   └── shared/                                 # References shared plugin infrastructure
-│       └── (path reference to ../gcp-to-aws/references/shared/)
-│           ├── handoff-gates.md                # Shared gate protocol (NOT used by heroku-to-aws — heroku's gates live in phase `_preconditions`/`_postconditions` + INTERPRETER.md § Gate protocol)
-│           ├── migration-complexity.md         # Complexity tier definitions (Small/Medium/Large)
-│           ├── schema-estimate-infra.md        # estimation-infra.json schema
-│           └── validate-artifacts.md           # Pre-report validation
+│   └── shared/                                 # heroku-to-aws's own shared references
+│           ├── README.md                       # what lives here + pointers to plugin-neutral shared data
+│           ├── heroku-pricing-cache.md          # Heroku plan pricing (source-side baseline)
+│           └── schema-discover-heroku.md        # heroku-resource-inventory.json schema
 ```
 
 | Condition                                                | Action                                                                                                                                                       |
@@ -148,7 +146,7 @@ heroku-to-aws/
 - **Sizing**: Development tier (e.g., `db.t4g.micro` for databases, 0.5 CPU for Fargate)
 - **Migration mode**: Adapts based on available inputs (Terraform primary, Procfile/app.json supplementary, billing optional)
 - **Cost currency**: USD
-- **Timeline assumption**: 2-16 weeks depending on migration complexity — small (2-6 weeks), medium (6-12 weeks), large (12-18 weeks). See `references/shared/migration-complexity.md` for tier definitions.
+- **Timeline assumption**: 2-16 weeks depending on migration complexity — small (2-6 weeks), medium (6-12 weeks), large (12-18 weeks). Complexity tiers are classified per `../shared/estimate/complexity-tiers.json`.
 
 ## Feedback & Sharing Checkpoints
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/estimate/estimate-defaults.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/knowledge/estimate/estimate-defaults.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Tunable estimate-phase assumptions for the heroku-to-aws skill (the heuristic knobs an org adjusts, independent of the cost algorithm and the AWS rate table). AWS rates live in shared/pricing/aws-infra-pricing.json; cost FORMULAS and tier/heuristic logic stay in estimate.md prose. Complexity-tier bands + timelines are NOT here (they live in the shared references/shared/migration-complexity.md).",
+  "_comment": "Tunable estimate-phase assumptions for the heroku-to-aws skill (the heuristic knobs an org adjusts, independent of the cost algorithm and the AWS rate table). AWS rates live in shared/pricing/aws-infra-pricing.json; cost FORMULAS and tier/heuristic logic stay in estimate.md prose. Complexity-tier bands are NOT here (thresholds live in ../shared/estimate/complexity-tiers.json; timelines are inline in estimate-cost-engine.md).",
   "log_volume_gb_per_service": {
     "_comment": "Per-service monthly CloudWatch log-volume heuristic, counted PER DESIGNED SERVICE (MSK is per broker). Used by the observability cost step. Heuristic because Heroku's logging model differs, so source billing doesn't apply.",
     "fargate_task": 3,

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
@@ -20,7 +20,7 @@ _produces:
 
 ## Output: Write `estimation-infra.json`
 
-Assemble the full artifact conforming to `shared/schema-estimate-infra.md`:
+Assemble the full artifact conforming to `../shared/estimate/estimation-infra.schema.json`:
 
 ```json
 {
@@ -97,7 +97,7 @@ every-service-priced, complexity tier), then emit `GATE_FAIL` (do NOT patch arti
 STOP) or `HANDOFF_OK | phase=estimate | artifacts=estimation-infra.json` and advance.
 
 One check needs this fragment's context: `estimation-infra.json` must also pass
-`shared/schema-estimate-infra.md` validation (the schema shape) — verify that as part
+`../shared/estimate/estimation-infra.schema.json` validation (the schema shape) — verify that as part
 of the `_validate_json` postcondition.
 
 ---

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
@@ -432,7 +432,7 @@ Only include optimizations relevant to the designed architecture. Do not include
 
 ## Part 7: Complexity Tier Classification
 
-Load `shared/migration-complexity.md`. Classify using these inputs from the current artifacts:
+Load the tier thresholds declared in `_knowledge` (`../shared/estimate/complexity-tiers.json`). Classify using these inputs from the current artifacts:
 
 | Input                | Source                                                                            | Key                                                                                                   |
 | -------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -485,7 +485,7 @@ Include in `estimation-infra.json`:
 }
 ```
 
-**Timeline guidance** (from `migration-complexity.md` Infrastructure Path):
+**Timeline guidance** (infrastructure path):
 
 | Tier   | Weeks | Approach                            |
 | ------ | ----- | ----------------------------------- |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -9,6 +9,8 @@ _input:
 _knowledge:
   - { file: knowledge/estimate/estimate-defaults.json }
   - { file: ../shared/pricing/aws-infra-pricing.json }
+  - { file: ../shared/estimate/complexity-tiers.json }
+  - { file: ../shared/estimate/estimation-infra.schema.json }
 _fragments:
   - _id: cost-engine
     _trigger: { _always: true }
@@ -69,7 +71,7 @@ _forbids_files:
 
 ## Overview
 
-Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture. Produce `estimation-infra.json` conforming to `shared/schema-estimate-infra.md`. Classify migration complexity using `shared/migration-complexity.md`.
+Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture. Produce `estimation-infra.json` conforming to `../shared/estimate/estimation-infra.schema.json`. Classify migration complexity using the tier thresholds in `../shared/estimate/complexity-tiers.json`.
 
 **Inputs:**
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -5,8 +5,6 @@ _reads:
   - terraform (fragment contribution)
   - docs (fragment contribution)
   - eks-generate (fragment contribution, when EKS in design)
-_knowledge:
-  - { file: references/shared/validate-artifacts.md }
 _produces:
   - generation-warnings.json
 ---
@@ -23,8 +21,7 @@ _produces:
 
 ## Step 3: Validate Complete Artifact Set
 
-Load the validation reference declared in `_knowledge`
-(`references/shared/validate-artifacts.md`). Verify the complete set of generated artifacts:
+Verify the complete set of generated artifacts:
 
 1. `terraform/main.tf` — provider configuration
 2. `terraform/variables.tf` — input variables

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/README.md
@@ -1,31 +1,28 @@
-# Shared Infrastructure References
+# heroku-to-aws Shared References
 
-This directory references the shared plugin infrastructure located at:
+This directory holds references shared _within_ the heroku-to-aws skill (across its
+phases). It no longer symlinks the gcp-to-aws sibling skill — heroku-to-aws is
+self-contained.
 
-```
-../gcp-to-aws/references/shared/
-```
+| File                        | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `heroku-pricing-cache.md`   | Heroku plan pricing (source-side baseline for the estimate) |
+| `schema-discover-heroku.md` | `heroku-resource-inventory.json` schema                     |
 
-The heroku-to-aws skill reuses these shared files from the gcp-to-aws sibling skill:
+## Plugin-neutral shared data
 
-| File                       | Purpose                                                     |
-| -------------------------- | ----------------------------------------------------------- |
-| `handoff-gates.md`         | Fail-closed phase handoff protocol (HANDOFF_OK / GATE_FAIL) |
-| `migration-complexity.md`  | Complexity tier definitions (Small/Medium/Large)            |
-| `schema-estimate-infra.md` | `estimation-infra.json` schema                              |
-| `validate-artifacts.md`    | Pre-report validation (Generate Step 0; read-only)          |
+Cross-skill data that other DSL migration skills also use lives in the plugin-neutral
+`skills/shared/` tree (not owned by any single skill), referenced by phase frontmatter
+`_knowledge` or `INTERPRETER.md`:
 
-## Usage
+| Path                                                 | Purpose                                      |
+| ---------------------------------------------------- | -------------------------------------------- |
+| `../../shared/state/phase-status.schema.json`        | `.phase-status.json` schema (JSON Schema)    |
+| `../../shared/estimate/estimation-infra.schema.json` | `estimation-infra.json` schema (JSON Schema) |
+| `../../shared/estimate/complexity-tiers.json`        | Migration complexity-tier thresholds         |
+| `../../shared/pricing/aws-infra-pricing.json`        | Cached AWS infrastructure pricing            |
 
-When a phase reference instructs you to "Load `references/shared/<file>`", read the file from:
-
-```
-migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/<file>
-```
-
-This avoids file duplication while maintaining consistent behavior across skills.
-
-> **Note:** the `.phase-status.json` schema is no longer here. It is defined once,
-> as a real JSON Schema, at `../../shared/state/phase-status.schema.json` (a
-> plugin-neutral home, not owned by any single skill), and referenced by
-> `INTERPRETER.md` § The interpreter loop.
+The gate protocol, re-entry, and phase-status lifecycle that used to live in shared
+gcp prose are now defined in `INTERPRETER.md` (§ Gate protocol, § `_re_entry_guard`,
+§ The interpreter loop) and each phase's `_preconditions` / `_postconditions`
+frontmatter.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/handoff-gates.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/handoff-gates.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/handoff-gates.md

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/migration-complexity.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/migration-complexity.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/migration-complexity.md

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/schema-estimate-infra.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/schema-estimate-infra.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/schema-estimate-infra.md

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/validate-artifacts.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/shared/validate-artifacts.md
@@ -1,1 +1,0 @@
-../../../gcp-to-aws/references/shared/validate-artifacts.md

--- a/migrate/plugins/migration-to-aws/skills/shared/estimate/complexity-tiers.json
+++ b/migrate/plugins/migration-to-aws/skills/shared/estimate/complexity-tiers.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Migration complexity-tier classification thresholds for DSL-driven migration skills. Data only: the tier BOUNDARY rules a skill's estimate phase evaluates to classify a migration as small/medium/large. The per-skill INPUTS (which artifacts/fields feed these rules) and the resulting TIMELINE guidance live in the consuming phase's prose, not here. Evaluate tiers from large down to small; the first matching tier wins (highest-matching-tier).",
+  "_meta": {
+    "unit": "monthly_spend is USD/month; service_count is metadata.total_services",
+    "evaluation_order": ["large", "medium", "small"]
+  },
+  "tiers": {
+    "large": {
+      "match": "any",
+      "conditions": {
+        "service_count_gte": 9,
+        "monthly_spend_gt": 10000,
+        "multi_region": true,
+        "compliance_present": true
+      }
+    },
+    "medium": {
+      "match": "any",
+      "not_higher": true,
+      "conditions": {
+        "service_count_range": [4, 8],
+        "monthly_spend_range": [1000, 10000],
+        "has_databases": true,
+        "availability_multi_az": true
+      }
+    },
+    "small": {
+      "match": "default",
+      "note": "Not large, not medium. Equivalently: service_count <= 3, monthly_spend < 1000, no databases or replicated stateful storage, availability single-az or unspecified, no compliance requirements."
+    }
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/shared/estimate/estimation-infra.schema.json
+++ b/migrate/plugins/migration-to-aws/skills/shared/estimate/estimation-infra.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://awslabs.github.io/startups/migration-to-aws/estimate/estimation-infra.schema.json",
+  "title": "estimation-infra.json",
+  "description": "Schema for the infrastructure cost-estimate artifact produced by a migration skill's estimate phase. projected_costs carries three pricing SCENARIOS (premium/balanced/optimized) for the same design — not three Terraform roots. Source-cloud baseline fields live under current_costs and are source-agnostic here (a skill records its own source monthly/annual). Cost FORMULAS and tier semantics are the estimate phase's prose, not this schema.",
+  "type": "object",
+  "required": ["phase", "pricing_source", "projected_costs", "complexity_tier", "recommendation"],
+  "properties": {
+    "phase": { "const": "estimate" },
+    "design_source": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "pricing_source": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["cached", "live", "cached_fallback", "unavailable"] },
+        "message": { "type": "string" },
+        "fallback_staleness": { "type": "object" },
+        "services_by_source": {
+          "type": "object",
+          "properties": {
+            "live": { "type": "array", "items": { "type": "string" } },
+            "fallback": { "type": "array", "items": { "type": "string" } },
+            "estimated": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "services_with_missing_fallback": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "accuracy_confidence": { "type": "string" },
+    "current_costs": {
+      "type": "object",
+      "description": "The source-platform baseline. 'source' names how it was derived; the monthly/annual totals and breakdown are the skill's source-platform spend (a skill may use source-specific key names such as heroku_monthly).",
+      "required": ["source"],
+      "properties": {
+        "source": { "type": "string" },
+        "baseline_note": { "type": ["string", "null"] },
+        "breakdown": { "type": "object" }
+      }
+    },
+    "projected_costs": {
+      "type": "object",
+      "required": ["aws_monthly_premium", "aws_monthly_balanced", "aws_monthly_optimized"],
+      "properties": {
+        "aws_monthly_premium": { "type": "number" },
+        "aws_monthly_balanced": { "type": "number" },
+        "aws_monthly_optimized": { "type": "number" },
+        "aws_annual_optimized": { "type": "number" },
+        "breakdown": { "type": "object" }
+      }
+    },
+    "cost_comparison": { "type": "object" },
+    "migration_cost_considerations": { "type": "object" },
+    "roi_analysis": { "type": "object" },
+    "optimization_opportunities": { "type": "array" },
+    "complexity_tier": { "type": "string", "enum": ["small", "medium", "large"] },
+    "complexity_inputs": { "type": "object" },
+    "financial_summary": { "type": "object" },
+    "recommendation": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": { "type": "string", "enum": ["migrate_optimized", "migrate_phased", "stay"] },
+        "migrate_if": { "type": "array" },
+        "stay_if": { "type": "array" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

`heroku-to-aws` symlinked five shared reference files from the `gcp-to-aws` sibling skill. This removes all of them — heroku-to-aws is now **self-contained**, with no symlinks into gcp.

**No behavior change.** `gcp-to-aws` is untouched.

## Why

Those shared files are **gcp-authored** — they reference gcp artifacts (`gcp-resource-inventory.json`, `estimation-ai.json`, `migration-report.html`, Cloud SQL, CUDs) that heroku never produces. In every case, heroku had **already re-authored inline** whatever it actually needed, so the symlink was either dead weight or a source of gcp-flavored drift.

## Per symlink

| File | Action |
|---|---|
| `handoff-gates.md` | **Dropped.** Heroku's gates live in each phase's `_preconditions`/`_postconditions` + `INTERPRETER.md` § Gate protocol. |
| `migration-complexity.md` | Tier **thresholds** heroku uses → `skills/shared/estimate/complexity-tiers.json` (neutral data). Heroku's inputs + timelines were already inline; gcp stage-playbooks/billing/AI paths dropped (heroku never used them). |
| `schema-estimate-infra.md` | Heroku's `estimation-infra.json` shape was already inline in `estimate-assemble.md` → formalized as a real **JSON Schema** at `skills/shared/estimate/estimation-infra.schema.json` (source-agnostic `current_costs` — no `gcp_monthly`). |
| `validate-artifacts.md` | Heroku's generate assembler already validates from its **own inline checklist**; removed the gcp-flavored `_knowledge` pointer #108 had added. |

## New plugin-neutral data (JSON, not owned by any skill)

- `skills/shared/estimate/complexity-tiers.json`
- `skills/shared/estimate/estimation-infra.schema.json`

(Joins the existing `skills/shared/state/phase-status.schema.json` and `skills/shared/pricing/`.)

## gcp-to-aws

Untouched — its files and its own references are unchanged. Migrating gcp onto these plugin-neutral standards is a separate, later effort.

## Verification

- Both new JSON schemas valid; `mise run build` green.
- Read-only interpreter trace confirms estimate resolves complexity-tiers + the estimation-infra schema from the neutral home (heroku's inline shape validates against it), and generate validates from its own inline checklist with zero dangling gcp references.

_Note: the pre-existing semgrep CI failure (a taint-analysis timeout on the validator, unrelated to this change) is tracked separately._
