### PR TITLE
refactor(migration-to-aws): relocate INTERPRETER.md to plugin-neutral skills/shared/dsl/

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -31,9 +31,12 @@ description: "Migrate workloads from Heroku to AWS. Triggers on: migrate from He
 
 Phase and unit files carry a YAML frontmatter block that declares how the phase is
 composed — its inputs, the fragments it runs, the assembler that combines them,
-what it produces, its gates, and what it requires/advances-to. `INTERPRETER.md` is
-the contract: it defines every frontmatter key, the fragment/assembler model, and
-the interpreter loop. Read it first, then execute a phase file's prose body.
+what it produces, its gates, and what it requires/advances-to. The DSL interpreter
+contract is the plugin-shared `../shared/dsl/INTERPRETER.md`: it defines every
+frontmatter key, the fragment/assembler model, and the interpreter loop. **Load it
+first** (once, at the start of a migration), then execute a phase file's prose
+body. Elsewhere in this skill, `INTERPRETER.md` (without a path) refers to this
+same loaded contract.
 
 Frontmatter is being introduced phase-by-phase; a phase file without it runs from
 its prose as before.

--- a/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
@@ -1,8 +1,10 @@
 # Interpreter
 
-How to read and act on the structured frontmatter that phase files carry. This is
-the runtime contract: when a phase file begins with a `---` YAML block, read it
-first and act on the keys below, then execute the phase's prose body.
+The plugin-shared contract for DSL-driven migration skills: how to read and act on
+the structured frontmatter that phase files carry. It is skill-AGNOSTIC — any
+migration skill under this plugin can author its phases to this grammar and drive
+execution from this one interpreter. When a phase file begins with a `---` YAML
+block, read it first and act on the keys below, then execute the phase's prose body.
 
 Frontmatter is being introduced phase-by-phase. A phase file with no frontmatter
 runs entirely from its prose, as before.


### PR DESCRIPTION
## What

Relocates the DSL interpreter contract from `skills/heroku-to-aws/INTERPRETER.md` to a plugin-neutral home, `skills/shared/dsl/INTERPRETER.md` — alongside the neutral state/estimate/pricing data. The contract was made skill-agnostic in #108; this puts it where the shared DSL standard lives, signalling to other skill authors that this is the shared way to author migration skills, not a heroku-only artifact.

**No behavior change.** `gcp-to-aws` untouched.

## No symlink, no citation churn

The ~20 references to INTERPRETER across `SKILL.md` and the phase files are all **bare-name citations** ("enforced per `INTERPRETER.md` § Gate protocol", "see `INTERPRETER.md` § `_re_entry_guard`") — never load instructions or paths. The contract is **loaded once**, and `SKILL.md` is the single place that names its location. So the move needs neither a symlink (which PR #110 just removed as an anti-pattern) nor rewriting 20 references.

- `git mv skills/heroku-to-aws/INTERPRETER.md → skills/shared/dsl/INTERPRETER.md`
- `SKILL.md` § Phase Structure names the shared path once ("load `../shared/dsl/INTERPRETER.md` first") and states the convention: a bare `INTERPRETER.md` elsewhere refers to that loaded contract.
- `INTERPRETER.md` intro reframed as the plugin-shared, skill-agnostic contract (author-facing signal).
- Every bare `INTERPRETER.md § X` citation left unchanged.

## Verification

- `mise run build` green (frontmatter validator has no INTERPRETER path dependency — it only comment-references the grammar; markdownlint; dprint; security).
- Read-only interpreter trace confirms a cold agent loads INTERPRETER from the shared path via SKILL.md's single statement and resolves all bare-name citations to that loaded contract with no not-found risk.

_Note: the pre-existing semgrep CI failure (a taint-analysis timeout on the validator, unrelated to this change) is tracked separately._
