### PR TITLE
refactor(migration-to-aws): declare cold-start entry phase in SKILL.md

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -67,6 +67,14 @@ phase's `_preconditions` / fragments / `_assemble` / `_postconditions`, advances
 gates are all derived from the phase files' frontmatter and `INTERPRETER.md` — they
 are not restated here.
 
+**Cold start (entry phase).** On a cold start — no `.migration/` run with a
+`.phase-status.json` yet — begin at `references/phases/discover/discover.md`, this
+skill's entry phase (the one carrying `_init: true`). The interpreter loads THIS
+phase directly; it does not scan every phase's frontmatter to discover the root.
+All subsequent phases are reached by following each phase's `_advances_to`. On a
+warm start, `current_phase` in `.phase-status.json` is authoritative (see
+`INTERPRETER.md` § The interpreter loop).
+
 **Clarify is mandatory (heroku policy).** Do not skip Clarify or jump straight to
 Design, Estimate, or Generate even if the user asks — there is no exception for
 "quick" or "obvious" migrations. A `preferences.json` that was not produced by an

--- a/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
@@ -18,14 +18,21 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
 **On each invocation:**
 
 1. **Load state.** Find the run directory under `.migration/` and read its
-   `.phase-status.json`. If none exists, the first backbone phase runs and
-   establishes state via `_init` (see § `_init`).
+   `.phase-status.json`. If none exists, this is a COLD START: load the skill's
+   DECLARED entry phase (the skill's SKILL.md names it) and run it — it carries
+   `_init: true` and establishes state (see § `_init`). Do NOT scan every phase's
+   frontmatter to find the root; the skill declares its own entry so this is a
+   single, direct load. (The entry phase is, by contract, the backbone head — the
+   one phase with no `_requires_phase` and with `_init: true`; CI enforces that
+   these coincide, so the declared entry is unambiguous.)
 2. **Determine the current phase (deterministic):**
    - If `current_phase` is present in `.phase-status.json`, use it (it is
-     authoritative).
-   - Otherwise walk the backbone in order (see § Backbone vs checkpoint) and pick
-     the FIRST phase whose `phases.<phase>` is not `"completed"`. If all backbone
-     phases are `"completed"`, the state is the terminal (`complete`).
+     authoritative). This is the normal WARM-START path.
+   - Otherwise (state exists but has no `current_phase`) walk the backbone in order
+     (see § Backbone vs checkpoint) and pick the FIRST phase whose
+     `phases.<phase>` is not `"completed"`. If all backbone phases are
+     `"completed"`, the state is the terminal (`complete`). (On a cold start there
+     is no state to read — step 1's declared entry phase is used directly.)
 3. **Validate state before proceeding.** See § State-file validation below. STOP
    on any inconsistency rather than guessing.
 4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
@@ -241,7 +248,10 @@ phase (or the `complete` terminal). The backbone is the chain of backbone phases
 wired by `_advances_to` (forward) and `_requires_phase` (backward), from the first
 phase (no `_requires_phase`) to the one whose `_advances_to` is the terminal
 `complete`. The interpreter derives this chain from the phase frontmatter; it is
-not hardcoded.
+not hardcoded. The head of the backbone (the phase with no `_requires_phase`) is
+the skill's entry phase and carries `_init: true`; the skill names it in SKILL.md
+so a cold start loads it directly rather than scanning to find it (see § The
+interpreter loop, step 1).
 
 A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
@@ -289,7 +299,9 @@ The assembler file (named by a phase's `_assemble._file`) carries:
 
 When the phase being entered has `_init: true`, perform migration-state setup
 BEFORE running any of its fragments. This replaces what was previously written
-out as a per-phase "initialize" step.
+out as a per-phase "initialize" step. Exactly one phase per skill carries `_init:
+true` — the backbone head / declared entry phase — so this setup runs once, on the
+cold start that begins a migration.
 
 1. Check for an existing `.migration/` directory at the project root.
    - **If existing runs are found:** list them with their phase status and ask:

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -282,6 +282,70 @@ _produces:
     assert.match(findings.map((f) => f.message).join('\n'), /chain inconsistency/);
   });
 
+  // ---- entry phase: _init uniqueness + _init ⟺ backbone head ----
+
+  it('accepts a single _init phase that is the backbone head', () => {
+    // chainSkill: discover has _init:true and no _requires_phase (the head).
+    const findings = validateFixture(chainSkill());
+    assert.equal(findings.length, 0, `expected no findings, got: ${JSON.stringify(findings)}`);
+  });
+
+  it('rejects two phases both declaring _init: true', () => {
+    const files = chainSkill();
+    // Give clarify _init too (now discover AND clarify both claim the entry).
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_init: true\n_requires_phase: discover');
+    const findings = validateFixture(files);
+    assert.match(findings.map((f) => f.message).join('\n'), /multiple phases declare '_init: true'/);
+  });
+
+  it('rejects an _init phase that also declares _requires_phase (entry must be the head)', () => {
+    const files = chainSkill();
+    // Move _init off the head: strip it from discover, add it to clarify (which
+    // has a _requires_phase) so _init and 'no _requires_phase' no longer coincide.
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_init: true\n', '');
+    files['references/phases/clarify/clarify.md'] = files[
+      'references/phases/clarify/clarify.md'
+    ].replace('_requires_phase: discover', '_init: true\n_requires_phase: discover');
+    const findings = validateFixture(files);
+    assert.match(
+      findings.map((f) => f.message).join('\n'),
+      /entry phase 'clarify' declares '_init: true' but also '_requires_phase: discover'/,
+    );
+  });
+
+  it('rejects a checkpoint phase declaring _init: true (entry must be backbone)', () => {
+    const files = chainSkill();
+    // Strip _init from discover; put it on the feedback checkpoint.
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_init: true\n', '');
+    files['references/phases/feedback/feedback.md'] = files[
+      'references/phases/feedback/feedback.md'
+    ].replace('_kind: checkpoint', '_kind: checkpoint\n_init: true');
+    const findings = validateFixture(files);
+    assert.match(
+      findings.map((f) => f.message).join('\n'),
+      /checkpoint phase 'feedback' declares '_init: true'/,
+    );
+  });
+
+  it('rejects a fully-declared backbone with no _init entry phase', () => {
+    const files = chainSkill();
+    // Remove the only _init: the backbone (discover->clarify) now has no entry.
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_init: true\n', '');
+    const findings = validateFixture(files);
+    assert.match(
+      findings.map((f) => f.message).join('\n'),
+      /no phase declares '_init: true'/,
+    );
+  });
+
   // ---- _re_entry_guard ----
 
   // discover guards its downstream (clarify); clarify's _produces is 'clarify.json'.

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -280,6 +280,43 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
 
