### PR TITLE
refactor(migration-to-aws): generate contract = mandatory floor + forbids ceiling

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -4,8 +4,6 @@ _of_phase: generate
 _contributes:
   - MIGRATION_GUIDE.md
   - README.md
-  - { file: scripts/migrate-postgres.sh, _when: "Postgres (RDS/Aurora) is in the design" }
-  - { file: scripts/migrate-redis.sh, _when: "Redis (ElastiCache) is in the design" }
 ---
 
 # Generate Phase: Documentation and Script Generation

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -2,8 +2,8 @@
 _fragment: eks-generate
 _of_phase: generate
 _contributes:
-  - { file: terraform/eks.tf, _when: "aws-design.json has an eks_cluster entry OR a service with aws_service == 'EKS'" }
-  - { file: kubernetes/, _when: "aws-design.json has an eks_cluster entry OR a service with aws_service == 'EKS'" }
+  - terraform/eks.tf
+  - kubernetes/
 ---
 
 # EKS Generate Phase

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -5,6 +5,9 @@ _contributes:
   - terraform/main.tf
   - terraform/variables.tf
   - terraform/outputs.tf
+  - terraform/security.tf
+  - terraform/.gitignore
+  - terraform/terraform.tfvars.example
 ---
 
 # Generate Phase: Terraform Configuration Generation

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -23,13 +23,12 @@ _produces:
   - terraform/main.tf
   - terraform/variables.tf
   - terraform/outputs.tf
+  - terraform/security.tf
+  - terraform/.gitignore
+  - terraform/terraform.tfvars.example
   - MIGRATION_GUIDE.md
   - README.md
   - generation-warnings.json
-  - { file: terraform/eks.tf, _when: "aws-design.json has an eks_cluster entry OR a service with aws_service == 'EKS'" }
-  - { file: kubernetes/, _when: "aws-design.json has an eks_cluster entry OR a service with aws_service == 'EKS'" }
-  - { file: scripts/migrate-postgres.sh, _when: "Postgres (RDS/Aurora) is in the design" }
-  - { file: scripts/migrate-redis.sh, _when: "Redis (ElastiCache) is in the design" }
 _advances_to: complete
 _preconditions:
   - _check_phase_completed: estimate
@@ -41,7 +40,7 @@ _preconditions:
   - _validate_json: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
     _on_failure: _unrecoverable
 _postconditions:
-  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, MIGRATION_GUIDE.md, README.md]
+  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md]
     _on_failure: _halt_and_inform
   - _assert: "terraform/main.tf has valid provider configuration; terraform/variables.tf declares at least an aws_region variable"
     _on_failure: _halt_and_inform
@@ -49,14 +48,19 @@ _postconditions:
     _on_failure: _halt_and_inform
   - _assert: "MIGRATION_GUIDE.md has Prerequisites and Verification sections; README.md lists the artifacts"
     _on_failure: _halt_and_inform
-  - _assert: "the conditional artifacts declared in _produces exist per their _when: if Postgres is in the design, scripts/migrate-postgres.sh exists; if Redis is in the design, scripts/migrate-redis.sh exists"
+  - _assert: "if Postgres is in the design, scripts/migrate-postgres.sh exists; if Redis is in the design, scripts/migrate-redis.sh exists"
     _on_failure: _halt_and_inform
-  - _assert: "if EKS is in the design (terraform/eks.tf + kubernetes/ declared in _produces with _when): terraform/eks.tf exists WITH cluster + node group resources, AND the kubernetes/ directory has namespace + deployment manifests"
+  - _assert: "if EKS is in the design, terraform/eks.tf exists WITH cluster + node group resources, AND a kubernetes/ directory has namespace + deployment manifests"
     _on_failure: _halt_and_inform
   - _assert: "every designed service is accounted for (generated or listed in generation-warnings.json)"
     _on_failure: _halt_and_inform
   - _assert: "no placeholder {{VARIABLE}} tokens remain in Terraform .tf files (those belong in variables.tf as var.* references)"
     _on_failure: _halt_and_inform
+_forbids_files:
+  - heroku-resource-inventory.json
+  - preferences.json
+  - aws-design.json
+  - estimation-infra.json
 ---
 
 # Phase 5: Generate Migration Artifacts


### PR DESCRIPTION
## What

Reframes `generate`'s `_produces` from *"the exhaustive artifact set"* (which it never truly was — the phase fans out to 18+ files, including per-formation `kubernetes/` manifests and per-service outputs that can't be enumerated) to a **mandatory floor** plus an explicit **forbids ceiling**. For a terminal fan-out phase, that's a truer contract than a pretend-exhaustive list.

## Model

- **`_produces` = the always-emitted floor only** (bare filenames, no `_when`). Added the 3 always-on terraform files that were emitted-but-undeclared (`security.tf`, `.gitignore`, `terraform.tfvars.example`) alongside the existing core.
- **`_forbids_files` = new explicit ceiling.** `generate` was the only phase without one. For a terminal phase the meaningful forbid is the *inverse* of the upstream phases (which forbid downstream artifacts): forbid **overwriting its 4 upstream inputs** (`heroku-resource-inventory` / `preferences` / `aws-design` / `estimation-infra`.json). Read-yes (they're `_input`), create-no.
- **Open tail** (domain `.tf`: database/cache/messaging/compute/vpc; `eks.tf` + `kubernetes/`; migration scripts) is intentionally **not** enumerated — it's data-driven and unbounded. Governed at runtime by the fragments' `_trigger`s + the conditional `_postconditions` asserts, which remain the gate.

## Relationship to #118

This **supersedes #118's application to `generate`** (removes the 4 `{file, _when}` entries from its `_produces`) but **keeps the #118 grammar intact** — `_produces`/`_contributes` still parse `{file, _when}`, all **45 validator tests stay green** — so a future phase that wants conditional-mandatory artifacts can still use it. (Per the decision: don't change the grammar, someone may need it.)

Reverted `generate-docs` / `generate-eks` `_contributes` to bare (the fragment `_trigger`s already carry the conditionality); added the 3 floored files to `generate-terraform` `_contributes` so single-creator finds their creator.

## Also (cold-review catch)

The completion gate's `_check_file_exists` now verifies the **full declared floor** (added `security.tf` / `.gitignore` / `tfvars.example`) — it previously under-checked its own floor. The postcondition⊆`_produces` invariant is preserved.

## Verification

- `mise run build` green: markdownlint, tsc strict, `lint:frontmatter` (real skill OK), 45/45 tests, `fmt:check`.
- **Cold-validated** read-only (EKS + Postgres, no Redis): `_produces` reads as a floor; `eks.tf`/`kubernetes/`/`migrate-postgres.sh` still produced via fragment triggers + enforced by asserts; `migrate-redis.sh` correctly absent; `_forbids_files` understood as read-yes/create-no vs `_input`; behavior fully determined.

## Note (pre-existing, not fixed here)

`generation-warnings.json` is a bare `_produces` entry but is actually conditionally emitted ("if any services skipped") — a small latent inconsistency, left for a focused follow-up.

## Ownership

Team-owned skill files only — **no admin-owned paths**.
