### PR TITLE
docs(heroku-to-aws): prune redundant prose from discover + clarify phases

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-assemble.md
@@ -90,8 +90,6 @@ Write `$MIGRATION_DIR/preferences.json`:
 6. `network.existing_vpc_id` and `network.subnet_ids` are `null`/empty when no Private Space peering exists.
 7. `data.database_ha`, `data.redis_ha`, `data.kafka_retention_days` are omitted entirely when those services are not present in the inventory.
 
-After writing `preferences.json`, delete any stale `$MIGRATION_DIR/preferences-draft.json` left by an older skill version (drafts are no longer written or consumed).
-
 ---
 
 ## Validation Checklist
@@ -130,12 +128,8 @@ private-space conditionals), then emit `GATE_FAIL` (STOP; do not patch artifacts
 
 ---
 
-## Step 5: Update Phase Status
+## Step 5: Update Phase Status and Hand Off
 
-Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop) to update `.phase-status.json`:
-
-- Set `phases.clarify` to `"completed"`
-- Set `current_phase` to `"design"`
-- Update `last_updated` to current ISO timestamp
+Only after `HANDOFF_OK`, apply the phase-status update protocol (`INTERPRETER.md` § The interpreter loop) — mark `phases.clarify` completed and advance per `_advances_to` — in the **same turn** as the output message below.
 
 Output to user: "Clarification complete. Proceeding to Phase 3: Design AWS Architecture."

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-interview.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify-interview.md
@@ -31,9 +31,7 @@ Check `$MIGRATION_DIR/` for existing state:
 - If A: Skip to Validation Checklist with the existing `preferences.json`.
 - If B: Delete `preferences.json`, continue to Step 1.
 
-**Case 2 — No prior state**: Continue to Step 1. (If a stale
-`preferences-draft.json` from an older skill version is present, delete it — the
-interview no longer resumes from drafts; it always runs to completion in one pass.)
+**Case 2 — No prior state**: Continue to Step 1.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/clarify/clarify.md
@@ -61,18 +61,12 @@ Questions are organized into **three batches** (≤7 per batch) presented sequen
 
 ---
 
-## Sub-Files
-
-- **clarify-interview.md** → the adaptive interview: prior-run check, fast-path gate, active-question selection, and the progressive-batch Q&A (with the full Question Catalog + Defaults Table). Interprets answers into `preferences.json` fields.
-- **clarify-assemble.md** → the assembler: assembles + writes the final `preferences.json`, runs the validation checklist + completion handoff gate, and updates `.phase-status.json`.
-
----
-
 ## Step 1: Run the Interview
 
 Load `references/phases/clarify/clarify-interview.md` and follow it. It handles the
 prior-run check, determines fast-path eligibility, selects the active question set,
-and presents the questions in progressive batches — interpreting each answer.
+and presents the questions in progressive batches — interpreting each answer. It
+contains the full Question Catalog and Defaults Table.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-assemble.md
@@ -32,12 +32,12 @@ After all sub-discoveries complete, assemble `heroku-resource-inventory.json` in
    - `procfile_parse_warning`, `app_json_parse_warning` (per-app parse warnings or null)
 6. Include `billing_profile` section (if billing data available, with `available`, `total_monthly_cost`, `currency`, `billing_period`, `line_items`).
 7. Include `terraform_metadata` section (if Terraform discovery ran, with `found`, `tf_files_scanned`, `resource_types_extracted`, `parse_warnings`).
-8. Verify NO forbidden fields exist: `cluster_id`, `creation_order_depth`, `edges`, `dependencies`, `must_migrate_together`.
 
 **If assembly fails** (no valid resources from any source after sub-discoveries ran):
+this is an unrecoverable error (`INTERPRETER.md` § `_on_error` — `_unrecoverable`).
+STOP and output: "Discovery ran but produced no valid resources. Check that your
+input files contain valid Heroku resources and try again."
 
-Apply **unrecoverable error behavior** (Rule 4 in `discover.md`):
-
-- Revert `phases.discover` to `"pending"`.
-- Preserve prior completed phases.
-- STOP and output: "Discovery ran but produced no valid resources. Check that your input files contain valid Heroku resources and try again."
+(The phase's `_postconditions` separately enforce that no forbidden clustering
+fields — `cluster_id`, `creation_order_depth`, `edges`, `dependencies`,
+`must_migrate_together` — appear in the assembled artifact.)

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-billing.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-billing.md
@@ -16,14 +16,13 @@ _contributes:
 
 ## Step 0: Self-Scan for Billing Files
 