+  // ---- Entry phase: `_init` uniqueness + `_init` ⟺ backbone head ----
+  // The skill's cold-start entry is the backbone head (the phase with no
+  // _requires_phase) and it carries `_init: true` (INTERPRETER.md § The interpreter
+  // loop, step 1 + § `_init`). SKILL.md names this phase so a cold start loads it
+  // directly instead of scanning all phase frontmatter to find the root. These
+  // checks guarantee that entry is single and unambiguous, so the SKILL.md pointer
+  // has exactly one legal target.
+  const initPhases = skill.phases.filter((p) => p.init);
+  //   (a) at most one `_init` phase (a migration bootstraps state once).
+  if (initPhases.length > 1) {
+    const names = initPhases.map((p) => p.phase).join(", ");
+    for (const p of initPhases) {
+      add(skill.rel(p.sourceFile), `multiple phases declare '_init: true' (${names}) — a skill has exactly one entry phase`);
+    }
+  }
+  for (const p of initPhases) {
+    //   (b) the `_init` phase must be a backbone phase (a checkpoint is off-backbone,
+    //       trigger-entered — it can never be the entry).
+    if (p.role === "checkpoint") {
+      add(skill.rel(p.sourceFile), `checkpoint phase '${p.phase}' declares '_init: true' — only a backbone phase can be the entry (checkpoints are off-backbone, trigger-entered)`);
+    }
+    //   (c) the `_init` phase must be the backbone head (no _requires_phase) — the
+    //       entry cannot depend on an upstream phase.
+    if (p.requiresPhase) {
+      add(skill.rel(p.sourceFile), `entry phase '${p.phase}' declares '_init: true' but also '_requires_phase: ${p.requiresPhase}' — the entry phase is the backbone head and must have no _requires_phase`);
+    }
+  }
+  //   (d) once the backbone is fully present (>1 backbone phase), an entry MUST exist:
+  //       exactly one `_init` phase. (Partial-rollout tolerant: skip while only one
+  //       phase carries frontmatter.)
+  {
+    const backboneCount = skill.phases.filter((p) => p.role === "backbone").length;
+    if (backboneCount > 1 && initPhases.length === 0) {
+      add(skill.rel(skill.phases[0].sourceFile), `no phase declares '_init: true' — the backbone has no entry phase to bootstrap migration state on a cold start`);
+    }
+  }
+
   // ---- _knowledge (JSON data deps resolve) + _input (resolves to an upstream _produces) ----
   const skillRoot = join(skill.referencesRoot, "..");
   // every artifact any declared phase produces (for _input resolution)


### PR DESCRIPTION
## What

The DSL interpreter's cold-start path said *\"the first backbone phase runs\"* and step 2 said *\"walk the backbone in order.\"* Read literally, an interpreter must inspect **every** phase file's frontmatter to find the root (the phase with no `_requires_phase`). Because the skill's `\"Load\" = read the whole file` and each phase body is ~800 lines, that O(n) scan conflicts with the skill's own progressive-loading rules (*\"do not speculatively load files\"*).

The **entry point** is the one part of the backbone with no cheap derivation, so it earns an explicit home. SKILL.md now **declares** its cold-start entry; the interpreter loads it directly instead of scanning. The rest of the chain is still derived one `_advances_to` edge at a time — that redundancy was retired in the earlier convergence arc and is **not** reintroduced here.

## Changes

- **`SKILL.md` § Execution** — declare the cold-start entry phase (`references/phases/discover/discover.md`, the `_init` phase).
- **`INTERPRETER.md`** loop step 1/2 — cold start loads the *declared* entry phase (no full-frontmatter scan); the warm-start `current_phase` path is unchanged. Backbone + `_init` sections note that head == entry == `_init`.
- **`check.ts`** — assert `_init` **uniqueness**, that the `_init` phase is the **backbone head** (backbone role, no `_requires_phase`), and that a fully-declared backbone has an entry. Stays **skill-agnostic** (does not read SKILL.md) — it guarantees the frontmatter has a single unambiguous entry that the SKILL.md pointer must name. **+5 tests (40 total).**

## Verification

- `mise run build` green (fmt:check + 40/40 validator tests + scanners).
- **Cold-validated** with a read-only interpreter trace: starts at `discover` from the SKILL.md **declaration**, opens **zero** phase files to make the decision (progressive loading respected), and fires `_init` state setup.

## Ownership

Touches only team-owned skill/contract/validator files — **no admin-owned paths** (`.github/`, `.semgrep.yaml`, etc.) in this PR.