### PR TITLE
docs(heroku-to-aws): prune redundant prose from estimate phase

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
@@ -20,55 +20,19 @@ _produces:
 
 ## Output: Write `estimation-infra.json`
 
-Assemble the full artifact conforming to `../shared/estimate/estimation-infra.schema.json`:
+Assemble the full artifact conforming to `../shared/estimate/estimation-infra.schema.json`
+(that schema is the field contract — do not re-enumerate it here). Each section is the
+corresponding output the cost-engine fragment computed: `pricing_source` +
+`current_costs` (Part 1), `projected_costs` (Parts 2/2B), `cost_comparison` (Part 3),
+`migration_cost_considerations` (Part 4), `roi_analysis` (Part 5),
+`optimization_opportunities` (Part 6), `complexity_tier` + `complexity_inputs`
+(Part 7), and `recommendation` (Part 8).
+
+The assembler additionally DERIVES the `financial_summary` roll-up (not produced by
+any single cost-engine Part; the schema leaves its shape open):
 
 ```json
 {
-  "phase": "estimate",
-  "design_source": "infrastructure",
-  "timestamp": "<ISO 8601>",
-  "pricing_source": {
-    "status": "cached|live|cached_fallback|unavailable",
-    "message": "<human-readable pricing status>",
-    "fallback_staleness": {
-      "last_updated": "<cache date>",
-      "days_old": "<N>",
-      "is_stale": false,
-      "staleness_warning": null
-    },
-    "services_by_source": {
-      "live": [],
-      "fallback": [],
-      "estimated": []
-    },
-    "services_with_missing_fallback": []
-  },
-  "accuracy_confidence": "±5-10%",
-
-  "current_costs": {
-    "source": "billing_data|user_provided|unavailable",
-    "heroku_monthly": "<total or null>",
-    "heroku_annual": "<total × 12 or null>",
-    "baseline_note": "<source description>",
-    "breakdown": { "dyno": "<X>", "addon": "<X>", "platform": "<X>" }
-  },
-
-  "projected_costs": {
-    "aws_monthly_premium": "<N>",
-    "aws_monthly_balanced": "<N>",
-    "aws_monthly_optimized": "<N>",
-    "aws_annual_optimized": "<N × 12>",
-    "breakdown": { "...per-service entries..." }
-  },
-
-  "cost_comparison": { "...from Part 3..." },
-  "migration_cost_considerations": { "...from Part 4..." },
-  "roi_analysis": { "...from Part 5..." },
-  "optimization_opportunities": [ "...from Part 6..." ],
-
-  "complexity_tier": "<small|medium|large>",
-  "complexity_inputs": { "...from Part 7..." },
-
   "financial_summary": {
     "current_heroku_monthly": "<N or null>",
     "projected_aws_balanced_monthly": "<N>",
@@ -77,9 +41,7 @@ Assemble the full artifact conforming to `../shared/estimate/estimation-infra.sc
     "monthly_savings_optimized": "<heroku - optimized>",
     "annual_savings_optimized": "<× 12>",
     "recommendation": "<summary sentence>"