-Scan the target directory for Heroku billing data:
+This fragment runs only when its `_trigger` glob matches a billing/invoice file
+(see frontmatter). Confirm at least one such file is present and readable.
 
-- `**/*billing*.csv` — Heroku Enterprise CSV billing export
-- `**/*invoice*.csv` — Heroku Dashboard invoice CSV export
-- `**/*billing*.json` — Heroku billing JSON (API export or Dashboard download)
-- `**/*invoice*.json` — Heroku Dashboard invoice JSON
-
-**Exit gate:** If NO billing files are found, **exit cleanly**. Return no output artifacts. Set `billing_profile.available` to `false` in the inventory contribution. Other sub-discovery files will still produce their artifacts.
+**Exit gate:** If no usable billing file is found (none present, or the matched
+file(s) turn out not to be parseable billing data), contribute
+`billing_profile: { available: false }` and **exit cleanly** — return no other
+output. Discovery continues; other sub-discoveries still produce their artifacts.
 
 Log: "No billing files found — skipping billing discovery. Cost comparison will be limited to projected AWS costs only."
 
@@ -249,25 +248,12 @@ Produce the `billing_profile` section for inclusion in `heroku-resource-inventor
 | `line_items[].cost`          | number  | Yes      | Cost amount for this line item                                                                                  |
 | `parse_warnings`             | array   | Yes      | Any warnings generated during parsing (empty array if none)                                                     |
 
-### When Billing Profile is Unavailable
-
-If no billing files are found (Step 0 exit gate), the parent orchestrator sets:
-
-```json
-{
-  "billing_profile": {
-    "available": false
-  }
-}
-```
-
 ---
 
 ## Error Handling
 
 | Error Category                  | Behavior                                       | Effect on Discovery                                         |
 | ------------------------------- | ---------------------------------------------- | ----------------------------------------------------------- |
-| No billing files found          | Exit cleanly, no output                        | Discovery continues with API/Terraform inventory only       |
 | Unrecognized CSV header format  | Log warning with filename, skip file           | Try next billing file; if none remain, exit cleanly         |
 | Unrecognized JSON structure     | Log warning with filename, skip file           | Try next billing file; if none remain, exit cleanly         |
 | Malformed JSON (parse error)    | Log warning with filename and error, skip file | Try next billing file; if none remain, exit cleanly         |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
@@ -504,22 +504,23 @@ terraform-specific content and rules:
   primary inventory data; Procfile/app.json supplements them (adds `command`,
   buildpacks, declared add-ons). When Procfile was available, formation entries
   have `command` populated; otherwise `command` is `null`.
-- **`terraform_metadata`:** contribute this shape —
-  ```json
-  {
-    "terraform_metadata": {
-      "found": true,
-      "tf_files_scanned": 5,
-      "resource_types_extracted": ["heroku_app", "heroku_addon", "heroku_formation"],
-      "parse_warnings": []
-    }
-  }
-  ```
 - **Confidence:** set `metadata.confidence` to `"full"` when all Terraform files
   parsed successfully, or `"reduced"` if any parse errors occurred or expected
   resources were missing.
 - **Discovery sources:** contribute `"terraform"` to `metadata.discovery_sources`,
   and `"procfile"` as well if Procfile/app.json were found and parsed.
+- **`terraform_metadata`:** contribute the shape shown below.
+
+```json
+{
+  "terraform_metadata": {
+    "found": true,
+    "tf_files_scanned": 5,
+    "resource_types_extracted": ["heroku_app", "heroku_addon", "heroku_formation"],
+    "parse_warnings": []
+  }
+}
+```
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover-terraform.md
@@ -48,15 +48,6 @@ Specifically, match lines containing `resource "heroku_` (with double-quote befo
 - `heroku_pipeline`
 - `heroku_space`
 
-### 0c. Exit Gate
-
-**If NO `.tf` files contain any `heroku_*` resource blocks:**
-
-- Log: "No Terraform files with heroku_* resources found — skipping Terraform discovery."
-- **Exit cleanly.** Return no output artifacts. Other sub-discovery files will still produce their artifacts.
-
-**If at least one `heroku_*` resource found → continue to Step 1.**
-
 ---
 
 ## Step 1: Extract Resources from Terraform
@@ -505,59 +496,44 @@ For each `heroku_app` resource:
 
 ## Step 4: Output Contribution for Parent Orchestrator
 
