### PR TITLE
docs(migration-to-aws): add plugin-level DSL authoring guide

### DIFF
--- a/migrate/plugins/migration-to-aws/docs/01-concepts.md
+++ b/migrate/plugins/migration-to-aws/docs/01-concepts.md
@@ -1,0 +1,158 @@
+# Concepts — the mental model
+
+Read this before the grammar reference. The keys make sense only once you hold the
+model behind them.
+
+## 1. The LLM is the interpreter. There is no engine.
+
+At runtime the markdown files **are** the program and the language model **is** the
+machine that runs them. Nothing parses a phase file and executes it except an LLM
+reading it and following its instructions.
+
+That single fact drives everything else:
+
+- A phase file's frontmatter is not config for some runtime — it is a set of
+  instructions the LLM reads and acts on, using the shared `INTERPRETER.md` as its
+  operating manual.
+- An opaque condition like `_when: "inventory has a heroku-postgresql addon"` is not
+  code. The LLM reads it, looks at the inventory, and decides. No regex, no
+  evaluator.
+- Because the LLM behaves by **reading instructions**, anything a key does
+  differently in different places must be written down in `INTERPRETER.md` — that is
+  the only place per-context behavior can live. (This is why `INTERPRETER.md`
+  explains `_when` several times: the four contexts genuinely differ.)
+
+There is a separate, unrelated effort — the MCP engine — that builds deterministic
+runtime tools (provision a database, dump/restore, verify). That is _execution_.
+This DSL is _planning_: it produces a plan (inventory, design, cost estimate,
+generated Terraform) that a human or an engine then acts on. Don't conflate the two.
+
+## 2. Structure is checkable; judgment is the LLM's.
+
+Every phase file has two layers, with a hard line between them.
+
+**Structure** — identity, ordering, inputs, outputs, gates, data dependencies — is
+declared in a **closed-vocabulary frontmatter block**. A typed validator
+(`tools/frontmatter-validator/`) parses it and enforces structural rules the build
+fails on. This is the layer with teeth.
+
+**Judgment** — how to parse Terraform, how to size an RDS instance, how to word a
+clarifying question — stays in **markdown prose** the LLM reads and executes. The
+grammar deliberately does not try to check this. Two escape hatches carry judgment
+_inside_ the structured layer, and both are bound-but-never-evaluated by CI:
+
+- `_when: "<prose>"` — an opaque condition (a fragment trigger, a knowledge-load
+  guard). The LLM decides if it holds.
+- `_assert: "<prose>"` — an opaque postcondition ("every services[] entry has a
+  service_id…"). The LLM evaluates it against the produced artifact.
+
+**A green `lint:frontmatter` validates structure, never values.** It confirms the
+wiring is sound — closed vocab, resolved references, a consistent phase chain,
+single-creator artifacts. It says nothing about whether an `_assert` body is true or
+a `_when` was judged correctly. That is the deal: you get static guarantees on the
+skeleton, and you trust the model on the flesh. Knowing _where_ the judgment is (it
+is isolated to `_when`/`_assert` prose) is itself the safety property — nothing else
+invites interpretation.
+
+## 3. Knowledge vs procedure vs contract — three homes, no inlining.
+
+A unit's `.md` file is **procedure** (the algorithm). Two other kinds of content
+must live elsewhere so they can change independently:
+
+| Content       | Test — "would you change this for a reason unrelated to the algorithm?" | Home                       |
+| ------------- | ----------------------------------------------------------------------- | -------------------------- |
+| **Knowledge** | Yes — a lookup table, a tunable constant, a default                     | `knowledge/<skill>/*.json` |
+| **Procedure** | No — it _is_ the branch/order/error-policy                              | the unit `.md` `## Step:`  |
+| **Contract**  | It is the _shape_ of a produced artifact                                | `schemas/*.json`           |
+
+The procedure **references** knowledge and schemas; it never re-lists them. A datum
+lives in exactly one place — duplication is a drift surface and a validator concern.
+(A fourth home, `templates/<phase>/`, holds output skeletons the generate phase
+emits — HCL, docs, scripts.) The guardrail cuts both ways: extract _data_ and
+_tunable constants_; never extract _logic_ or _contract_ (that would hollow the
+procedure into "look up X in file Y" and it stops reading as an algorithm).
+
+## 4. The three unit kinds.
+
+A phase's work decomposes into **fragments** plus exactly one **assembler**. Three
+kinds, three contracts:
+
+| Kind          | Role                                    | Reads            | Writes                                    |
+| ------------- | --------------------------------------- | ---------------- | ----------------------------------------- |
+| **Phase**     | lifecycle + composition                 | —                | — (composes the units below)              |
+| **Fragment**  | one unit of work, single responsibility | source inputs    | contributes to 1..N artifacts (to disk)   |
+| **Assembler** | combine / enrich fragment contributions | fragment outputs | creates and/or mutates the phase artifact |
+
+The rules that make this a real taxonomy (not just three file types):
+
+- **Fragments are a flat, independent set.** A fragment never reads another
+  fragment's output. If output B derives from output A, that coupling is a _signal
+  they belong in the same fragment_ — not two fragments with a dependency edge.
+  There is no fragment DAG, no ordering contract between fragments.
+- **One responsibility per fragment.** A fragment may write several files, but only
+  if they share one _reason to change_ (one source). Two sources → two fragments
+  (heroku's `terraform` vs `billing` discovery). The test is "two reasons to change
+  → two fragments", not "two files → two fragments".
+- **Exactly one assembler per phase, and it is terminal.** Its job spans a spectrum:
+  merge several fragment outputs into one file, enrich a fragment's file in place,
+  derive new cross-cutting files, or — when fragments already wrote the artifact —
+  just validate it. Even a no-op assembler earns its place: _its postconditions are
+  the phase's artifact-level contract._
+- **Single creator, last-writer owns.** Every artifact has exactly one creator (a
+  fragment or the assembler) and zero-or-more mutators (the assembler only). Whoever
+  writes a file last owns its final postconditions. The validator enforces this.
+
+Why split at all? Because the three have genuinely different contracts, and
+separating them keeps each file small and each responsibility checkable. A phase
+orchestrator reads as "what runs when"; a fragment reads as "what I produce and must
+satisfy"; the assembler reads as "the artifact's final shape".
+
+## 5. The phase lifecycle — backbone, gates, and the handoff.
+
+A migration is a linear chain of **backbone** phases, wired by two frontmatter keys:
+`_advances_to` (forward) and `_requires_phase` (backward). The chain runs from the
+**head** (the one phase with no `_requires_phase`, which also carries `_init: true`)
+to the **terminal** (the one phase whose `_advances_to` is `complete`). The
+interpreter _derives_ this chain from the frontmatter — it is never hardcoded in a
+phase-order table.
+
+Each phase runs behind two gates (see `INTERPRETER.md` § Gate protocol):
+
+- **Entry gate (`_preconditions`).** Checked before any work: predecessor completed,
+  single active phase, inputs present and valid. A failure stops the phase.
+- **Completion gate (`_postconditions`).** Checked before the phase is marked
+  `completed` and control advances: the artifact exists, is valid JSON, and satisfies
+  the `_assert` judgments. On all-pass the LLM emits `HANDOFF_OK | phase=… |
+  artifacts=…` and advances; on any failure it emits `GATE_FAIL`, stops, and does not
+  patch the artifact to force a pass.
+
+**Golden rule: never advance without `HANDOFF_OK`.** `_produces` is the phase's
+return contract, `_postconditions` assert it, `HANDOFF_OK` is the return statement,
+`_advances_to` is the tail call. A phase is a function; the gate is its boundary.
+
+Two more lifecycle constructs:
+
+- **Checkpoint phases** (`_kind: checkpoint`, e.g. feedback) are _off_ the backbone.
+  They are entered by a phase-level `_trigger` (the user opts in), return control
+  instead of advancing, and have no `_advances_to`. A resolved checkpoint is
+  "completed" even if the user declined — participation is a separate signal (the
+  artifact's presence).
+- **Re-entry guard** (`_re_entry_guard`) protects against re-running a phase whose
+  downstream already completed (which would leave the downstream artifact stale). It
+  stops unless the user confirms, and on confirm resets the downstream phases to
+  pending.
+
+## 6. Derive, don't declare.
+
+A recurring principle you will see enforced: when the validator needs a closed set to
+check against, it **derives** it from the existing declarations rather than reading a
+separate manifest. The set of valid phase names is `{ the _phase of every phase file
+}` — there is no `phases:` list to keep in sync. A second source of truth is a drift
+surface, and eliminating drift surfaces is the reason this grammar exists. When you
+extend the grammar, resist the urge to add a manifest; derive the fact from what is
+already declared.
+
+---
+
+Next: [02-grammar-reference.md](02-grammar-reference.md) — every key, its shape, and a
+real example.

--- a/migrate/plugins/migration-to-aws/docs/02-grammar-reference.md
+++ b/migrate/plugins/migration-to-aws/docs/02-grammar-reference.md
@@ -1,0 +1,279 @@
+# Grammar reference
+
+Every frontmatter key in the DSL, its shape, its meaning, and a real example pulled
+from `skills/heroku-to-aws/`. This is a lookup — read [01-concepts.md](01-concepts.md)
+first for the model.
+
+**Authoritative sources** (these win on any disagreement): the shapes are
+`tools/frontmatter-validator/types.ts`; the closed vocabulary is
+`tools/frontmatter-validator/parse.ts`; the runtime meaning is
+`skills/shared/dsl/INTERPRETER.md`.
+
+## The closed vocabulary
+
+Every `_`-prefixed key is closed: a key not in the set for its unit kind is a
+`unknown … frontmatter key` finding (a typo fails the build rather than being
+silently ignored). The sets, verbatim from `parse.ts`:
+
+- **Phase keys (16):** `_phase`, `_title`, `_kind`, `_requires_phase`, `_init`,
+  `_input`, `_fragments`, `_trigger`, `_assemble`, `_produces`, `_advances_to`,
+  `_re_entry_guard`, `_preconditions`, `_postconditions`, `_forbids_files`,
+  `_knowledge`.
+- **Fragment keys (3):** `_fragment`, `_of_phase`, `_contributes`.
+- **Assembler keys (5):** `_assemble`, `_of_phase`, `_reads`, `_produces`,
+  `_knowledge`.
+- **Check kinds (5):** `_check_phase_completed`, `_check_single_active_phase`,
+  `_check_file_exists`, `_validate_json`, `_assert`.
+- **`_on_failure` / `_on_error` actions (4):** `_warn_and_skip`, `_default_and_warn`,
+  `_halt_and_inform`, `_unrecoverable`.
+- **Re-entry guard sub-keys (4):** `_stale_if_completed`, `_stale_artifact`,
+  `_on_reentry`, `_on_confirm`.
+
+## Unit file structure
+
+A unit file (phase orchestrator, fragment, or assembler) is: a `---`-fenced YAML
+frontmatter block, then an optional `# H1`, then prose (`## Step:` sections and
+orientation). The frontmatter is the only structural source of truth; the prose is
+procedure the LLM executes.
+
+---
+
+## Phase frontmatter
+
+The phase orchestrator file `references/phases/<name>/<name>.md` composes the phase.
+
+### Identity & role
+
+| Key               | Shape                      | Meaning                                                                                                         |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `_phase`          | string                     | the phase's id (matches the directory/file name)                                                                |
+| `_title`          | string                     | human title                                                                                                     |
+| `_kind`           | `backbone` \| `checkpoint` | `backbone` (default when absent) = a step on the linear lifecycle; `checkpoint` = off-backbone, trigger-entered |
+| `_requires_phase` | phase name                 | the phase that must be `completed` before this one starts (omitted on the head phase)                           |
+| `_init`           | `true`                     | present only on the backbone head — this phase bootstraps migration state before its fragments run              |
+
+### Composition
+
+| Key          | Shape                                                   | Meaning                                                                                                                  |
+| ------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `_fragments` | ordered list of `{ _id, _trigger, _file }`              | the units of work; each is loaded + run when its `_trigger` fires (below)                                                |
+| `_assemble`  | `{ _file }`                                             | the single terminal assembler — **mandatory**, exactly one per phase                                                     |
+| `_input`     | scalar or list — `workspace`, a glob, or artifact names | what the phase reads (the initial file scan, the phase-status glob, or upstream artifacts)                               |
+| `_knowledge` | list of `{ file, _when? }`                              | JSON data dependencies (sizing/pricing/mapping tables); loaded only when `_when` holds; each `file` must resolve on disk |
+
+### Lifecycle & flow
+
+| Key               | Shape                                                                | Meaning                                                                                            |
+| ----------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `_advances_to`    | phase name or a terminal (`complete`)                                | the next phase on success (backbone only; a checkpoint has none)                                   |
+| `_trigger`        | a trigger form (below)                                               | **checkpoint phases only** — how the phase is entered; backbone phases have no phase-level trigger |
+| `_re_entry_guard` | `{ _stale_if_completed, _stale_artifact, _on_reentry, _on_confirm }` | stale-downstream guard (backbone phases with a downstream)                                         |
+
+### Contract
+
+| Key               | Shape                                                | Meaning                                                                                       |
+| ----------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `_preconditions`  | ordered list of checks (below)                       | the entry gate — all must pass before the phase does any work                                 |
+| `_postconditions` | ordered list of checks (below)                       | the completion gate — all must pass before the phase is `completed` + advances                |
+| `_produces`       | list of bare filenames and/or `{ file, _when }` maps | the artifact(s) the phase writes (a mandatory floor, not necessarily exhaustive)              |
+| `_forbids_files`  | glob list                                            | files/dirs the phase MUST NOT create (scope boundary; a violation is a postcondition failure) |
+
+### Example — a backbone phase (`design.md`, abridged)
+
+```yaml
+_phase: design
+_title: "Design AWS Architecture"
+_requires_phase: clarify
+_input:
+  - heroku-resource-inventory.json
+  - preferences.json
+_knowledge:
+  - { file: knowledge/design/dyno-fargate-sizing.json, _when: "inventory has a formation AND kubernetes is ecs-fargate or absent" }
+  - { file: knowledge/design/postgres-rds-sizing.json, _when: "inventory has a heroku-postgresql addon" }
+_fragments:
+  - _id: mapping-engine
+    _trigger: { _always: true }
+    _file: phases/design/design-mapping.md
+  - _id: eks-mapping
+    _trigger: { _when: "preferences kubernetes is 'eks-managed' or 'eks-or-ecs'" }
+    _file: phases/design/design-eks.md
+_assemble:
+  _file: phases/design/design-assemble.md
+_produces:
+  - aws-design.json
+_advances_to: estimate
+_re_entry_guard:
+  _stale_if_completed: estimate
+  _stale_artifact: estimation-infra.json
+  _on_reentry: stop_unless_confirmed
+  _on_confirm: reset_downstream_to_pending
+_preconditions:
+  - _check_phase_completed: clarify
+    _on_failure: _halt_and_inform
+  - _check_file_exists: [heroku-resource-inventory.json, preferences.json]
+    _on_failure: _unrecoverable
+_postconditions:
+  - _check_file_exists: aws-design.json
+    _on_failure: _halt_and_inform
+  - _assert: "every services[] entry has service_id, source_resource_id, aws_service, aws_config"
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - "terraform/**"
+  - estimation-infra.json
+```
+
+### Example — a checkpoint phase (`feedback.md`, abridged)
+
+Note: `_kind: checkpoint`, a phase-level `_trigger`, and NO `_advances_to`.
+
+```yaml
+_phase: feedback
+_title: "Feedback (Optional)"
+_kind: checkpoint
+_requires_phase: discover
+_input: "**/.phase-status.json"
+_trigger: { _when: "the user opts in to providing feedback at a feedback checkpoint" }
+_fragments:
+  - _id: collect
+    _trigger: { _always: true }
+    _file: phases/feedback/feedback-collect.md
+_assemble:
+  _file: phases/feedback/feedback-assemble.md
+_produces:
+  - feedback.json
+  - trace.json
+_preconditions:
+  - _check_phase_completed: discover
+    _on_failure: _halt_and_inform
+_postconditions:
+  - _check_file_exists: feedback.json
+    _on_failure: _warn_and_skip
+```
+
+---
+
+## Fragment frontmatter
+
+A fragment file does one unit of work and writes its contribution to disk.
+
+| Key            | Shape                                                | Meaning                                                                         |
+| -------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `_fragment`    | string                                               | the fragment's id — **must match** the `_id` the phase's `_fragments` list uses |
+| `_of_phase`    | phase name                                           | the phase this fragment belongs to — **must match** the owning phase's `_phase` |
+| `_contributes` | list of bare filenames and/or `{ file, _when }` maps | the artifact section(s) this fragment writes into                               |
+
+### Example (`design-mapping.md`)
+
+```yaml
+_fragment: mapping-engine
+_of_phase: design
+_contributes:
+  - aws-design.json
+```
+
+**`_contributes` rule:** list what the fragment writes _unconditionally given it
+runs_. A fragment that is itself trigger-gated (the eks fragment fires only via its
+`_when`) lists its outputs **bare** — the conditionality is already captured by the
+fragment's trigger. Outputs a fragment emits only under an _internal_ branch (e.g.
+"emit `database.tf` only if a DB is present") are the _open tail_ and are NOT listed
+at all — they are governed by the fragment's step prose and the phase's `_assert`s.
+
+---
+
+## Assembler frontmatter
+
+Exactly one per phase; runs last; the single creator/mutator of the phase artifact.
+
+| Key          | Shape                                                | Meaning                                                         |
+| ------------ | ---------------------------------------------------- | --------------------------------------------------------------- |
+| `_assemble`  | string                                               | the assembler's id                                              |
+| `_of_phase`  | phase name                                           | the phase this assembler belongs to                             |
+| `_reads`     | list                                                 | the fragment contributions it combines                          |
+| `_produces`  | list of bare filenames and/or `{ file, _when }` maps | the artifact(s) it creates — the assembler is the creator       |
+| `_knowledge` | list of `{ file, _when? }`                           | reference/data files it loads; each `file` must resolve on disk |
+
+### Example (`design-assemble.md`)
+
+```yaml
+_assemble: assemble-design
+_of_phase: design
+_reads:
+  - mapping-engine (fragment contribution)
+  - eks-mapping (fragment contribution, when EKS selected)
+_produces:
+  - aws-design.json
+```
+
+---
+
+## Shared value grammars
+
+### Trigger forms
+
+A `_trigger` (on a `_fragments[]` entry, or a checkpoint phase's `_trigger`) is one of:
+
+| Form                     | Meaning                                                                          | Checkable?            |
+| ------------------------ | -------------------------------------------------------------------------------- | --------------------- |
+| `{ _always: true }`      | always runs                                                                      | mechanical            |
+| `{ _glob: "<pattern>" }` | runs when ≥1 file matching the glob exists in the workspace                      | mechanical            |
+| `{ _when: "<prose>" }`   | runs when the prose condition holds (the LLM decides against the phase's inputs) | **judgment (opaque)** |
+| anything else            | parsed as `unknown` → a check flags it                                           | —                     |
+
+A false `_when` trigger skips the fragment silently _and does not even load its file_
+(lazy). A misjudged `_when` fails open — it can silently drop an entire fragment — so
+put high-consequence branching behind mechanical triggers where you can.
+
+### Check kinds (used in `_preconditions` / `_postconditions`)
+
+Each list entry is one check plus an `_on_failure` action. Six are mechanical
+(deterministic recipes); `_assert` is the judgment escape hatch.
+
+| Check                        | Arg                   | Passes when                                         | Kind         |
+| ---------------------------- | --------------------- | --------------------------------------------------- | ------------ |
+| `_check_phase_completed`     | a phase name          | `.phase-status.json` `phases.<name> == "completed"` | mechanical   |
+| `_check_single_active_phase` | `true`                | at most one backbone phase is `in_progress`         | mechanical   |
+| `_check_file_exists`         | filename or `[names]` | each named file exists in `$MIGRATION_DIR/`         | mechanical   |
+| `_validate_json`             | filename or `[names]` | each named file parses as valid JSON                | mechanical   |
+| `_assert`                    | opaque prose          | the LLM judges the prose true against the artifact  | **judgment** |
+
+`_assert` is where the whole postcondition contract can go soft: a `_validate_json`
+has real teeth, but an `_assert` body is only checked for "is a non-empty string in
+the right list" — CI never reads it. Use mechanical checks where you can; reserve
+`_assert` for genuine judgment (per-entry field presence, enum-over-content,
+conditionals CI can't evaluate).
+
+### `_on_failure` / `_on_error` actions
+
+Every check's `_on_failure` names one of these. Two STOP, two CONTINUE:
+
+| Action              | Effect                                     | Phase status         |
+| ------------------- | ------------------------------------------ | -------------------- |
+| `_warn_and_skip`    | record a warning; skip this item; continue | remain `in_progress` |
+| `_default_and_warn` | apply a documented default; warn; continue | remain `in_progress` |
+| `_halt_and_inform`  | stop; surface a diagnostic                 | retain `in_progress` |
+| `_unrecoverable`    | stop; surface an error                     | revert to `pending`  |
+
+### `_re_entry_guard` sub-keys
+
+Present on a backbone phase with a downstream; all four are required together.
+
+| Sub-key               | Value (closed)                  | Meaning                                                                            |
+| --------------------- | ------------------------------- | ---------------------------------------------------------------------------------- |
+| `_stale_if_completed` | a phase name (= `_advances_to`) | the downstream phase whose completion makes re-running THIS phase unsafe           |
+| `_stale_artifact`     | a filename                      | the downstream artifact named in the `GATE_FAIL` line (∈ that phase's `_produces`) |
+| `_on_reentry`         | `stop_unless_confirmed`         | what to do on a stale re-entry (the only value today)                              |
+| `_on_confirm`         | `reset_downstream_to_pending`   | what to do when the user confirms the re-run (the only value today)                |
+
+### Conditional artifacts — `{ file, _when }`
+
+`_produces` and `_contributes` (and `_knowledge`) accept, per entry, either a bare
+filename or an inline `{ file: <path>, _when: <prose> }` map — the artifact is
+produced only when the design predicate holds. `_when` is opaque (bound, not
+evaluated). A trailing-slash `file` (e.g. `kubernetes/`) names a produced
+**directory** — used when a unit emits a set of dynamically-named files with no fixed
+name. CI checks only that a map entry carries a parseable, non-empty `file:`.
+
+---
+
+Next: [03-authoring-guide.md](03-authoring-guide.md) — build a phase end to end.

--- a/migrate/plugins/migration-to-aws/docs/03-authoring-guide.md
+++ b/migrate/plugins/migration-to-aws/docs/03-authoring-guide.md
@@ -1,0 +1,247 @@
+# Authoring guide
+
+How to build a migration skill on the DSL, or add/extend a phase in one. Assumes
+you've read [01-concepts.md](01-concepts.md) and have
+[02-grammar-reference.md](02-grammar-reference.md) open for lookups.
+
+The running example is a fictional `render-to-aws` skill, but every pattern is drawn
+from the real `skills/heroku-to-aws/`. When in doubt, read the corresponding file
+there — it is the reference implementation.
+
+## The skill layout
+
+A DSL skill lives under `skills/<name>/` with this shape:
+
+```
+skills/<name>/
+├── SKILL.md                        ← entry point; names the cold-start entry phase
+├── references/
+│   ├── phases/
+│   │   └── <phase>/
+│   │       ├── <phase>.md           ← the phase ORCHESTRATOR (phase frontmatter)
+│   │       ├── <phase>-<work>.md    ← a FRAGMENT (fragment frontmatter)
+│   │       └── <phase>-assemble.md  ← the ASSEMBLER (assembler frontmatter)
+│   └── schemas/                     ← *.json output contracts
+├── knowledge/<name>/                ← *.json lookup data (referenced by _knowledge)
+└── templates/<phase>/               ← output skeletons the generate phase emits
+```
+
+The validator discovers phases by scanning `references/phases/<name>/<name>.md` — the
+orchestrator file **must** be named after its directory.
+
+## Step 1 — decide the backbone
+
+List your phases in order and pick, for each, what it consumes and produces. The
+chain is wired by two keys that must agree in both directions:
+
+- each phase's `_advances_to` = the next phase (last phase → `complete`)
+- each phase's `_requires_phase` = the previous phase (first phase → omit it)
+
+The **head** phase (no `_requires_phase`) also carries `_init: true` — it bootstraps
+migration state on a cold start. Exactly one phase per skill has each of: `_init:
+true`, no `_requires_phase`, and `_advances_to: complete`. Anything off this linear
+spine (an optional feedback survey) is a **checkpoint**, not a backbone phase.
+
+Sketch for `render-to-aws`:
+
+```
+discover (_init) → clarify → design → generate → complete
+                                    ↖ feedback (checkpoint, off-backbone)
+```
+
+## Step 2 — write the phase orchestrator
+
+Create `references/phases/discover/discover.md`. The frontmatter declares the
+contract; the prose delegates to the units.
+
+```yaml
+---
+_phase: discover
+_title: "Discover Render Resources"
+_init: true
+_input: workspace
+_fragments:
+  - _id: services
+    _trigger: { _always: true }
+    _file: phases/discover/discover-services.md
+_assemble:
+  _file: phases/discover/discover-assemble.md
+_produces:
+  - render-resource-inventory.json
+_advances_to: clarify
+_preconditions:
+  - _check_single_active_phase: true
+    _on_failure: _halt_and_inform
+_postconditions:
+  - _check_file_exists: render-resource-inventory.json
+    _on_failure: _halt_and_inform
+  - _validate_json: render-resource-inventory.json
+    _on_failure: _halt_and_inform
+_forbids_files:
+  - README.md
+  - "*.txt"
+  - "terraform/**"
+---
+
+# Phase 1: Discover Render Resources
+
+Lightweight orchestrator that delegates to the discovery fragment(s), then the
+assembler. Execute steps in order.
+
+## Step 1: Run discovery
+Load `references/phases/discover/discover-services.md` and follow it.
+
+## Step 2: Assemble
+Load `references/phases/discover/discover-assemble.md` and follow it.
+
+## Scope Boundary
+This phase inventories Render resources ONLY — no AWS mapping, cost, or Terraform.
+```
+
+Notes:
+
+- The orchestrator body is thin — it points at units. Do NOT restate gate rules,
+  phase-order tables, or "set status to in_progress" recipes; the interpreter owns
+  all of that (`INTERPRETER.md`). Restating them is duplication and a drift surface.
+- `_input: workspace` means "the initial file scan" (only valid on the `_init`
+  phase). Downstream phases list upstream artifacts by name instead.
+- A `_postconditions._check_file_exists` may only name a file in this phase's
+  `_produces` — CI hard-fails otherwise (it forces `_produces` to be honest).
+
+## Step 3 — write the fragment(s)
+
+Create `references/phases/discover/discover-services.md`. This is where the real work
+lives — the deterministic how-to, worked examples, parsing rules.
+
+```yaml
+---
+_fragment: services
+_of_phase: discover
+_contributes:
+  - render-resource-inventory.json
+---
+
+# Discover: Render services
+
+## Step: scan
+Glob for `render.yaml`; for each service block, extract name, type, plan, env.
+[…the actual extraction rules + a worked example…]
+```
+
+Rules the validator enforces:
+
+- `_fragment` **must equal** the `_id` the phase's `_fragments` list used
+  (`services`). `_of_phase` **must equal** the owning phase's `_phase` (`discover`).
+- Split by **reason to change**: one source per fragment. Two independent sources
+  (say `render.yaml` vs a billing CSV) → two fragments, never one fragment with a
+  dependency on another. A fragment never reads another fragment's output.
+
+## Step 4 — write the assembler
+
+Create `references/phases/discover/discover-assemble.md`. Every phase has exactly
+one, and it is terminal.
+
+```yaml
+---
+_assemble: assemble-inventory
+_of_phase: discover
+_reads:
+  - services (fragment contribution)
+_produces:
+  - render-resource-inventory.json
+---
+
+# Discover: assemble inventory
+
+## Step: combine
+Merge the fragment contributions into render-resource-inventory.json.
+[…assembly rules; the artifact's field definitions / schema reference…]
+```
+
+The assembler owns the **artifact-level contract**. Even a no-op assembler (fragments
+already wrote the file) earns its place: its postconditions are the phase's contract.
+
+**Single-creator rule.** Each `_produces` artifact needs exactly one creator:
+
+- If the **assembler** `_produces` it → the assembler is the creator; fragments that
+  also name it in `_contributes` are content-contributors (fine).
+- Otherwise **exactly one fragment** must `_contributes` it. Zero → "no unit creates
+  it". Two+ fragments with no assembler owner → "ambiguous creator". Both fail CI.
+
+## Step 5 — knowledge, schemas, templates
+
+Don't inline data or artifact shapes in prose:
+
+- **Lookup tables / tunable constants** → `knowledge/<skill>/*.json`, referenced from
+  the phase's `_knowledge` with an optional `_when` guard. Load only when the guard
+  holds; don't speculatively load a table for a resource type absent from the input.
+- **Artifact shape** → `schemas/*.json`; the assembler references it (a
+  `_validate_json` / `_assert`), it does not re-list fields in prose.
+- **Output skeletons** (generate phase) → `templates/<phase>/`, referenced not
+  inlined.
+
+Every `_knowledge` file must resolve on disk, or CI fails.
+
+## Step 6 — wire checkpoints (optional)
+
+An off-backbone phase (a feedback survey) is a checkpoint: `_kind: checkpoint`, a
+phase-level `_trigger` (how it's entered), and NO `_advances_to`. It returns control
+instead of advancing. Where it's offered is orchestration prose in SKILL.md, not part
+of the phase contract. See `skills/heroku-to-aws/references/phases/feedback/`.
+
+## Step 7 — the re-entry guard (optional)
+
+If re-running a phase would leave a downstream artifact stale, add a
+`_re_entry_guard`. All four sub-keys are required, and two must agree with the chain:
+`_stale_if_completed` must equal this phase's `_advances_to`, and `_stale_artifact`
+must be one of that downstream phase's `_produces`. See `design.md` for a live one.
+
+## Step 8 — validate
+
+Run the typed validator against your skill root:
+
+```bash
+mise run lint:frontmatter
+```
+
+(The shipped task points at `skills/heroku-to-aws`; to check another skill, run the
+validator directly: `node tools/frontmatter-validator/validate.ts skills/<name>`.)
+
+It discovers your phases, binds the frontmatter, and reports findings — exit non-zero
+on any. See [04-validator-checks.md](04-validator-checks.md) for what each finding
+means. Then run the full build before pushing:
+
+```bash
+mise run build
+```
+
+`build` runs `lint:md` (markdownlint), `lint:types` (tsc on the validator),
+`lint:frontmatter`, `fmt:check` (dprint), and the security scanners.
+
+## Common mistakes (and the check that catches each)
+
+| Mistake                                                          | Finding                                                                                |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Typo'd a key (`_produce:`)                                       | `unknown … frontmatter key '_produce'`                                                 |
+| Fragment `_fragment`/`_of_phase` doesn't match the phase's ref   | `_fragment id '…' != phase reference _id '…'`                                          |
+| Forgot the assembler                                             | `missing _assemble._file`                                                              |
+| `_produces` an artifact no unit creates                          | `no unit creates it — single-creator rule`                                             |
+| Two fragments `_contributes` the same file, no assembler owner   | `ambiguous creator (single-creator rule)`                                              |
+| `_postconditions` gates a file not in `_produces`                | `not in this phase's _produces`                                                        |
+| `_advances_to` names a phase dir that doesn't exist              | `dangling forward edge`                                                                |
+| `_advances_to`/`_requires_phase` disagree between two phases     | `chain inconsistency`                                                                  |
+| Backbone phase missing `_advances_to`, or has a phase `_trigger` | `backbone phase must declare _advances_to` / `must NOT declare a phase-level _trigger` |
+| Two phases with `_init: true`, or none once the backbone is full | `multiple phases declare '_init: true'` / `no phase declares '_init: true'`            |
+| `_knowledge` file path is wrong                                  | `_knowledge file does not resolve`                                                     |
+
+### The markdownlint gotcha (MD031)
+
+`dprint fmt:check` does NOT flag a fenced code block nested inside a bullet list, but
+`markdownlint` MD031 (blanks-around-fences) DOES — so `fmt:check` can pass locally
+while CI's `lint:md` fails. Always run the full `mise run build` (or at least `mise
+run lint:md`) before pushing prose that nests code fences in bullets. Fix: pull the
+fence out to a top-level block with blank lines around it.
+
+---
+
+Next: [04-validator-checks.md](04-validator-checks.md) — the full check catalog.

--- a/migrate/plugins/migration-to-aws/docs/04-validator-checks.md
+++ b/migrate/plugins/migration-to-aws/docs/04-validator-checks.md
@@ -1,0 +1,232 @@
+# Validator checks
+
+The full catalog of structural checks `mise run lint:frontmatter` enforces, drawn
+from `tools/frontmatter-validator/check.ts`. Each entry: what it enforces, what trips
+it, how to fix. The validator is **skill-agnostic** — every check is a property of
+the phase/fragment/assembler grammar, not of any particular skill.
+
+## What the validator does (and does not) guarantee
+
+It parses every `references/phases/<name>/<name>.md` and its referenced
+fragments/assemblers into the typed model (`types.ts`), then runs these checks.
+**Green means the structure is sound**: closed vocabulary, resolved references, a
+consistent phase chain, single-creator artifacts, honest `_produces`. It does **not**
+evaluate `_when` conditions or `_assert` bodies — those are opaque prose bound and
+transported verbatim, judged by the LLM at runtime. Structure has teeth; judgment
+does not. That is by design.
+
+## The partial-rollout tolerance model
+
+The grammar was introduced phase-by-phase into a skill that started as plain prose,
+so the validator is deliberately tolerant of a **partial rollout**: a phase file that
+carries no frontmatter runs from its prose, as before, and is simply not bound. Many
+checks therefore _self-skip when they can't be sure_:
+
+- The valid phase set is **derived** from the phase files that declare frontmatter —
+  never hardcoded. A reference to a phase that doesn't yet carry frontmatter is left
+  **unverified** rather than failed.
+- Membership checks (`_requires_phase`, `_check_phase_completed`,
+  `_stale_if_completed`) only fire when **more than one** phase declares frontmatter
+  AND the target isn't itself declared.
+- The backbone chain-consistency block runs only once the whole backbone is
+  frontmatter-present.
+
+The one check that resolves against the **filesystem** rather than the declared set —
+the dangling `_advances_to` edge — exists precisely so a truly-absent target still
+fails even while the chain block self-skips. Understanding this tolerance explains why
+a check you expected sometimes stays quiet on a half-migrated skill.
+
+---
+
+## Closed-vocabulary checks
+
+**Enforces:** every `_`-key is in the closed set for its unit kind.
+**Trips on:** a typo or an invented key — `unknown phase frontmatter key '_produce'`,
+`unknown fragment frontmatter key '…'`, `unknown assembler frontmatter key '…'`,
+`unknown _re_entry_guard sub-key '…'`.
+**Fix:** use a real key (see [02-grammar-reference.md](02-grammar-reference.md)). A
+typo fails the build rather than being silently ignored — that is the point.
+
+## Backbone / checkpoint contract
+
+**Enforces** (`INTERPRETER.md` § `_kind`):
+
+- a **backbone** phase (default) MUST declare `_advances_to` and MUST NOT declare a
+  phase-level `_trigger`;
+- a **checkpoint** phase MUST declare a phase-level `_trigger` and MUST NOT declare
+  `_advances_to`.
+
+**Trips on:** `backbone phase '…' must declare _advances_to`; `backbone phase '…' must
+NOT declare a phase-level _trigger`; `checkpoint phase '…' must declare a phase-level
+_trigger`; `checkpoint phase '…' must NOT declare _advances_to`.
+**Fix:** decide whether the phase is on the linear spine (backbone) or off it
+(checkpoint) and give it the matching keys. Feedback is the canonical checkpoint.
+
+## `_requires_phase` membership
+
+**Enforces:** `_requires_phase` names a declared phase (when >1 phase has
+frontmatter).
+**Trips on:** `_requires_phase '…' names no declared phase`.
+**Fix:** correct the phase name, or add frontmatter to the referenced phase.
+
+## Fragment resolution + back-references
+
+**Enforces:** each `_fragments[]._file` resolves on disk; the target has fragment
+frontmatter; its `_fragment` id equals the phase's `_id`; its `_of_phase` equals the
+phase.
+**Trips on:** `fragment '…' _file does not resolve`; `referenced as a fragment … but
+has no fragment frontmatter`; `_fragment id '…' != phase reference _id '…'`;
+`_of_phase '…' != '…'`; `fragment '…' has an unrecognized _trigger form`.
+**Fix:** correct the path, add the fragment frontmatter, or align the ids.
+
+## Assembler: exactly one, resolves, back-references
+
+**Enforces:** the phase declares `_assemble._file`; it resolves; the target has
+assembler frontmatter; its `_of_phase` matches.
+**Trips on:** `missing _assemble._file (a phase must have exactly one assembler)`;
+`_assemble._file does not resolve`; `referenced as the assembler … but has no
+assembler frontmatter`; `_of_phase '…' != '…'`.
+**Fix:** every phase needs exactly one assembler, even a no-op validator one.
+
+## Single-creator ownership
+
+**Enforces:** each phase `_produces` artifact has exactly one creator. If the
+assembler `_produces` it, the assembler is the creator (fragments may still
+`_contributes` content to it). Otherwise exactly one fragment must `_contributes` it.
+**Trips on:** `phase _produces '…' but no unit creates it … single-creator rule`
+(zero creators); `phase _produces '…' is declared by multiple fragments (…) with no
+assembler owner — ambiguous creator`.
+**Fix:** either have the assembler `_produces` the artifact (making fragment
+`_contributes` entries content-contributions), or ensure exactly one fragment claims
+it.
+
+## Re-entry guard checks
+
+**Enforces** (`INTERPRETER.md` § `_re_entry_guard`), when a `_re_entry_guard` is
+present:
+
+- all four sub-keys present (`_stale_if_completed`, `_stale_artifact`, `_on_reentry`,
+  `_on_confirm`);
+- `_on_reentry` ∈ {`stop_unless_confirmed`}; `_on_confirm` ∈
+  {`reset_downstream_to_pending`};
+- the phase has a real downstream (not a terminal / not absent);
+- `_stale_if_completed` equals this phase's `_advances_to`;
+- `_stale_if_completed` names a declared phase;
+- **(hard)** `_stale_artifact` is one of the downstream phase's `_produces`.
+
+**Trips on:** `_re_entry_guard missing _stale_artifact`; `… _on_reentry '…' is not a
+recognized value`; `phase '…' has a _re_entry_guard but no downstream backbone
+phase`; `_stale_if_completed '…' should equal this phase's _advances_to '…'`;
+`_stale_artifact '…' is not in the _produces of the downstream phase '…'`.
+**Fix:** align the guard with the chain; make `_stale_artifact` the exact downstream
+artifact whose staleness you're guarding against.
+
+## Gate checks (`_preconditions` / `_postconditions`)
+
+**Enforces:** every check `kind` is in the closed `CHECK_KINDS` set; every
+`_on_failure` is in the closed `ON_ERROR_ACTIONS` set; a `_check_phase_completed` arg
+names a declared phase.
+**Trips on:** `unknown _postconditions check kind '…' (allowed: …)`; `… has an
+unrecognized _on_failure action '…' (allowed: …)`; `_check_phase_completed '…' names
+no declared phase`.
+**Fix:** use a real check kind and a real action. Note `_assert` bodies are NOT
+checked for truth — only that the entry is well-formed.
+
+## Postcondition ⊆ `_produces` (hard fail)
+
+**Enforces:** a `_postconditions._check_file_exists` may only name a file the phase
+declares in `_produces` — a phase can only gate on artifacts it says it produces.
+**Trips on:** `_postconditions asserts _check_file_exists '…' but it is not in this
+phase's _produces (declared: …)`.
+**Fix:** add the file to `_produces` (if the phase really produces it) or drop the
+gate. This guards against a hollow `_produces` that omits real outputs.
+
+## Dangling `_advances_to` edge
+
+**Enforces:** `_advances_to` names either a terminal (`complete`/`done`/`end`) or a
+phase that **exists on disk** (`references/phases/<name>/<name>.md`). Resolves against
+the directory, not the declared set — so it still fires for a truly-absent target even
+during partial rollout.
+**Trips on:** `_advances_to '…' names neither a terminal … nor an existing phase …
+dangling forward edge`.
+**Fix:** correct the target, or create the phase directory/file.
+
+## Backbone chain-consistency
+
+**Enforces** (once >1 backbone phase is present and all forward edges resolve):
+
+- **exactly one head** (a backbone phase with no `_requires_phase`);
+- **exactly one terminal** (a backbone phase whose `_advances_to` is
+  `complete`/`done`/`end`);
+- **forward ⇒ back:** if A `_advances_to` B, then B `_requires_phase` A;
+- **back ⇒ forward:** if B `_requires_phase` A, then A `_advances_to` B.
+
+**Trips on:** `backbone must have exactly one head … found N`; `backbone must have
+exactly one terminal … found N`; `chain inconsistency: '…' _advances_to '…', but '…'
+_requires_phase '…'`.
+**Fix:** make the two directional edges agree. A consistent chain with one head and
+one terminal is necessarily a single acyclic line — which is what a migration
+backbone is.
+
+## `_init` uniqueness + backbone head
+
+**Enforces** (`INTERPRETER.md` § interpreter loop / `_init`):
+
+- at most one phase with `_init: true`;
+- the `_init` phase is a **backbone** phase (not a checkpoint);
+- the `_init` phase has no `_requires_phase` (it is the head);
+- once the backbone is fully present, an `_init` phase MUST exist.
+
+**Trips on:** `multiple phases declare '_init: true' (…)`; `checkpoint phase '…'
+declares '_init: true'`; `entry phase '…' declares '_init: true' but also
+'_requires_phase: …'`; `no phase declares '_init: true' — the backbone has no entry
+phase`.
+**Fix:** put `_init: true` on the single head phase and nowhere else. SKILL.md names
+this phase so a cold start loads it directly.
+
+## `_knowledge` + `_input` resolution
+
+**Enforces:**
+
+- every `_knowledge` `file` (on a phase or an assembler) resolves on disk, relative
+  to the skill root;
+- every `_input` entry is `workspace`, a glob, or an artifact some declared phase
+  `_produces` (the produced-by check fires only when >1 phase has frontmatter).
+
+**Trips on:** `_knowledge file does not resolve: …`; `_input '…' is not produced by
+any declared phase`.
+**Fix:** correct the path, or ensure the input artifact is declared in some phase's
+`_produces`.
+
+## Conditional-artifact well-formedness
+
+**Enforces:** a conditional `_produces` / `_contributes` entry (the `{ file, _when }`
+map form) carries a parseable, non-empty `file:`. CI does NOT evaluate `_when` (opaque
+prose, same as `_knowledge._when`).
+**Trips on:** `_produces has a conditional entry with no parseable 'file:' (expected
+'{ file: <path>, _when: <prose> }')`.
+**Fix:** write the map as `{ file: path/to/artifact, _when: "the predicate" }`.
+
+---
+
+## Where checks run out — the judgment surface
+
+These are **not** bugs; they are the deliberate edge of "structure is checkable":
+
+- **`_when` conditions** (triggers, knowledge guards, conditional artifacts) are
+  bound but never evaluated. A misjudged `_when` fails **open** — it can silently
+  skip a fragment or a data load. Put high-consequence branching behind mechanical
+  triggers (`_glob`, `_always`) where you can.
+- **`_assert` bodies** are checked only for "non-empty string in the right list". The
+  entire judgment half of the postcondition contract rides on prose the validator
+  never reads. Reserve `_assert` for genuine judgment; prefer the mechanical check
+  kinds (`_check_file_exists`, `_validate_json`) wherever the property is mechanical.
+
+The value of the grammar is that it **isolates** these to named, greppable places —
+so a reviewer knows exactly where the LLM's judgment is load-bearing.
+
+---
+
+Back to the [README](README.md) · the model in [01-concepts.md](01-concepts.md) · the
+keys in [02-grammar-reference.md](02-grammar-reference.md) · building in
+[03-authoring-guide.md](03-authoring-guide.md).

--- a/migrate/plugins/migration-to-aws/docs/README.md
+++ b/migrate/plugins/migration-to-aws/docs/README.md
@@ -1,0 +1,90 @@
+# The Migration DSL — plugin documentation
+
+This folder documents the **phase DSL** that the `migration-to-aws` skills are
+built on: a declarative frontmatter grammar an LLM interprets at runtime to drive
+a multi-phase migration, with a static validator (`mise run lint:frontmatter`) that
+checks the structure before anything runs.
+
+If you are about to author a new migration skill (or extend an existing one) and
+you want your agent to understand the grammar, **point it at this directory.** The
+docs are written to be read top-to-bottom by a human and loaded wholesale by an
+agent.
+
+## Why this exists
+
+A migration ("move a Heroku app to AWS", "move a GCP project to AWS") is a long,
+multi-step process: discover what exists, clarify intent, design the target,
+estimate cost, generate artifacts, collect feedback. Two failure modes dominate
+when you express that as a plain prose skill:
+
+1. **Silent drift between phases.** A phase claims to produce an artifact the next
+   phase needs, but the wiring is only in prose — nothing catches a rename, a typo,
+   or a hollow "produces" list until a run fails halfway through.
+2. **Orchestration prose the model half-follows.** Hardcoded phase-order tables,
+   "set status to in_progress" recipes, and gate-rule restatements pile up in every
+   phase file, drift out of sync with each other, and add load cost without adding
+   behavior.
+
+The DSL answers both by splitting each phase file into two layers:
+
+- **Structure → frontmatter (checkable).** The phase's identity, ordering, inputs,
+  outputs, gates, and data dependencies live in a closed-vocabulary YAML block. A
+  zero-dependency validator parses every phase/fragment/assembler file and fails the
+  build on a broken reference, an unknown key, a dangling phase edge, a hollow
+  `_produces`, an ambiguous artifact creator, and more.
+- **Judgment → prose (interpreted).** The actual work — how to parse Terraform, how
+  to size a database, how to word a question — stays in markdown the LLM reads and
+  executes. The grammar deliberately does **not** try to make judgment checkable.
+
+The dividing line is the whole design: **structure is checkable; judgment is the
+LLM's.** See [01-concepts.md](01-concepts.md) for the full rationale.
+
+## What it is (and is NOT)
+
+- It **is** a declarative grammar the LLM interprets. The markdown _is_ the program;
+  the LLM _is_ the interpreter. There is **no engine and no server** — nothing
+  executes the phase files except a language model reading them.
+- It **is** statically validated. `mise run lint:frontmatter` runs a typed parser +
+  structural checks over a skill's phase files. Green means the _structure_ is sound
+  (closed vocab, resolved references, a consistent phase chain, single-creator
+  artifacts). It does **not** mean the prose is correct — opaque conditions
+  (`_when`) and judgment assertions (`_assert`) are bound but never evaluated by CI.
+- It is **not** the MCP engine. A separate effort explores deterministic runtime
+  tools (provision, dump/restore, verify). That is _execution_; this DSL is
+  _planning_. Keep the two apart: the DSL plans a migration; it does not run one.
+
+## Getting started
+
+1. Read [01-concepts.md](01-concepts.md) — the mental model (10 min). Without it the
+   grammar looks arbitrary.
+2. Skim [02-grammar-reference.md](02-grammar-reference.md) — every frontmatter key,
+   its shape, and a real example. This is the lookup you return to.
+3. Follow [03-authoring-guide.md](03-authoring-guide.md) — build a phase (its
+   orchestrator + a fragment + the assembler), wire it into the backbone, and get to
+   a green `lint:frontmatter`.
+4. Keep [04-validator-checks.md](04-validator-checks.md) open while authoring — when
+   a check fails, it tells you what the check enforces and how to fix it.
+
+## The canonical sources (what these docs answer to)
+
+These docs are a _teaching layer_. The authorities they describe — and that win on
+any disagreement — are all in the plugin:
+
+| Source                                 | Role                                                                         |
+| -------------------------------------- | ---------------------------------------------------------------------------- |
+| `skills/shared/dsl/INTERPRETER.md`     | the **runtime semantics** — what the LLM does with each key (the spec)       |
+| `tools/frontmatter-validator/types.ts` | the **shape** of every frontmatter key (the typed model the parser binds to) |
+| `tools/frontmatter-validator/parse.ts` | the **closed vocabulary** (which keys/verbs/actions are legal)               |
+| `tools/frontmatter-validator/check.ts` | the **structural checks** the build enforces                                 |
+| `skills/heroku-to-aws/`                | the **living example** — a complete 6-phase skill authored to this grammar   |
+
+If a doc here and one of those sources disagree, the source is right — please open a
+fix to the doc.
+
+## The living example
+
+`skills/heroku-to-aws/` is a full migration skill built on this DSL: six phases
+(discover → clarify → design → estimate → generate, plus an off-backbone feedback
+checkpoint). Every construct in these docs is used there. When an explanation is
+abstract, go read the corresponding phase file — the examples in these docs are
+pulled from it verbatim.


### PR DESCRIPTION
## What

Adds `migrate/plugins/migration-to-aws/docs/` — a plugin-level authoring guide for the **phase DSL** that the migration-to-aws skills are built on. A content author who wants to create a new migration skill can point their agent at this directory (or read it themselves) to understand the DSL, its design rationale, its grammar, and how to author + validate a skill.

Five docs, written to be read top-to-bottom by a human AND loaded wholesale by an agent:

- **README.md** — why the DSL exists (the two failure modes it kills: silent cross-phase drift + orchestration prose the model half-follows), what it is and isn't (the LLM interprets it, there is no engine; it is not the MCP runtime), a getting-started path, and the table of canonical in-repo sources these docs answer to.
- **01-concepts.md** — the mental model: LLM-as-interpreter (no engine/server), *structure is checkable / judgment is the LLM's*, the knowledge/procedure/contract content homes, the three unit kinds (phase/fragment/assembler) and the rules that make them a real taxonomy, the phase lifecycle (backbone, gates, `HANDOFF_OK`), and derive-don't-declare.
- **02-grammar-reference.md** — every closed-vocabulary `_`-key for phase/fragment/assembler with its shape, meaning, and a **verbatim example** from `skills/heroku-to-aws/`, plus the shared value grammars (trigger forms, check kinds, `_on_failure`/`_on_error` actions, `_re_entry_guard`, conditional `{ file, _when }` artifacts).
- **03-authoring-guide.md** — a step-by-step build of a phase (orchestrator + fragment + assembler), wiring the backbone, running the validator, and a common-mistakes → validator-finding table (including the MD031 markdownlint gotcha that has bitten CI).
- **04-validator-checks.md** — the full check catalog from `check.ts`: what each check enforces, what trips it, how to fix it, the partial-rollout tolerance model, and where checks deliberately run out (the `_when` / `_assert` judgment surface).

## Source of truth

All content is drawn from the grammar **as shipped on `main`**:

- `skills/shared/dsl/INTERPRETER.md` (runtime semantics)
- `tools/frontmatter-validator/{types,parse,check}.ts` (shape, closed vocab, structural checks — run via `mise run lint:frontmatter`)
- `skills/heroku-to-aws/` (the living 6-phase example every construct is pulled from)

Note: there is an older, unshipped set of DSL docs on the `feat/heroku-dsl-refactor` plan-of-record branch (`skills/heroku-to-aws-dsl/docs/`). Those describe a *different, richer* validator (`scripts/dsl-validator/`) that is not on main. These new docs intentionally describe the **shipped** grammar so an author's agent running the real build sees exactly what the docs say. The plan-of-record docs are left as-is.

## Testing

`mise run build` green — `lint:md` (markdownlint, incl. MD031/MD032), `lint:types`, `lint:frontmatter`, `fmt:check` (dprint), and the security scanners all pass. Docs-only change; no code or skill behavior touched.
