### PR TITLE
docs(heroku-to-aws): prune redundant prose from generate phase

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -21,18 +21,10 @@ _produces:
 
 ## Step 3: Validate Complete Artifact Set
 
-Verify the complete set of generated artifacts:
-
-1. `terraform/main.tf` — provider configuration
-2. `terraform/variables.tf` — input variables
-3. `terraform/outputs.tf` — resource outputs
-4. `terraform/vpc.tf` — VPC configuration (new or existing reference)
-5. `terraform/security.tf` — security groups and IAM
-6. Domain-specific `.tf` files (per design content)
-7. `MIGRATION_GUIDE.md` — step-by-step migration procedure
-8. `README.md` — artifact listing and quick start
-9. Database migration scripts (conditional on design content)
-10. `generation-warnings.json` (always written; empty `warnings` array when nothing was skipped)
+The full generated artifact set (core terraform files + MIGRATION_GUIDE.md +
+README.md + generation-warnings.json) is gate-checked by this phase's
+`_postconditions` (see the Completion Handoff Gate below). This assembler adds the
+cross-artifact checks that span multiple fragment outputs:
 
 **Cross-reference checks:**
 
@@ -56,15 +48,9 @@ accounted for, no `{{VARIABLE}}` placeholders), then emit `GATE_FAIL` (STOP) or
 
 ---
 
-## Step 4: Update Phase Status
+## Step 4: Update Phase Status and Hand Off
 
-Only after `HANDOFF_OK`. Use the read-merge-write update protocol (`INTERPRETER.md` § The interpreter loop):
-
-1. Read current `.phase-status.json` from disk.
-2. Set `phases.generate` to `"completed"`.
-3. Set `current_phase` to `"complete"`.
-4. Update `last_updated` to current ISO 8601 timestamp.
-5. Write the full file.
+Only after `HANDOFF_OK`, apply the phase-status update protocol (`INTERPRETER.md` § The interpreter loop) — mark `phases.generate` completed and advance per `_advances_to` (the `complete` terminal) — in the **same turn** as the output message below.
 
 Output to user:
 
@@ -87,27 +73,16 @@ After this output, SKILL.md handles the post-Generate share prompt and feedback 
 
 ## Output Files
 
-**Generate phase writes to `$MIGRATION_DIR/`. Required outputs:**
-
-1. `.phase-status.json` — updated per Step 4
-2. `terraform/` — complete Terraform configuration directory
-3. `MIGRATION_GUIDE.md` — migration procedure
-4. `README.md` — artifact overview
-
-**Conditional outputs:**
-
-- `scripts/migrate-postgres.sh` — when Postgres in design
-- `scripts/migrate-redis.sh` — when Redis in design
-- `generation-warnings.json` — always written (empty `warnings` array when nothing was skipped)
+This phase's artifacts are declared in `_produces` (the terraform floor + MIGRATION_GUIDE.md + README.md + generation-warnings.json; `.phase-status.json` is updated per Step 4). Conditional outputs (`scripts/migrate-postgres.sh` when Postgres in design, `scripts/migrate-redis.sh` when Redis in design) are governed by the docs fragment's Step 0/Step 3; `generation-warnings.json` is always written (empty `warnings` array when nothing was skipped).
 
 ---
 
 ## Error Handling
 
-| Error Category                       | Behavior                                  | Status Transition      |
-| ------------------------------------ | ----------------------------------------- | ---------------------- |
-| Predecessor phase incomplete         | GATE_FAIL, halt                           | Remain `pending`       |
-| Input artifact missing/invalid       | GATE_FAIL, halt                           | Retain `in_progress`   |
-| Terraform generation partial failure | Log to generation-warnings.json, continue | Continue `in_progress` |
-| Documentation generation failure     | GATE_FAIL at Step 2 gate                  | Retain `in_progress`   |
-| Handoff gate check fails             | Halt pipeline, surface diagnostic         | Retain `in_progress`   |
+Non-fatal generation errors and their handling (fatal predecessor/input/gate failures are handled by `_preconditions`/`_postconditions` + `INTERPRETER.md` § `_on_error`):
+
+| Error Category                       | Behavior                                  |
+| ------------------------------------ | ----------------------------------------- |
+| Terraform generation partial failure | Log to generation-warnings.json, continue |
+| Documentation generation failure     | GATE_FAIL at the completion gate          |
+| Handoff gate check fails             | Halt pipeline, surface diagnostic         |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -16,19 +16,6 @@ _contributes:
 
 ---
 