-This sub-discovery contributes two sections to `heroku-resource-inventory.json`:
+The phase assembler (`discover-assemble.md`) owns the inventory's STRUCTURE (which
+sections exist and their field lists). This fragment contributes the following
+terraform-specific content and rules:
 
-### 4a. Resources Contribution
-
-All Terraform-sourced resource entries are included directly in the `resources[]` array as the primary inventory data. Procfile/app.json data supplements Terraform entries with additional fields (commands, buildpacks).
-
-### 4b. `terraform_metadata` Section
-
-```json
-{
-  "terraform_metadata": {
-    "found": true,
-    "tf_files_scanned": 5,
-    "resource_types_extracted": ["heroku_app", "heroku_addon", "heroku_formation"],
-    "parse_warnings": []
+- **Resources:** all Terraform-sourced entries go into `resources[]` as the
+  primary inventory data; Procfile/app.json supplements them (adds `command`,
+  buildpacks, declared add-ons). When Procfile was available, formation entries
+  have `command` populated; otherwise `command` is `null`.
+- **`terraform_metadata`:** contribute this shape —
+  ```json
+  {
+    "terraform_metadata": {
+      "found": true,
+      "tf_files_scanned": 5,
+      "resource_types_extracted": ["heroku_app", "heroku_addon", "heroku_formation"],
+      "parse_warnings": []
+    }
   }
-}
-```
-
-### 4c. Confidence Metadata Contribution
-
-Terraform + repo artifacts is the primary (and only) discovery path in v1:
-
-- Set `metadata.confidence` to `"full"` when all Terraform files parsed successfully
-- Set `metadata.confidence` to `"reduced"` if any parse errors occurred or expected resources were missing
-- `metadata.discovery_sources` includes `"terraform"` and (if Procfile/app.json found) `"procfile"`
-
-### 4d. Output Assembly
-
-All Terraform-extracted resources are the primary inventory entries. Procfile/app.json data supplements them (adds `command`, buildpacks, declared add-ons).
-
-If Procfile was available: formation resources will have `command` fields populated.
-If Procfile was NOT available: formation `command` fields will be `null`.
-
-### 4e. Discovery Sources Contribution
-
-Add `"terraform"` to `metadata.discovery_sources` array. If Procfile or app.json were found and parsed, also add `"procfile"`.
+  ```
+- **Confidence:** set `metadata.confidence` to `"full"` when all Terraform files
+  parsed successfully, or `"reduced"` if any parse errors occurred or expected
+  resources were missing.
+- **Discovery sources:** contribute `"terraform"` to `metadata.discovery_sources`,
+  and `"procfile"` as well if Procfile/app.json were found and parsed.
 
 ---
 
 ## Error Handling
 
-| Error Category                         | Behavior                                     | Effect on Discovery                      |
-| -------------------------------------- | -------------------------------------------- | ---------------------------------------- |
-| No `.tf` files in workspace            | Exit cleanly, no output                      | Billing discovery may still run          |
-| No `heroku_*` resources in `.tf` files | Exit cleanly, no output                      | Billing discovery may still run          |
-| HCL parse error in one file            | Log warning, skip malformed blocks, continue | Other files still processed              |
-| HCL parse error in all files           | Log warning, exit cleanly                    | Billing discovery may still run          |
-| Unresolvable Terraform reference       | Set `heroku_app: "unassociated"`, continue   | Resource included with limited context   |
-| `heroku_app` resource has no `name`    | Skip resource, log warning                   | Other resources still processed          |
-| `heroku_addon` has unparseable `plan`  | Record with `plan: "unknown"`, continue      | Resource included with limited plan info |
-| File read permission denied            | Log warning, skip file, continue             | Other files still processed              |
-| Circular Terraform references          | Resolve to best-effort, log warning          | Resources included with available data   |
+| Error Category                        | Behavior                                     | Effect on Discovery                      |
+| ------------------------------------- | -------------------------------------------- | ---------------------------------------- |
+| HCL parse error in one file           | Log warning, skip malformed blocks, continue | Other files still processed              |
+| HCL parse error in all files          | Log warning, exit cleanly                    | Billing discovery may still run          |
+| Unresolvable Terraform reference      | Set `heroku_app: "unassociated"`, continue   | Resource included with limited context   |
+| `heroku_app` resource has no `name`   | Skip resource, log warning                   | Other resources still processed          |
+| `heroku_addon` has unparseable `plan` | Record with `plan: "unknown"`, continue      | Resource included with limited plan info |
+| File read permission denied           | Log warning, skip file, continue             | Other files still processed              |
+| Circular Terraform references         | Resolve to best-effort, log warning          | Resources included with available data   |
 
 **Key principle:** Terraform discovery is the **primary** discovery path in v1. Any parse failure results in a warning and graceful skip for that specific block — it should NOT halt the entire discovery. Partial results are always better than no results.
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -48,78 +48,9 @@ _forbids_files:
 Lightweight orchestrator that delegates to domain-specific discoverers. Each sub-discovery file is self-contained — it scans for its own input, processes what it finds, and exits cleanly if nothing is relevant.
 **Execute ALL steps in order. Do not skip or deviate.**
 
