### PR TITLE
skill: add hipaa-assistant

### DIFF
--- a/solution-architecture/plugins/aws-dev-toolkit/hipaa-assistant/SKILL.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/hipaa-assistant/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: hipaa-assistant
+description: >
+  Activate when the user asks about HIPAA compliance scanning, validating AWS
+  configurations against HIPAA Security Rule controls, or pre-deployment HIPAA
+  checks for GenAI workloads on AWS.
+---
+
+# HIPAA Assistant
+
+A Go-based CLI and MCP server that scans your AWS configurations against HIPAA
+Security Rule controls before deployment.
+
+## What it does
+
+- **Scan** - Analyzes CloudFormation, Terraform, or application code for HIPAA
+  Security Rule compliance gaps
+- **Advise** - Provides remediation steps for identified gaps
+- **Reference** - Maps each finding to the verbatim Code of Federal Regulations
+  text (45 CFR Part 164) so you know exactly which control is at risk
+
+## How to use it
+
+https://github.com/aws-samples/sample-hipaa-assistant
+
+Runs as a CLI tool or as an MCP server you can invoke directly from your IDE.
+
+## Disclaimer
+
+This tool provides cited technical guidance based on publicly available HIPAA
+Security Rule text (45 CFR Part 164) and AWS documentation. It is not legal
+advice and does not constitute a compliance certification. Work with qualified
+legal counsel and compliance professionals before handling PHI in production.


### PR DESCRIPTION
## Problem

Founders building HIPAA-compliant GenAI apps on AWS can't discover the sample-hipaa-assistant tool unless they're already searching GitHub.

## Solution

Adds a skill that surfaces the HIPAA assistant tool in founders' IDEs when they ask about HIPAA compliance scanning for GenAI workloads.

Closes #133

## Type of Change

- [x] New plugin/power/tool

## Team Folder

- [x] Other: `solution-architecture/`

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [ ] I have run `mise run build` locally and it passes
- [x] I have updated documentation if needed
- [x] My changes are scoped to my team's folder only