-## Inputs Required
-
-Before executing, the parent `generate.md` must have loaded:
-
-1. `$MIGRATION_DIR/aws-design.json` — designed AWS architecture
-2. `$MIGRATION_DIR/heroku-resource-inventory.json` — source Heroku resources
-3. `$MIGRATION_DIR/preferences.json` — migration preferences
-4. `$MIGRATION_DIR/estimation-infra.json` — cost estimates
-
-All four files must be valid JSON and present. If any are missing, exit cleanly — the parent orchestrator handles the GATE_FAIL.
-
----
-
 ## Step 0: Detect Data Store Presence
 
 Scan `aws-design.json`.services[] to determine which data store types exist in the design:
@@ -1238,30 +1225,10 @@ Verify all generated files:
 
 ---
 
-## Output Contribution
-
-This sub-file contributes to `$MIGRATION_DIR/`:
-
-1. `MIGRATION_GUIDE.md` — complete migration procedure
-2. `README.md` — artifact listing and quick start
-3. `scripts/migrate-postgres.sh` — PostgreSQL migration script (conditional)
-4. `scripts/migrate-redis.sh` — Redis migration script (conditional)
-
-The parent `generate.md` handles:
-
-- Merging with Terraform generation output
-- Generation warnings consolidation
-- Phase status update and handoff gate
-
-**Do not update `.phase-status.json` from this sub-file.**
-
----
-
 ## Error Handling
 
 | Error                          | Behavior                                        | Impact                                 |
 | ------------------------------ | ----------------------------------------------- | -------------------------------------- |
-| Input artifact missing         | Exit cleanly, no output                         | Parent handles GATE_FAIL               |
 | Template variable unresolvable | Use placeholder with `{{VARIABLE_NAME}}` format | User fills manually                    |
 | No data stores in design       | Omit Phase 2 entirely from guide                | Valid — compute-only migration         |
 | No deferred add-ons            | Omit Manual Migration Items section             | Valid — all add-ons mapped             |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -13,10 +13,6 @@ _contributes:
 > Terraform + kubernetes/ manifests; otherwise the Fargate generation path applies
 > and this fragment is skipped.
 
-**Applies when:** `aws-design.json` contains `aws_service: "EKS"` for one or more services.
-
-**Skip when:** No EKS services in design → existing Fargate generation path applies.
-
 ---
 
 ## Generated Artifacts

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -12,24 +12,11 @@ _contributes:
 
 # Generate Phase: Terraform Configuration Generation
 
-> Loaded by `generate.md` when `aws-design.json` and `estimation-infra.json` exist.
-
 **Execute ALL steps in order. Do not skip or optimize.**
 
 ## Overview
 
 Transform `aws-design.json` into deployable Terraform HCL configurations. Produces a `terraform/` directory in `$MIGRATION_DIR/` containing valid, `terraform validate`-passing configurations for all designed AWS resources.
-
-## Prerequisites
-
-Read the following artifacts from `$MIGRATION_DIR/`:
-
-- `aws-design.json` (REQUIRED) — AWS architecture design from Phase 3
-- `estimation-infra.json` (REQUIRED) — Cost estimates from Phase 4
-- `preferences.json` (REQUIRED) — User migration preferences from Phase 2
-- `heroku-resource-inventory.json` (REQUIRED) — Discovered Heroku resources from Phase 1
-
-If any required file is missing: **STOP**. Output: "Missing required artifact: [filename]. Complete the prior phase that produces it."
 
 ## Output Structure
 
@@ -1446,50 +1433,4 @@ After all files are written:
 
 **Note:** Full `terraform validate` requires `terraform init` (provider download). The generated configuration SHOULD pass `terraform validate` when run with network access. If validation cannot run (no Terraform binary, no network), log a note but do NOT block generation.
 
----
-
-## Output Summary
-
-Upon completion, the `$MIGRATION_DIR/terraform/` directory should contain:
-
-```
-terraform/
-├── main.tf                   # Provider, backend, data sources
-├── variables.tf              # All input variables
-├── outputs.tf                # Resource outputs
-├── vpc.tf                    # VPC configuration (new or data sources for existing)
-├── security.tf               # Security groups, IAM roles
-├── compute.tf                # ECS cluster, task definitions, services, ALBs
-├── database.tf               # RDS/Aurora, parameter groups, RDS Proxy
-├── cache.tf                  # ElastiCache replication groups
-├── messaging.tf              # MSK clusters and configurations
-├── .gitignore                # Terraform-specific ignore rules
-└── terraform.tfvars.example  # Example variable values
-```
-
-Files are only emitted if their domain has resources in `aws-design.json`. The minimum set is always: `main.tf`, `variables.tf`, `outputs.tf`, `security.tf`, `.gitignore`, `terraform.tfvars.example`.
-
-Additionally, `$MIGRATION_DIR/generation-warnings.json` is ALWAYS emitted (empty `warnings` array when no services were skipped).
-
----
-
-## Completion Handoff Gate (Fail Closed)
-
-Before returning control to `generate.md`, require:
-
-1. `$MIGRATION_DIR/terraform/main.tf` exists
-2. `$MIGRATION_DIR/terraform/variables.tf` exists
-3. `$MIGRATION_DIR/terraform/outputs.tf` exists
-4. At least one domain file (`compute.tf`, `database.tf`, `cache.tf`, `messaging.tf`, or `vpc.tf`) exists
-5. All resource cross-references resolve within the configuration
-6. `generation-warnings.json` exists (ALWAYS written; empty `warnings` array if all services mapped successfully)
-
-If this gate fails: STOP and output: "generate-terraform did not produce a valid terraform/ directory; do not continue Generate."
-
-## Generate Phase Integration
-
-The parent orchestrator (`generate.md`) uses the `terraform/` directory to:
-
-1. Gate documentation generation — `generate-docs.md` references terraform file names in `README.md`
-2. Validate the complete artifact set before phase completion
-3. Set phase completion status in `.phase-status.json`
+When all files are written, control returns to `generate.md` (then the phase assembler `generate-assemble.md`), which runs the phase completion handoff gate per its `_postconditions`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -65,76 +65,27 @@ _forbids_files:
 
 # Phase 5: Generate Migration Artifacts
 
