### PR TITLE
fix(migration-to-aws): generation-warnings.json is always written (empty when clean)

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -32,7 +32,7 @@ Verify the complete set of generated artifacts:
 7. `MIGRATION_GUIDE.md` — step-by-step migration procedure
 8. `README.md` — artifact listing and quick start
 9. Database migration scripts (conditional on design content)
-10. `generation-warnings.json` (if any services were skipped)
+10. `generation-warnings.json` (always written; empty `warnings` array when nothing was skipped)
 
 **Cross-reference checks:**
 
@@ -76,7 +76,7 @@ Artifacts produced:
 • MIGRATION_GUIDE.md — Step-by-step migration procedure
 • README.md — Artifact listing and quick start
 • scripts/ — Database migration scripts
-[• generation-warnings.json — N service(s) require manual setup]
+[• generation-warnings.json — N service(s) require manual setup]   (show this line only when warnings is non-empty; the file is always written)
 
 Migration planning is complete. All artifacts are in $MIGRATION_DIR/.
 ```
@@ -98,7 +98,7 @@ After this output, SKILL.md handles the post-Generate share prompt and feedback 
 
 - `scripts/migrate-postgres.sh` — when Postgres in design
 - `scripts/migrate-redis.sh` — when Redis in design
-- `generation-warnings.json` — when any services skipped
+- `generation-warnings.json` — always written (empty `warnings` array when nothing was skipped)
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -883,7 +883,7 @@ Follow the verification checklist in `MIGRATION_GUIDE.md` Phase 4, then perform 
 - `has_postgres`: True if any service has `aws_service` containing `"RDS PostgreSQL"` or `"Aurora PostgreSQL"`
 - `has_redis`: True if any service has `aws_service == "ElastiCache Redis"`
 - `has_kafka`: True if any service has `aws_service == "Amazon MSK"`
-- `generation_warnings_exist`: True if `generation-warnings.json` was created during Terraform generation
+- `generation_warnings_exist`: True if `generation-warnings.json` has a NON-EMPTY `warnings` array (the file is always written, so test its contents, not its existence)
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -69,7 +69,7 @@ Generate `$MIGRATION_DIR/terraform/` with the following file organization. Only 
 | Security Group, IAM Role/Policy    | `security.tf`  |
 | CloudWatch Logs                    | `compute.tf`   |
 
-**Unmapped services:** If `aws-design.json` contains a `service_id` with an `aws_service` value that has no Terraform resource mapping in this file (e.g., CloudWatch + X-Ray composite, Amazon SES, Amazon SNS), **skip** that resource and log a warning to `generation-warnings.json`. Do NOT halt generation.
+**Unmapped services:** If `aws-design.json` contains a `service_id` with an `aws_service` value that has no Terraform resource mapping in this file (e.g., CloudWatch + X-Ray composite, Amazon SES, Amazon SNS), **skip** that resource and record a warning in `generation-warnings.json` (which is ALWAYS written — see Step 10 — with an empty `warnings` array when nothing is skipped). Do NOT halt generation.
 
 ---
 
@@ -1329,10 +1329,20 @@ resource "aws_cloudwatch_log_group" "msk" {
 
 ## Step 10: Handle Unmapped Resources and Warnings
 
-For any `service_id` in `aws-design.json` whose `aws_service` does not have a Terraform resource mapping defined in Steps 4–9 above:
+**Always write `$MIGRATION_DIR/generation-warnings.json`** — it is a mandatory
+artifact of this phase (part of generate's `_produces` floor), a manifest that
+records whatever could NOT be generated. Write it even when nothing was skipped:
+in that case the `warnings` array is EMPTY (`"warnings": []`). A consumer can then
+rely on the file always existing rather than testing for its absence.
+
+For any `service_id` in `aws-design.json` whose `aws_service` does not have a
+Terraform resource mapping defined in Steps 4–9 above:
 
 1. **Skip** the resource — do NOT generate Terraform for it
-2. **Log** the skip to `$MIGRATION_DIR/generation-warnings.json`
+2. **Append** the skip as an entry in `generation-warnings.json`'s `warnings` array
+
+If every service mapped successfully, still write the file with an empty
+`warnings` array.
 
 ### `generation-warnings.json` Schema
 
@@ -1459,7 +1469,7 @@ terraform/
 
 Files are only emitted if their domain has resources in `aws-design.json`. The minimum set is always: `main.tf`, `variables.tf`, `outputs.tf`, `security.tf`, `.gitignore`, `terraform.tfvars.example`.
 
-Additionally, `$MIGRATION_DIR/generation-warnings.json` is emitted if any services were skipped.
+Additionally, `$MIGRATION_DIR/generation-warnings.json` is ALWAYS emitted (empty `warnings` array when no services were skipped).
 
 ---
 
@@ -1472,7 +1482,7 @@ Before returning control to `generate.md`, require:
 3. `$MIGRATION_DIR/terraform/outputs.tf` exists
 4. At least one domain file (`compute.tf`, `database.tf`, `cache.tf`, `messaging.tf`, or `vpc.tf`) exists
 5. All resource cross-references resolve within the configuration
-6. `generation-warnings.json` exists if any services were skipped (empty `warnings` array if all mapped successfully)
+6. `generation-warnings.json` exists (ALWAYS written; empty `warnings` array if all services mapped successfully)
 
 If this gate fails: STOP and output: "generate-terraform did not produce a valid terraform/ directory; do not continue Generate."
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -40,7 +40,7 @@ _preconditions:
   - _validate_json: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
     _on_failure: _unrecoverable
 _postconditions:
-  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md]
+  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md, generation-warnings.json]
     _on_failure: _halt_and_inform
   - _assert: "terraform/main.tf has valid provider configuration; terraform/variables.tf declares at least an aws_region variable"
     _on_failure: _halt_and_inform
@@ -94,7 +94,7 @@ Load `references/phases/generate/generate-terraform.md` and execute completely.
 This produces:
 
 - `$MIGRATION_DIR/terraform/` directory with all `.tf` files
-- `$MIGRATION_DIR/generation-warnings.json` (if any services were skipped)
+- `$MIGRATION_DIR/generation-warnings.json` (always written; empty `warnings` array when nothing was skipped)
 
 **Gate check after Step 1:**
 


### PR DESCRIPTION
## What

Resolves a self-contradiction the #119 floor review surfaced: `generation-warnings.json` was declared as a **bare (unconditional)** entry in `generate`'s `_produces` floor, but the prose said it was written *"if any services were skipped."* A clean migration would then leave a declared floor artifact **absent** — a mis-declared contract.

## Decision

Chose the **"always written, empty when clean"** reading (the more specific source already described the empty-array case). `generation-warnings.json` is now a genuine always-present **manifest**: every service either generates **or** appears in its `warnings` array, and a consumer can rely on the file always existing rather than testing for absence.

## Changes

- **`generate-terraform.md`** — Step 10 now instructs **always write** the file, `warnings: []` when nothing was skipped. The overview skip-note, Output Summary, and Completion Handoff Gate item 6 reworded to always-written.
- **`generate.md`** — `generation-warnings.json` added to the completion-gate `_check_file_exists` (a floor artifact should be gate-verified; it was in `_produces` but unchecked). postcondition⊆`_produces` invariant preserved.
- **`generate-assemble.md`** — validation list + cross-ref reworded to always-written; the user-facing "N service(s) require manual setup" output line clarified to display **only when `warnings` is non-empty** (the file is always written regardless).
- **`generate-docs.md`** — `generation_warnings_exist` flag redefined to key off a **non-empty** `warnings` array (was "file was created" — always true now), so the README only advertises the warnings row when there are actual warnings.

## Verification

- `mise run build` green: markdownlint, tsc strict, `lint:frontmatter` (real skill OK), 45/45 tests, `fmt:check`.
- **Cold-validated** read-only: a clean compute-only run writes the file with `warnings: []`; the floor + `_check_file_exists` both cover it; the README flag keys off content not existence; no residual conditional phrasing across the 4 files (the one soft spot the reviewer found — the overview skip-note — was tightened to reference the always-written rule).

## Context

Closes N3 follow-up (a) from the handoff ledger. N3's other follow-up (domain `.tf` open-tail) remains by-design.

## Ownership

Team-owned skill files only — **no admin-owned paths**.