-## Sub-Discovery Files
+Procfile and app.json parsing is integrated into the Terraform discovery flow (there is no standalone Procfile fragment) — when repo artifacts are found alongside Terraform, they supplement resource data with commands, buildpacks, and declared add-ons.
 
-- **discover-terraform.md** → Terraform discovery (primary): `.tf` files with `heroku_*` resource types
-- **discover-billing.md** → Billing data parsing: Heroku Dashboard invoices or Enterprise CSV exports
-
-Procfile and app.json parsing is integrated into the Terraform discovery flow — when repo artifacts are found alongside Terraform, they supplement resource data with commands, buildpacks, and declared add-ons.
-
-All sub-discoveries contribute to a single `heroku-resource-inventory.json` artifact.
-
-**Note:** Platform API discovery is NOT supported in v1. No API calls are made. Discovery is entirely file-based (Terraform + repo + billing).
-
----
-
-## Phase Status State Machine
-
-### Valid Transitions
-
-```
-pending → in_progress → completed
-```
-
-Status NEVER goes backward under normal operation. Only an **unrecoverable error** reverts the current phase to `pending`.
-
-### Phase Gate Rules (Fail Closed)
-
-**Rule 1 — Predecessor gate:** A phase may transition to `in_progress` ONLY when its immediate predecessor phase has status `completed`. The ordered phase list is:
-
-```
-discover → clarify → design → estimate → generate
-```
-
-- `discover` has no predecessor — it may always start.
-- `clarify` requires `phases.discover == "completed"`.
-- `design` requires `phases.clarify == "completed"`.
-- `estimate` requires `phases.design == "completed"`.
-- `generate` requires `phases.estimate == "completed"`.
-
-If the predecessor is not `completed`, emit:
-
-```
-GATE_FAIL | phase=<target_phase> | field=phases.<predecessor> | reason=missing
-```
-
-Do NOT advance. Do NOT modify `.phase-status.json`. Tell the user which prior phase must complete first.
-
-**Rule 2 — Single active phase:** At most one core phase (discover, clarify, design, estimate, generate) may be `in_progress` at any time. If another phase is already `in_progress`, emit:
-
-```
-GATE_FAIL | phase=<target_phase> | field=phases.<active_phase> | reason=invalid
-```
-
-**Rule 3 — GATE_FAIL halt behavior:** When any handoff gate check fails at phase completion:
-
-1. Retain the failing phase's status as `in_progress` — do NOT revert it.
-2. Do NOT advance `current_phase`.
-3. Do NOT modify any artifacts to force the gate to pass.
-4. Surface a diagnostic to the user identifying:
-   - The phase that failed (`phase=<name>`)
-   - The specific field or artifact that failed (`field=<dotted.path>`)
-   - The failure reason (`reason=missing|invalid|stale_downstream`)
-5. Tell the user: "Re-run Phase N (phase name) to produce the missing field, then continue."
-
-**Rule 4 — Unrecoverable error behavior:** When a phase fails during execution due to an unrecoverable error (e.g., no Heroku sources found, corrupted state file, critical sub-discovery failure that blocks all outputs):
-
-1. Revert that phase's status to `pending` in `.phase-status.json`.
-2. Preserve all artifacts and status values from prior completed phases — do NOT touch them.
-3. Surface a diagnostic to the user identifying:
-   - The failed phase
-   - The error category (e.g., `no_sources`, `state_corrupted`, `auth_failure`)
-   - Actionable guidance on how to resolve
-
-**Rule 5 — Phase re-entry:** Stale-downstream re-entry is handled by each phase's `_re_entry_guard` frontmatter — see `INTERPRETER.md` § `_re_entry_guard`. Re-running a phase after a downstream phase completed requires explicit user confirmation; on confirmation the downstream phases are reset to `"pending"`.
+**Note:** Platform API discovery is NOT supported in v1. No API calls are made. Discovery is entirely file-based (Terraform + repo + billing). All sub-discoveries contribute to a single `heroku-resource-inventory.json` artifact via the phase assembler.
 
 ---
 