-> Loaded by SKILL.md when `phases.estimate == "completed"` AND `phases.generate != "completed"`.
-
 **Execute ALL steps in order. Do not skip or optimize.**
-
-## Sub-Files
-
-- **generate-terraform.md** → routes the design into Terraform: writes the `terraform/` directory and `generation-warnings.json`.
-- **generate-docs.md** → fills the docs + script templates: writes `MIGRATION_GUIDE.md`, `README.md`, and database migration scripts in `scripts/`.
-- **generate-eks.md** → the EKS branch: fires (via its `_when` trigger) only when the design contains `aws_service: "EKS"`; writes `terraform/eks.tf` + the `kubernetes/` manifests.
-- **generate-assemble.md** → the assembler: cross-artifact validation, completion handoff gate, and `.phase-status.json` update.
-
----
 
 ## Step 0: Validate Prerequisites
 
 The entry gate (estimate completed, single active phase, all four inputs present + valid
 JSON) is enforced by this phase's `_preconditions` frontmatter per `INTERPRETER.md`
-§ Gate protocol. Once the preconditions pass, set `phases.generate` to `"in_progress"`
-and `current_phase` to `"generate"` in `.phase-status.json`, then proceed.
+§ Gate protocol; proceed once it passes.
 
 ---
 
 ## Step 1: Generate Terraform Configurations
 
-Load `references/phases/generate/generate-terraform.md` and execute completely.
-
-This produces:
-
-- `$MIGRATION_DIR/terraform/` directory with all `.tf` files
-- `$MIGRATION_DIR/generation-warnings.json` (always written; empty `warnings` array when nothing was skipped)
-
-**Gate check after Step 1:**
-
-- `terraform/main.tf` must exist
-- `terraform/variables.tf` must exist
-- `terraform/outputs.tf` must exist
-- At least one domain file must exist (`compute.tf`, `database.tf`, `cache.tf`, `messaging.tf`, or `vpc.tf`)
-
-If gate fails: STOP. Output: "Terraform generation failed. Check generation-warnings.json for details."
-
-**EKS Generation (conditional):**
-
-If `aws-design.json` contains any service with `aws_service: "EKS"`:
-
-- Load `references/phases/generate/generate-eks.md`
-- Follow its instructions to produce `terraform/eks.tf` and `kubernetes/` directory
-- Add Helm provider to `terraform/main.tf`
-- Add EKS sections to MIGRATION_GUIDE.md
-
-If NO services have `aws_service: "EKS"`, skip EKS generation entirely.
+Load `references/phases/generate/generate-terraform.md` and execute completely. When the
+design contains EKS (`aws_service: "EKS"`), the `eks-generate` fragment also fires per its
+`_fragments` `_when` trigger; follow `references/phases/generate/generate-eks.md`.
 
 ---
 
 ## Step 2: Generate Documentation and Scripts
 
 Load `references/phases/generate/generate-docs.md` and execute completely.
-
-This produces:
-
-- `$MIGRATION_DIR/MIGRATION_GUIDE.md`
-- `$MIGRATION_DIR/README.md`
-- `$MIGRATION_DIR/scripts/migrate-postgres.sh` (if Postgres in design)
-- `$MIGRATION_DIR/scripts/migrate-redis.sh` (if Redis in design)
-
-**Gate check after Step 2:**
-
-- `MIGRATION_GUIDE.md` must exist
-- `README.md` must exist
-
-If gate fails: STOP. Output: "Documentation generation incomplete. MIGRATION_GUIDE.md or README.md missing."
 
 ---
 


