### PR TITLE
fix(migration-to-aws): catch dangling _advances_to (validator false-green)

### DIFF
--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -78,6 +78,16 @@ _produces:
 # Assembler
 prose body.
 `,
+    // A partial-rollout stub: 'clarify' is a REAL downstream phase whose file
+    // exists but carries NO frontmatter yet (mid phase-by-phase rollout). It is
+    // invisible to the typed model (bindSkill skips no-frontmatter files) but makes
+    // discover's `_advances_to: clarify` resolve on disk — so the dangling-edge
+    // check tolerates it (a real phase, not a typo).
+    'references/phases/clarify/clarify.md':
+`# Clarify
+
+prose-only phase (no frontmatter yet).
+`,
   };
 }
 
@@ -171,10 +181,26 @@ _contributes:
   });
 
   it('does NOT fail an _advances_to that points at a phase without frontmatter (partial rollout)', () => {
+    // goodSkill includes a frontmatter-less clarify.md stub — a real phase mid-
+    // rollout. discover._advances_to: clarify must resolve (dir exists) and NOT be
+    // flagged as dangling, even though clarify has no typed frontmatter yet.
     const findings = validateFixture(goodSkill());
     assert.ok(
       !findings.some((f) => /advances_to|clarify/.test(f.message)),
       'should not fail on an unverifiable forward reference',
+    );
+  });
+
+  it('rejects an _advances_to that names a phase with no file on disk (dangling forward edge)', () => {
+    const files = goodSkill();
+    // Point discover at a phase that does not exist at all (a typo, not rollout).
+    files['references/phases/discover/discover.md'] = files[
+      'references/phases/discover/discover.md'
+    ].replace('_advances_to: clarify', '_advances_to: clarify_TYPO');
+    const findings = validateFixture(files);
+    assert.match(
+      findings.map((f) => f.message).join('\n'),
+      /_advances_to 'clarify_TYPO' names neither a terminal.*nor an existing phase.*dangling forward edge/s,
     );
   });
 

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -229,6 +229,27 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
 
+  // ---- _advances_to membership (dangling forward-edge check) ----
+  // A phase's _advances_to must name either a terminal (complete/done/end) or a
+  // phase that EXISTS ON DISK (a references/phases/<name>/<name>.md file). This is
+  // independent of the chain-consistency block below (which is gated on the whole
+  // backbone being frontmatter-present and self-SKIPS the moment any _advances_to
+  // is unresolvable — so a dangling edge would otherwise slip through as a false
+  // OK). Resolving against the phase DIRECTORY (not the frontmatter-declared set)
+  // preserves partial-rollout tolerance: an edge to a real phase that has no
+  // frontmatter yet still resolves; only an edge to a phase that does not exist at
+  // all fails.
+  for (const phase of skill.phases) {
+    if (!phase.advancesTo || TERMINALS.has(phase.advancesTo)) continue;
+    const targetFile = join(skill.referencesRoot, "phases", phase.advancesTo, `${phase.advancesTo}.md`);
+    if (!existsSync(targetFile)) {
+      add(
+        skill.rel(phase.sourceFile),
+        `_advances_to '${phase.advancesTo}' names neither a terminal (complete/done/end) nor an existing phase (no references/phases/${phase.advancesTo}/${phase.advancesTo}.md) — dangling forward edge`,
+      );
+    }
+  }
+
   // ---- Backbone chain-consistency (backbone phases only; checkpoints excluded) ----
   // The backbone is the linear lifecycle wired by _advances_to (forward) and
   // _requires_phase (backward). Checkpoints (_kind: checkpoint) are off-backbone and


### PR DESCRIPTION
## What

The frontmatter validator silently **passed** a phase whose `_advances_to` names a phase that doesn't exist — a false green on a broken backbone.

## Root cause

The backbone chain-consistency block is gated on `advTargetsResolvable`, which **self-skips** the moment any `_advances_to` is unresolvable (it assumes "that phase just isn't frontmatter-annotated yet — partial rollout"). And unlike `_requires_phase`, `_advances_to` had **no independent membership check**. So a genuine dangling/typo'd forward edge disables the very checks meant to catch it.

**Reproduced:** setting `generate._advances_to` to a non-existent phase (`generate` has no `_re_entry_guard` to incidentally trip) → validator reports `OK`, exit 0. CI would pass a backbone that dead-ends nowhere. (A typo on `discover` only went red by luck — its `_re_entry_guard._stale_if_completed` cross-check tripped a *different* rule.)

## Fix

An **independent** dangling-forward-edge check: each non-terminal `_advances_to` target must resolve to a phase **directory on disk** (`references/phases/<name>/<name>.md`), not the frontmatter-declared set.

This preserves partial-rollout tolerance — an edge to a real phase whose file exists but has no frontmatter *yet* still resolves — while failing only on an edge to a phase that **doesn't exist at all**. (In the real heroku rollout the prose file was always present when frontmatter lagged, so this matches how rollout actually happened.)

## Changes

- **`check.ts`** — +independent dangling-forward-edge check (disk membership), placed before the rollout-gated chain block so it can't be self-skipped.
- **tests** — `goodSkill()` now includes a frontmatter-less `clarify.md` stub so its partial-rollout test is **faithful** (real phase, no frontmatter → tolerated, resolves on disk); **+1 regression test** for a truly-absent target (typo → fail). **41 tests total.**

## Verification

- `mise run build` green: lint:md, lint:types (tsc strict), lint:frontmatter (real skill clean), 41/41 tests, fmt:check.
- Manually confirmed: broken `generate._advances_to` now **fails** with a clear message; real skill stays clean.

## Ownership

Touches only team-owned validator + tests — **no admin-owned paths**.