@@ -157,12 +88,7 @@ Glob for: `**/*billing*.csv`, `**/*invoice*.csv`, `**/*billing*.json`, `**/*invo
 
 ### 1d. Source validation gate
 
-**If NO Terraform files with `heroku_*` resources found** (regardless of whether Procfile/app.json exist):
-
-1. Apply **unrecoverable error behavior** (Rule 4):
-   - Revert `phases.discover` to `"pending"` in `.phase-status.json`.
-   - Preserve all other phase statuses unchanged.
-2. STOP and output: "No Terraform files with heroku_* resources found. Heroku Terraform is required for discovery. Procfile and app.json alone are not sufficient."
+**If NO Terraform files with `heroku_*` resources found** (regardless of whether Procfile/app.json exist): this phase's `_preconditions` `_assert` fails with `_on_failure: _unrecoverable` (see `INTERPRETER.md` § Gate protocol / `_on_error`) — STOP and output: "No Terraform files with heroku_* resources found. Heroku Terraform is required for discovery. Procfile and app.json alone are not sufficient."
 
 ---
 
@@ -226,16 +152,9 @@ emit `GATE_FAIL` (STOP; do not patch artifacts) or
 
 ---
 
-## Step 5: Update Phase Status
+## Step 5: Update Phase Status and Hand Off
 
-Only after `HANDOFF_OK`. In the **same turn** as the output message below, use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop) to update `.phase-status.json`:
-
-1. Read current `.phase-status.json` from disk.
-2. Set `phases.discover` to `"completed"`.
-3. Set `current_phase` to `"clarify"`.
-4. Update `last_updated` to current ISO 8601 timestamp.
-5. Keep all other phase values unchanged.
-6. Write the full file.
+Only after `HANDOFF_OK`, apply the phase-status update protocol (`INTERPRETER.md` § The interpreter loop) — mark `phases.discover` completed and advance per `_advances_to` — in the **same turn** as the output message below.
 
 Output to user — build message from inventory contents:
 
@@ -251,39 +170,22 @@ Format: "Discover phase complete. [artifact summaries] Next required step: Phase
 
 ## Output Files
 
-**Discover phase writes files to `$MIGRATION_DIR/`. Required outputs:**
-
-1. `.phase-status.json` — phase tracking (initialized in Step 0, updated in Step 5)
-2. `heroku-resource-inventory.json` — flat resource inventory
-
-**Optional outputs (depending on available sources):**
-
-- Billing profile embedded in inventory (not a separate file)
-
-**No other files must be created:**
-
-- No README.md
-- No discovery-summary.md
-- No EXECUTION_REPORT.txt
-- No discovery-log.md
-- No documentation or report files
-
-All user communication via output messages only.
+This phase's artifacts are declared in `_produces` and its scope boundary (files it must NOT create) in `_forbids_files`. Billing data, when present, is embedded in `heroku-resource-inventory.json` — not a separate file. All user communication is via output messages only (no report/log files).
 
 ---
 
 ## Error Handling
 
-| Error Category                                                 | Behavior                                       | Status Transition             |
-| -------------------------------------------------------------- | ---------------------------------------------- | ----------------------------- |
-| No Heroku Terraform files (no `.tf` with `heroku_*` resources) | STOP, surface diagnostic                       | Revert to `pending` (Rule 4)  |
-| Terraform parse error (malformed HCL)                          | Log warning, skip malformed blocks, continue   | Continue `in_progress`        |
-| Procfile/app.json parse error                                  | Record warning per-app, continue               | Continue `in_progress`        |
-| Generation detection unresolvable (no stack attr)              | Set `heroku_generation` to `unknown`, continue | Continue `in_progress`        |
-| Pipeline detection from Terraform incomplete                   | Record with available data, continue           | Continue `in_progress`        |
-| All sub-discoveries produce no resources                       | STOP, surface diagnostic                       | Revert to `pending` (Rule 4)  |
-| `.phase-status.json` invalid JSON                              | STOP, surface diagnostic                       | N/A (state corrupted)         |
-| Handoff gate check fails (GATE_FAIL)                           | Halt pipeline, surface diagnostic              | Retain `in_progress` (Rule 3) |
+Non-fatal discovery errors and their handling (fatal source/gate failures are handled by `_preconditions`/`_postconditions` + `INTERPRETER.md` § `_on_error`):
+
+| Error Category                                    | Behavior                                       |
+| ------------------------------------------------- | ---------------------------------------------- |
+| Terraform parse error (malformed HCL)             | Log warning, skip malformed blocks, continue   |
+| Procfile/app.json parse error                     | Record warning per-app, continue               |
+| Generation detection unresolvable (no stack attr) | Set `heroku_generation` to `unknown`, continue |
+| Pipeline detection from Terraform incomplete      | Record with available data, continue           |
+
+When all sub-discoveries produce no resources (or no Heroku Terraform is present), the phase's source `_precondition` fails `_unrecoverable`; a completion-gate failure halts per the gate protocol (retain `in_progress`, do not patch).
 
 ---
 


### PR DESCRIPTION
## What

Prunes redundant prose from the **discover** and **clarify** phase files so each phase/fragment carries only the prose it uniquely needs — retiring text that the DSL frontmatter, `INTERPRETER.md`, or a sibling unit already owns. No behavioral change; every deletion is verified covered elsewhere.

This continues the convergence arc (same spirit as #107, which retired SKILL.md orchestration prose): the interpreter drives off frontmatter + `INTERPRETER.md`, so duplicated orchestration prose in phase files is strictly redundant.

## Discover phase

- **discover.md** (−98 lines) — deleted the **Phase Status State Machine** (Rules 1–5: hardcoded `discover→clarify→…` chain, predecessor/single-active gates, GATE_FAIL/unrecoverable behavior — all owned by `INTERPRETER.md` + this phase's own `_preconditions`/`_re_entry_guard`); deleted the **Sub-Discovery Files** list (dup of `_fragments`) and **Output Files** list (dup of `_produces`/`_forbids_files`); trimmed Step 1d, Step 5 mechanics, and the Error-Handling status column. Kept the scan how-to, sub-discovery descriptions, and Scope Boundary.
- **discover-terraform.md** (−53) — deleted **Step 0c Exit Gate** (unreachable: the parent phase's source `_precondition` hard-fails before any fragment runs, and this fragment's `_trigger` is `_always`); consolidated the redundant **Step 4** (4a≈4d, 4e⊂4c, assembler overlap) into the terraform-specific contribution rules; dropped 2 unreachable Error-Handling rows. Kept all extraction rules, per-type details, and the 6 HCL→JSON worked examples (they aid a deterministic transform — that's what fragment prose is for).
- **discover-billing.md** (−14) — dropped the glob-list (dup of `_trigger`); made the fragment consistently own `billing_profile:{available:false}`; deleted the "When Unavailable" section (dup + contradicted Step 0 on who sets it); dropped one duplicate Error-Handling row.
- **discover-assemble.md** — **fixed a dangling reference** this branch created (the "Rule 4 in discover.md" pointer, since that rule was deleted → re-pointed to `INTERPRETER.md § _on_error`); deleted Rule 8 (forbidden-clustering check that duplicated the phase's `_postconditions._assert`).

## Clarify phase

- **clarify.md** — deleted the **Sub-Files** section (dup of `_fragments`/`_assemble` + Steps 1–2); kept the "Clarify is mandatory" HARD GATE doctrine.
- **clarify-interview.md** — removed the vestigial `preferences-draft.json` cleanup note (dead logic for the mid-batch resume feature removed in #102; nothing writes a draft). Kept the full interview logic + Question Catalog + Defaults Table.
- **clarify-assemble.md** — removed the matching draft-cleanup line; trimmed Step 5 mechanics (INTERPRETER owns the update protocol). Kept the `preferences.json` schema + the Validation Checklist (load-bearing — `_postconditions._assert` delegates to it by reference).

## Not touched (deliberately)

- **Phase-ordinal titles** ("Phase 1/2 of 6") — left for a separate consistent ordinal sweep across all phases (part of ledger #2), not scattered per-file.
- **Scope Boundary** blocks — kept everywhere (semantic "no AWS content" doctrine with no frontmatter home yet; the `_scope` vocab candidate).

## Verification

- `mise run build` green after every commit: `lint:frontmatter` (validator OK), 45/45 tests, `fmt:check`, markdownlint.
- Confirmed **no dangling "Rule N" references** remain in the discover phase, and **zero `preferences-draft` references** remain skill-wide.

## Ownership

Team-owned skill files only — **no admin-owned paths**.