### PR DESCRIPTION
## What

Prose-prune sweep for the **generate** phase of `heroku-to-aws` — continuing #121 (discover + clarify), #122 (design), and #124 (estimate). Each phase/fragment/assembler file is reconciled against the DSL contract so it carries only the prose it uniquely needs; text now owned by frontmatter, `INTERPRETER.md`, a sibling unit, or the schema is retired.

Net **−170 lines** (19 insertions / 189 deletions) across 5 files. Generate is the largest phase (~3500 lines), but the cuts are proportionally light — the terminal fan-out fragments (`generate-terraform`, `generate-docs`, `generate-eks`) are overwhelmingly real HCL / doc / manifest generation, which is exactly what fragment prose is for. The redundancy clustered at the head and tail of each file.

## Cuts (all covered by frontmatter / INTERPRETER / a sibling unit)

- **generate.md** (orchestrator) — the `> Loaded by SKILL.md when …` blockquote (predecessor gate + loop logic), `## Sub-Files` (dups `_fragments`/`_assemble`), Step 0's set-`in_progress`/`current_phase` recipe (kept the one-line gate pointer), the per-step "This produces:" lists in Steps 1 & 2 (dup `_contributes` + `_produces`), the "Gate check after Step N" blocks (dup the completion `_postconditions`), and the "EKS Generation (conditional)" prose block. Before cutting the EKS block I verified `generate-eks.md` owns both cross-fragment facts it named — the "Helm Provider Requirement" section (Helm provider → main.tf) and the "MIGRATION_GUIDE.md — EKS Sections" section — so nothing was lost. Kept a one-line pointer that the conditional EKS fragment fires.
- **generate-terraform.md** (fragment) — the `> Loaded by generate.md …` blockquote, `## Prerequisites` (dups `_input`/`_preconditions`; its exit branch is unreachable — the fragment runs only after preconditions pass), `## Output Summary` (dir tree + emission recap — dups `_contributes` AND the earlier `## Output Structure` section), the fragment-level `## Completion Handoff Gate` (dups the phase `_postconditions`), and `## Generate Phase Integration` (describes the orchestrator's job). Replaced the tail trio with a one-line pointer that control returns to the assembler's completion gate. **HCL Steps 1–12 + the Output-Structure routing tables are untouched.**
- **generate-docs.md** (fragment) — `## Inputs Required` (dups `_input`/`_preconditions` + unreachable exit), `## Output Contribution` (file list dups `_contributes`; the "parent handles merging/warnings/phase-status/handoff gate" bit is orchestration prose), and the one gate-dup row in the Error Handling table. **All MIGRATION_GUIDE / README / script templates + the content self-validation checklist are untouched.**
- **generate-eks.md** (fragment) — the bolded `Applies when:`/`Skip when:` pair (a third copy of the fragment's `_when` trigger, already in the blockquote + frontmatter), mirroring the design-eks cut in #122. **All EKS generation untouched.**
- **generate-assemble.md** (assembler) — mirrors the design-assemble cuts in #122, plus a Step-3 trim: the numbered artifact list → a one-line pointer (kept the Cross-reference checks — the assembler's real cross-artifact work); the Step-4 read-merge-write recipe + hardcoded `current_phase=complete` → an INTERPRETER pointer (kept the user-facing completion message); the `## Output Files` lists collapsed to behavioral facts; the Error-Handling "Status Transition" column dropped (dups `_on_error`) along with the two gate-dup rows.

## Templates investigation (no change)

While here, audited whether the embedded HCL (22 fenced blocks in `generate-terraform`) should move to a `templates/` folder. Finding: only `.gitignore` is a clean extraction candidate; ~19 blocks are skeleton + `<field>` interpolation + conditional-emission logic fused together (worked examples that carry the generation algorithm — the keep category). Extraction would need a `_templates` grammar key + `templates/` convention that main's `frontmatter-validator` does not support (that's the richer plan-of-record grammar), for a 1–2 file payoff. Left the HCL inline.

## Not touched (deliberate)

- Phase-ordinal titles ("Phase 5 …") — deferred to the separate ordinal sweep.
- The generation bodies (HCL, docs, manifests, migration scripts, worked examples) — the fragments' real work.
- gcp-to-aws — untouched.

## Testing

`mise run build` green (first try) — `lint:md` (markdownlint, incl. MD031), `lint:types`, `lint:frontmatter` (validator: OK, 6 phase files), `fmt:check` (dprint), and the security scanners. Grepped the generate phase dir afterward: no dangling `Rule N` / `State Machine` / `Status Transition` / cut-section refs, and no other phase references the removed sections. (The one `## Prerequisites` hit remaining is inside the *emitted* MIGRATION_GUIDE.md template, not a cut fragment section.) Pure prose deletion; no behavioral change.