-  },
-
-  "recommendation": { "...from Part 8..." }
+  }
 }
 ```
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-cost-engine.md
@@ -2,7 +2,7 @@
 _fragment: cost-engine
 _of_phase: estimate
 _contributes:
-  - estimation-infra.json (per-service costs, tiers, comparison, ROI, optimizations, complexity; created here, finalized by the assembler)
+  - estimation-infra.json
 ---
 
 # Estimate Phase: Cost Engine

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -63,33 +63,9 @@ _forbids_files:
 
 # Phase 4: Estimate AWS Costs
 
-> Loaded by SKILL.md when `phases.design == "completed"` AND `phases.estimate != "completed"`.
-
 **Execute ALL steps in order. Do not skip or optimize.**
 
----
-
-## Overview
-
-Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture. Produce `estimation-infra.json` conforming to `../shared/estimate/estimation-infra.schema.json`. Classify migration complexity using the tier thresholds in `../shared/estimate/complexity-tiers.json`.
-
-**Inputs:**
-
-- `$MIGRATION_DIR/aws-design.json` (from Phase 3)
-- `$MIGRATION_DIR/preferences.json` (from Phase 2)
-- `$MIGRATION_DIR/heroku-resource-inventory.json` (from Phase 1 — for billing profile)
-
-**Outputs:**
-
-- `$MIGRATION_DIR/estimation-infra.json`
-- `.phase-status.json` updated (estimate → completed)
-
----
-
-## Sub-Files
-
-- **estimate-cost-engine.md** → the cost engine: pricing-mode selection, prerequisites, and the full calculation (current Heroku costs, projected AWS costs + tiers, observability, comparison, ROI, optimization opportunities, complexity tier, recommendation) plus the MCP pricing recipes.
-- **estimate-assemble.md** → the assembler: assembles + writes `estimation-infra.json`, runs the completion handoff gate (incl. the Property-16 total invariant), updates `.phase-status.json`, and presents the summary.
+Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture, producing `estimation-infra.json` (conforming to `../shared/estimate/estimation-infra.schema.json`) and classifying migration complexity using the tier thresholds in `../shared/estimate/complexity-tiers.json`.
 
 ---
 


### PR DESCRIPTION
## What

Prose-prune sweep for the **estimate** phase of `heroku-to-aws` — continuing #121 (discover + clarify) and #122 (design). Each phase/fragment/assembler file is reconciled against the DSL contract so it carries only the prose it uniquely needs; text now owned by frontmatter, `INTERPRETER.md`, a sibling unit, or the JSON schema is retired.

Net **−62 lines** (13 insertions / 75 deletions) across 3 files. The estimate phase was already authored in the post-cleanup style (no per-phase state machine, no Output-Files/Error-Handling tables, no Step-N status recipe), so the cuts are modest and targeted.

## Cuts (all covered by frontmatter / INTERPRETER / schema)

- **estimate.md** (orchestrator) — cut the `> Loaded by SKILL.md when phases.design == completed AND phases.estimate != completed` blockquote (restated the predecessor gate `_preconditions._check_phase_completed: design` + the not-already-completed loop logic, both owned by `INTERPRETER.md` § Gate protocol + the interpreter loop). Folded the `## Overview` orientation sentence into the H1 intro (matching design.md) and dropped its **Inputs** list (dups `_input`) + **Outputs** list (dups `_produces` + INTERPRETER's status-update). Cut `## Sub-Files` (dups `_fragments`/`_assemble`; Steps 1–2 repeat it). Kept the Scope Boundary block.
- **estimate-cost-engine.md** (fragment) — **no prose cuts**. This is the cost engine itself (pricing-mode logic, per-service formulas, observability math, tier thresholds, ROI, recommendation, MCP recipes, worked JSON) — all real deterministic work that fragment prose is for. Only normalized the one inconsistent `_contributes` entry from a prose gloss to a bare filename (`- estimation-infra.json`), matching every other fragment in the skill; the gloss was redundant with the fragment's blockquote.
- **estimate-assemble.md** (assembler) — trimmed the `## Output` section's inline `estimation-infra.json` skeleton. It restated the shape right after citing `estimation-infra.schema.json` — a drift surface per the knowledge/contract no-duplication rule. Diffed the skeleton against the schema: the schema pins the top-level keys + `pricing_source`/`projected_costs` fields + enums, and the cost-engine's Parts 1–8 already emit each section's full JSON. The only section neither the schema nor a single Part defines is `financial_summary` (assembler-derived; the schema leaves its shape open). Replaced the ~60-line skeleton with a schema reference + a one-line-per-section assembly map (which Part fills which section) + the `financial_summary` block spelled out. Kept the Completion Handoff Gate (incl. the schema-validation context note) and the Present Summary template untouched.

## Not touched (deliberate)

- Phase-ordinal titles ("Phase 4 …") — deferred to the separate ordinal sweep.
- gcp-to-aws — untouched.

## Testing

`mise run build` green (first try) — `lint:md` (markdownlint, incl. MD031), `lint:types`, `lint:frontmatter` (validator: OK, 6 phase files), `fmt:check` (dprint), and the security scanners. Grepped the estimate phase dir afterward: no dangling `Rule N` / `State Machine` / cut-section refs, and no other phase references the removed sections. Pure prose deletion + one frontmatter normalization; no behavioral change (everything removed is owned by the schema or the cost-engine Parts).
