### PR TITLE
fix(ci): exclude broken semgrep registry rule bbp-pattern-inject

### DIFF
--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -133,6 +133,7 @@ jobs:
           fi
           set +e
           semgrep scan --oss-only --metrics=off --config=r/all \
+            --exclude-rule="bbp-pattern-inject" \
             --exclude-rule="ai.generic.detect-generic-ai-anthprop.detect-generic-ai-anthprop" \
             --exclude-rule="ai.generic.detect-generic-ai-oai.detect-generic-ai-oai" \
             --json-output semgrep-report.json $BASELINE_ARGS


### PR DESCRIPTION
The bbp-pattern-inject rule in the public Semgrep registry (pulled via --config=r/all) currently fails to parse, causing semgrep to exit with code 2 (scanner error) on every PR regardless of the code scanned. This turned the semgrep check red with 0 actual findings. Excluding the rule restores exit 0.

## Problem

<!-- Description of the problem being solved -->

## Solution

<!-- Description of how this pull request solves that problem -->

## Type of Change

- [ ] New plugin/power/tool
- [ ] Bug fix
- [ ] Enhancement to existing content
- [ ] Documentation update
- [x] Guardrail/CI update

## Team Folder

<!-- Which top-level folder does this PR affect? -->

- [ ] `advisor/`
- [ ] `migrate/`
- [ ] Other: ___

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My changes do not include hardcoded secrets, credentials, or internal-only content
- [ ] I have run `mise run build` locally and it passes
- [ ] I have updated documentation if needed
- [ ] My changes are scoped to my team's folder only
