### PR TITLE
feat: add bq-assess CLI + skill under solution-architecture/clis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,12 @@
       "source": "./migrate/plugins/ai-to-aws",
       "version": "1.0.1",
       "description": "End-to-end AI migration to Amazon Bedrock: assess your codebase, design the architecture, then execute — rewriting SDK calls, evaluating quality, and delivering a ready-to-merge git branch. Requires the migration-to-aws plugin (it powers the Assess phase). With both installed, use /ai-to-aws:llm-to-bedrock for AI workloads — it adds the Execute half on top of migration-to-aws's assessment."
+    },
+    {
+      "name": "bq-assess",
+      "source": "./solution-architecture/clis/bq-assess",
+      "version": "0.3.1",
+      "description": "Read-only BigQuery migration assessment: scans a BigQuery warehouse and scores every table on two axes — Migration Effort (moving the data to S3 Tables / Apache Iceberg) and Query Complexity (keeping the SQL running on Amazon Redshift) — then generates Iceberg DDL, load guidance, and a BigQuery-vs-AWS cost comparison as HTML + JSON reports. Ships as a full Python CLI plus a guided Claude Code skill. Assesses only; needs no AWS account to run."
     }
   ]
 }

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -82,17 +82,21 @@ jobs:
           pip install "bandit[sarif]==1.9.3"
           PLUGIN_DIR=migrate/plugins/ai-to-aws
           PLUGIN_CFG=$PLUGIN_DIR/bandit.yml
+          BQ_DIR=solution-architecture/clis/bq-assess
+          BQ_CFG=$BQ_DIR/bandit.yml
           set +e
           bandit -r "$PLUGIN_DIR" -c "$PLUGIN_CFG" -f sarif -o bandit-plugin.sarif
           PLUGIN_EXIT=$?
-          bandit -r . --exclude "./$PLUGIN_DIR,./migrate/plugins/migration-to-aws/tests" -f sarif -o bandit-other.sarif
+          bandit -r "$BQ_DIR" -c "$BQ_CFG" -f sarif -o bandit-bq.sarif
+          BQ_EXIT=$?
+          bandit -r . --exclude "./$PLUGIN_DIR,./migrate/plugins/migration-to-aws/tests,./$BQ_DIR" -f sarif -o bandit-other.sarif
           OTHER_EXIT=$?
           set -e
-          # Merge: keep pass-1 envelope, concatenate results from pass-2.
-          jq -s '.[0] as $p | .[1] as $o | $p | .runs[0].results += $o.runs[0].results' \
-            bandit-plugin.sarif bandit-other.sarif > bandit-report.sarif
-          # Surface non-zero from either pass.
-          if [ "$PLUGIN_EXIT" -ne 0 ] || [ "$OTHER_EXIT" -ne 0 ]; then
+          # Merge: keep pass-1 envelope, concatenate results from later passes.
+          jq -s '.[0] as $p | .[1] as $b | .[2] as $o | $p | .runs[0].results += ($b.runs[0].results + $o.runs[0].results)' \
+            bandit-plugin.sarif bandit-bq.sarif bandit-other.sarif > bandit-report.sarif
+          # Surface non-zero from any pass.
+          if [ "$PLUGIN_EXIT" -ne 0 ] || [ "$BQ_EXIT" -ne 0 ] || [ "$OTHER_EXIT" -ne 0 ]; then
             BANDIT_EXIT=1
           else
             BANDIT_EXIT=0

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ AI agent plugins, tools, and resources for startup builders on AWS.
 
 ## Plugins
 
-| Plugin                                        | Description                                                                                                                                                    | Status    |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| **[migration-to-aws](migrate/)**              | Assess & plan: migrate GCP/Azure infrastructure and AI workloads to AWS with resource discovery, architecture mapping, cost analysis, and Terraform generation | Available |
-| **[ai-to-aws](migrate/)**                     | Execute: rewrite LLM SDK calls to Amazon Bedrock, evaluate output quality against your test cases, and deliver a ready-to-merge git branch                     | Available |
-| **[aws-dev-toolkit](solution-architecture/)** | AWS development toolkit — 35 skills, 11 agents, and 3 MCP servers for building, migrating, and architecture reviews on AWS                                     | Available |
+| Plugin                                                 | Description                                                                                                                                                    | Status    |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| **[migration-to-aws](migrate/)**                       | Assess & plan: migrate GCP/Azure infrastructure and AI workloads to AWS with resource discovery, architecture mapping, cost analysis, and Terraform generation | Available |
+| **[ai-to-aws](migrate/)**                              | Execute: rewrite LLM SDK calls to Amazon Bedrock, evaluate output quality against your test cases, and deliver a ready-to-merge git branch                     | Available |
+| **[aws-dev-toolkit](solution-architecture/)**          | AWS development toolkit — 35 skills, 11 agents, and 3 MCP servers for building, migrating, and architecture reviews on AWS                                     | Available |
+| **[bq-assess](solution-architecture/clis/bq-assess/)** | Read-only BigQuery migration assessment — two-axis effort/complexity scoring, Iceberg DDL, and BigQuery-vs-AWS cost comparison (CLI + guided skill)            | Available |
 
 ## Installation
 
@@ -66,6 +67,8 @@ awslabs/startups/
 │       ├── migration-to-aws/         # Assess & plan
 │       └── ai-to-aws/                # Execute (AI/LLM migrations)
 ├── solution-architecture/            # Solution Architecture plugins (aws-dev-toolkit)
+│   └── clis/
+│       └── bq-assess/                # BigQuery migration assessment (CLI + skill)
 └── ...                               # Future team folders
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -78,10 +78,11 @@ run = [
 # =========
 
 [tasks."security:bandit"]
-description = "Run Bandit (two-pass: ai-to-aws plugin with its own skip config; rest of repo with full strictness — mirrors the CI bandit job in .github/workflows/security-scanners.yml)"
+description = "Run Bandit (multi-pass: each plugin with Python gets its own skip config; rest of repo with full strictness — mirrors the CI bandit job in .github/workflows/security-scanners.yml)"
 run = [
   "bandit -r migrate/plugins/ai-to-aws -c migrate/plugins/ai-to-aws/bandit.yml -x ./migrate/plugins/ai-to-aws/scripts/.venv",
-  "bandit -r . --exclude ./.tmp,./node_modules,./migrate/plugins/ai-to-aws,./migrate/plugins/migration-to-aws/tests",
+  "bandit -r solution-architecture/clis/bq-assess -c solution-architecture/clis/bq-assess/bandit.yml",
+  "bandit -r . --exclude ./.tmp,./node_modules,./migrate/plugins/ai-to-aws,./migrate/plugins/migration-to-aws/tests,./solution-architecture/clis/bq-assess",
 ]
 
 [tasks."security:semgrep"]

--- a/solution-architecture/clis/bq-assess/.claude-plugin/plugin.json
+++ b/solution-architecture/clis/bq-assess/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "bq-assess",
+  "displayName": "BigQuery Migration Assessment",
+  "version": "0.3.1",
+  "description": "Read-only BigQuery migration assessment: scans a BigQuery warehouse and scores every table on two axes — Migration Effort (moving the data to S3 Tables / Apache Iceberg) and Query Complexity (keeping the SQL running on Amazon Redshift) — then generates Iceberg DDL, load guidance, and a BigQuery-vs-AWS cost comparison as HTML + JSON reports. Assesses only; it does not execute the migration, and needs no AWS account to run.",
+  "author": {
+    "name": "Amazon Web Services"
+  },
+  "homepage": "https://github.com/awslabs/startups/tree/main/solution-architecture/clis/bq-assess",
+  "repository": "https://github.com/awslabs/startups",
+  "keywords": [
+    "bigquery",
+    "redshift",
+    "migration",
+    "assessment",
+    "iceberg",
+    "s3-tables",
+    "lakehouse",
+    "gcp",
+    "cost-comparison"
+  ],
+  "license": "Apache-2.0",
+  "skills": "./skills/"
+}

--- a/solution-architecture/clis/bq-assess/CONTEXT.md
+++ b/solution-architecture/clis/bq-assess/CONTEXT.md
@@ -1,0 +1,160 @@
+# bq-assess — BigQuery → AWS Lakehouse Migration Assessment
+
+A read-only tool that profiles an existing BigQuery warehouse and produces a migration
+assessment: a cost comparison against AWS and DDL/DML migration instructions for moving
+to an open lakehouse on AWS. It assesses; it does not execute the migration.
+
+## Language
+
+**Source**:
+The existing BigQuery warehouse being assessed. The tool reads only its metadata
+(and optionally its query logs) — never its data rows.
+_Avoid_: origin, legacy, source-of-truth
+
+**Storage Target**:
+Amazon S3 Tables — managed Apache Iceberg tables — where migrated data will live.
+The destination that schema conversion (DDL) targets. Iceberg natively supports
+nested types (struct/list/map), so nesting is not a storage obstacle.
+_Avoid_: destination, sink, "the Redshift tables" (Redshift is the engine, not the store)
+
+**Query Engine**:
+Amazon Redshift Serverless — the decoupled compute that queries and writes the
+Storage Target. Sized by compute (RPU), independent of stored data volume. This
+project targets Serverless only; provisioned Redshift is out of scope.
+_Avoid_: cluster, warehouse, database, "Redshift" unqualified
+
+**Assessment**:
+The tool's output for a Source: a [[cost-comparison]] and per-entity [[migration-instructions]]
+scored on two independent axes ([[migration-effort]] and [[query-complexity]]). Delivered
+as three paired HTML+JSON artifacts sharing one design language:
+
+- **Landing** — executive entry point: cost-comparison hero + headline counts, links onward.
+- **Migration Effort** — [[table]]s ranked by move-effort.
+- **Query Complexity** — [[table]]s + [[view-/-materialized-view-/-udf]]s ranked by rewrite effort.
+  JSON is split to mirror the three HTML files (one source per file, cross-referenced by
+  entity name); no CSV. HTML must be professional-grade (built via the `frontend-design` skill).
+  _Avoid_: report (that names the file, not the content), scan (that names one input step)
+
+**Migration Instructions**:
+The per-table guidance the tool emits, in three layers. Guidance for a human or a
+later phase to run — the tool itself never writes to the Storage Target.
+_Avoid_: migration script, ETL job, pipeline
+
+- **DDL** — Iceberg `CREATE TABLE` for the Storage Target. Always emitted (metadata only).
+- **Load/Sync DML** — Redshift SQL that loads BigQuery data into the Storage Target
+  (initial load) and keeps it current (ongoing upsert via `MERGE` on Iceberg).
+  Always emitted (metadata only). _Avoid_: ETL, COPY job.
+- **Query-Rewrite Guidance** — flags BigQuery-specific constructs in the [[query-workload]]
+  that won't run on the Query Engine and estimates rewrite effort. Only emitted when
+  query logs or view SQL are provided (the high-confidence upgrade).
+
+**Query Workload**:
+The set of `SELECT`/view/transform SQL the Source actually runs, observed via query
+logs or view definitions. Distinct from [[migration-instructions]] Load/Sync DML —
+this is the customer's existing read workload, the input to Query-Rewrite Guidance.
+_Avoid_: queries (ambiguous), DML (that's the load/sync SQL we emit)
+
+## Entities
+
+The [[assessment]] distinguishes two entity populations by what migrating them means:
+data that **moves** vs. SQL behavior that gets **rebuilt**. Tables appear in both
+interfaces; views/MVs/UDFs appear only in the [[query-complexity]] one.
+
+**Table**:
+A base table — state at rest. Moves into the Storage Target (Iceberg). The only entity
+with [[migration-effort]]. Also carries [[query-complexity]] when queried directly.
+_Avoid_: relation, dataset (that's the BQ container)
+
+**View / Materialized View / UDF**:
+SQL _behavior_, not state — rebuilt in the engine layer, never "moved." Zero
+[[migration-effort]] (nothing physical to relocate); scored only on [[query-complexity]].
+Each links to the [[table]]s it depends on.
+
+- **UDFs always land in the Query Engine** — Iceberg has no function concept. BigQuery
+  **JavaScript** UDFs are the hardest case (no Redshift equivalent → Python/Lambda UDF
+  rewrite); SQL UDFs port more directly.
+- **Views/MVs have a [[placement]] choice** — Redshift-local or Iceberg-catalog object.
+
+**Placement**:
+The per-entity recommended home for a view/MV: **Redshift** (full dialect, simplest,
+auto-refresh; engine-local) or **Iceberg catalog** (open, multi-engine queryable; stays
+in the lakehouse). Recommended per entity from signals (multi-engine consumption, refresh
+needs) — never a blanket default. Iceberg-MV _refresh_ mechanics are unverified and must
+be confirmed before appearing in [[migration-instructions]].
+_Avoid_: location, target (overloaded with Storage Target)
+
+## Cost
+
+**Cost Comparison**:
+The Source's current BigQuery run-rate vs the projected AWS run-rate (Storage Target +
+Query Engine). Headline metric is the **monthly run-rate delta**; annual savings and
+break-even are supporting detail (break-even depends on one-time migration cost, which
+derives from [[migration-effort]], not a flat per-table fee). Always shown; compute side
+degrades by confidence — no [[query-workload]] data → LOW, shown as an estimated _range_,
+clearly labelled an estimate, never a false point value.
+_Avoid_: TCO, savings (name the specific metric), ROI
+
+**BQ Pricing Model**:
+Which way the Source is billed — must be detected, not assumed. **On-demand** bills
+bytes scanned ($/TB); **Capacity (Editions)** bills [[slot-time]] via reservations
+(baseline/max/commitments). The current code assumes on-demand only; a capacity-billed
+Source needs slot-based costing or its baseline is fiction.
+_Avoid_: flat-rate, pricing tier
+
+**Slot Time**:
+BigQuery compute consumed, measured in slot-ms (`total_slot_ms` per job in
+`INFORMATION_SCHEMA.JOBS`). The utilization curve (avg / P50 / P99 / peak / idle
+fraction) is the bridge to Query Engine RPU-hours — both meter compute-time, so workload
+_shape_ maps across directly. Auto-captured with the existing `jobs.listAll` permission.
+Reservation _config_ (edition rate, commitment discounts) often needs manual entry from
+the customer's slot estimator or bill — the top confidence rung.
+_Avoid_: slots (ambiguous: capacity vs consumption), CPU
+
+## Scoring Axes
+
+The [[assessment]] scores every table on two independent axes. A table can be low on
+one and high on the other; they are never combined into a single number.
+
+**Migration Effort**:
+How hard it is to _move_ a table into the Storage Target. Measures data-movement
+reality, not schema shape (Iceberg stores nesting/partitioning natively). Driven by:
+data volume tiers (load mechanics), [[lossy-cast]] count, ongoing-sync need (`MERGE`
+vs one-shot load), and _non-clean_ partition/sort mappings. Clean time-partition and
+sort-order mappings are zero-effort annotations the tool derives for you; ingestion-time,
+range, and multi-column mappings are scored effort + flagged for review. Always scored.
+Surfaced in its own HTML interface. Categories: **AUTO** (tool's load/sync DML moves it,
+no human) / **ASSISTED** (moves it, but a flagged decision needs sign-off) / **MANUAL**
+(human designs the load).
+_Avoid_: complexity (reserved for the other axis), difficulty; REVIEW (that's the old
+single-axis label)
+
+**Lossy Cast**:
+A BigQuery type with no clean Iceberg equivalent, requiring a human-reviewed casting
+decision: `GEOGRAPHY`, `INTERVAL`, `TIME`, and `BIGNUMERIC` beyond Iceberg decimal
+precision. A first-class scored [[migration-effort]] factor surfaced with a visible
+"lossy cast — review" flag — never a silent fallback.
+_Avoid_: unknown type, unmapped type, fallback
+
+**Query Complexity**:
+How hard it is to keep the existing [[query-workload]] _running_ on the Query Engine
+over the Storage Target after migration. Driven by BigQuery-specific SQL constructs
+(`UNNEST`, function drift, `ARRAY_*`, struct navigation, UDFs, complex views). Surfaced
+in its own HTML interface. Always scored, never fails when logs are absent; degrades by
+confidence over the [[sql-surface]]:
+
+- No views/UDFs/logs → LOW ("no read workload visible").
+- Views + persistent UDFs auto-captured → MEDIUM (the defined SQL surface).
+-
+  - Query logs → HIGH (actual observed workload, weighted by run frequency).
+    Categories: **PORTABLE** (runs on the Query Engine as-is) / **ADAPT** (minor dialect
+    adaptation) / **REWRITE** (full manual rewrite — JS UDFs, `UNNEST`-heavy views).
+    _Avoid_: rewrite score, portability score; AUTO/REVIEW/MANUAL (those are the Effort axis)
+
+**SQL Surface**:
+Every piece of Source SQL the [[query-complexity]] axis scores. Captured automatically
+within the existing read-only `metadataViewer` role (definitions are metadata, not data):
+view SQL (`view_query`), materialized-view SQL (`mview_query`), and persistent UDFs /
+stored procedures (`list_routines` → `body`/`language`/`arguments`). Inline UDFs
+(`CREATE TEMP FUNCTION` in a query body) are the one part NOT auto-captured — they appear
+only when query logs are provided. No user-supplied SQL is required.
+_Avoid_: DDL (that's the table schema), source code

--- a/solution-architecture/clis/bq-assess/LICENSE
+++ b/solution-architecture/clis/bq-assess/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/solution-architecture/clis/bq-assess/PRIVACY.md
+++ b/solution-architecture/clis/bq-assess/PRIVACY.md
@@ -1,0 +1,57 @@
+# Privacy Policy
+
+This document describes how the `bq-assess` CLI and its Claude Code skill handle data.
+The tool is maintained by Amazon Web Services and distributed under the Apache-2.0 license.
+
+## What this tool is
+
+`bq-assess` is a read-only command-line tool plus a Claude Code skill that guides its use.
+It scans BigQuery **metadata** (schemas, partitioning, view definitions, and — optionally —
+query log statistics from `INFORMATION_SCHEMA`) and writes assessment reports (HTML + JSON)
+to your local filesystem.
+
+## Data the tool collects
+
+**The tool itself collects no data.** It runs no telemetry, analytics, crash reporting, or
+usage tracking. It sends nothing to the tool maintainers or to AWS.
+
+## Data the tool reads and where it goes
+
+- The CLI reads BigQuery metadata using **your** GCP credentials (Application Default
+  Credentials or a service account you supply). It never reads table row data.
+- All output (reports, optional collection bundles) is written **locally** to paths you
+  choose. Nothing is uploaded anywhere by the tool.
+- Optional query-log analysis reads anonymized query text from `INFORMATION_SCHEMA.JOBS`
+  (literals stripped). You can disable query text collection entirely with
+  `--exclude-query-text`.
+- The `bq-collect` mode produces a plain-JSON, checksummed bundle designed to be
+  **reviewed by you before sharing**. Whether and with whom you share a bundle is
+  entirely your decision.
+
+## GCP and AWS API calls
+
+- BigQuery metadata reads are governed by your agreement with Google Cloud.
+- Live pricing lookups (optional) query the public AWS Price List API and public GCP
+  pricing endpoints; these requests contain no project data — only region/SKU filters.
+
+## Data Claude / Claude Code receives
+
+When you use the Claude Code skill, the content of your conversation — including report
+summaries the skill reads and text loaded from skill files — is sent to Anthropic as part
+of the normal model inference flow. That data flow is governed by Anthropic's privacy
+policy, not this document. See <https://www.anthropic.com/legal/privacy>.
+
+## Sensitive data
+
+The tool never requests secrets or credentials beyond the GCP authentication you already
+have configured, and its property-based test suite includes explicit checks that generated
+reports contain no credential material.
+
+## Changes
+
+Changes to this policy are tracked in the repository's git history.
+
+## Contact
+
+For questions about this policy, open an issue at
+<https://github.com/awslabs/startups/issues>.

--- a/solution-architecture/clis/bq-assess/README.md
+++ b/solution-architecture/clis/bq-assess/README.md
@@ -1,0 +1,113 @@
+# bq-assess — BigQuery Migration Assessment
+
+Scan a BigQuery warehouse and get a migration assessment report with two-axis scoring
+(data movement effort + query rewrite complexity), S3 Tables DDL, and a cost comparison.
+Targets S3 Tables (Apache Iceberg) storage + Amazon Redshift (Serverless or Provisioned)
+compute. Read-only — no AWS account needed to run an assessment.
+
+## Quick Start (Claude Code)
+
+The fastest way to run an assessment. The skill handles setup, execution, and report
+interpretation for you.
+
+```
+/plugin marketplace add awslabs/startups
+/plugin install bq-assess@startups-for-aws
+```
+
+Then ask:
+
+> "Assess BigQuery migration for project my-project"
+
+## Prerequisites
+
+- [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed
+- GCP authentication configured:
+
+  ```bash
+  gcloud auth application-default login
+  ```
+
+- IAM role on the target project: `roles/bigquery.metadataViewer`
+- For query log analysis (optional, higher confidence): `roles/bigquery.resourceViewer`
+
+The skill checks your environment, runs the scan, summarizes the report in plain
+English, and points you to the generated HTML report.
+
+## What You Get
+
+The tool scans BigQuery metadata and produces:
+
+- Two-axis scoring per entity:
+  - **Migration Effort** (AUTO / ASSISTED / MANUAL) — data movement difficulty to S3 Tables
+  - **Query Complexity** (PORTABLE / ADAPT / REWRITE) — SQL rewrite difficulty for Redshift
+- S3 Tables (Iceberg) DDL for every table
+- Cost comparison (BigQuery vs AWS)
+- HTML report (3 pages: landing summary, effort breakdown, query detail)
+- JSON output for downstream automation
+
+## How It Works
+
+```
+Preflight → Scan → Interpret
+```
+
+1. **Preflight** — checks tools and credentials, collects your project ID
+2. **Scan** — runs the assessment CLI, streams progress
+3. **Interpret** — reads the JSON report, highlights top effort/complexity entities and
+   cost findings, points to the HTML report
+
+Say "stop" or "cancel" at any point to exit.
+
+## CLI Usage
+
+Prefer the command line? Install directly:
+
+```bash
+pip3 install "git+https://github.com/awslabs/startups.git#subdirectory=solution-architecture/clis/bq-assess"
+```
+
+Then:
+
+```bash
+bq-assess --gcp-project my-project --use-adc --format html,json --output reports/
+```
+
+For accurate cost estimates, add reservation details:
+
+```bash
+bq-assess --gcp-project my-project --use-adc \
+  --reservation-config my-reservation-config.json \
+  --format html,json --output reports/
+```
+
+See the [CLI Reference](docs/CLI_REFERENCE.md) for all flags and options.
+
+## Two Ways to Run
+
+- **Direct** (`bq-assess`) — scan and generate the report in one step, inside the
+  environment that has BigQuery access.
+- **Collect, then report** (`bq-collect` + `bq-assess report`) — run the lightweight
+  collector where the BigQuery credentials live; it writes a plain-JSON, checksummed
+  bundle you can review before sharing. Generate the report later, anywhere, fully
+  offline: `bq-assess report --bundle <dir-or-zip>`. Useful when the person running
+  the scan and the person analyzing the results are not the same.
+
+## Documentation
+
+- [CLI Reference](docs/CLI_REFERENCE.md) — all flags, options, and examples
+- [Migration Complexity Guide](docs/MIGRATION_COMPLEXITY_GUIDE.md) — two-axis scoring rules explained
+- [CONTEXT.md](CONTEXT.md) — project vocabulary and target architecture
+- [Architecture Decision Records](docs/adr/) — why Iceberg storage + Redshift engine, two scoring axes, partition mapping, per-entity placement
+
+## Development
+
+```bash
+pip3 install -e ".[dev]"
+pytest                           # 300+ tests (unit + property-based)
+bash tests/plugin/structure.sh   # plugin structural checks
+```
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/solution-architecture/clis/bq-assess/bandit.yml
+++ b/solution-architecture/clis/bq-assess/bandit.yml
@@ -1,0 +1,21 @@
+# Bandit configuration scoped to this plugin only.
+# Loaded explicitly via `bandit -c` so these skips apply only when
+# scanning files under this plugin directory. Python anywhere else in
+# the repo is scanned separately with no skips (same two-pass pattern
+# as migrate/plugins/ai-to-aws).
+#
+# Why each rule is skipped:
+#   B101 - pytest uses the assert statement as its assertion mechanism;
+#          every B101 hit in this plugin is inside tests/ (0 in src/,
+#          verified). Production code raises typed errors, not asserts.
+#   B608 - flags f-string SQL. bq-assess is a client-side, read-only
+#          assessment tool: the only values interpolated are the user's
+#          own GCP project/dataset identifiers, and every query runs
+#          with the user's own credentials against the user's own
+#          project - there is no privilege boundary to cross. The
+#          remaining hits build SQL *text* for the generated migration
+#          report (targets/iceberg/dml.py); that SQL is report output
+#          and is never executed by this tool.
+skips:
+  - B101
+  - B608

--- a/solution-architecture/clis/bq-assess/docs/CLI_REFERENCE.md
+++ b/solution-architecture/clis/bq-assess/docs/CLI_REFERENCE.md
@@ -1,0 +1,76 @@
+# bq-assess CLI Reference
+
+For the guided experience, see the [main README](../README.md).
+
+## Install
+
+```bash
+git clone <repo-url>
+cd bigqueryToRedshift
+pip install -e .
+```
+
+## Usage
+
+```bash
+# Minimal
+bq-assess --gcp-project my-project --use-adc
+
+# With query logs (higher confidence)
+bq-assess --gcp-project my-project --use-adc --include-query-logs
+
+# With exported query logs (no bigquery.jobs.listAll needed)
+bq-assess --gcp-project my-project --use-adc --query-logs path/to/logs.json
+
+# Full options
+bq-assess \
+  --gcp-project my-project \
+  --use-adc \
+  --datasets "prod_data,analytics" \
+  --include-query-logs \
+  --query-log-days 60 \
+  --format json,html,csv \
+  --output reports/
+
+# Interactive mode
+bq-assess --interactive
+
+# From config file
+bq-assess --config assessment-config.yaml
+```
+
+## Options
+
+| Flag                      | Description                                               | Default      |
+| ------------------------- | --------------------------------------------------------- | ------------ |
+| `--gcp-project`           | GCP project ID                                            | required     |
+| `--credentials`           | Path to service account JSON                              | —            |
+| `--use-adc`               | Use Application Default Credentials                       | false        |
+| `--datasets`              | Comma-separated dataset filter                            | all datasets |
+| `--include-query-logs`    | Analyze INFORMATION_SCHEMA.JOBS                           | false        |
+| `--query-logs`            | Path to exported query logs JSON                          | —            |
+| `--query-log-days`        | Query log lookback window in days (1-90)                  | 30           |
+| `--redshift-type`         | Target Redshift node type (overrides auto-recommendation) | auto         |
+| `--bigquery-monthly-cost` | Monthly BigQuery spend override                           | estimated    |
+| `--output`                | Output directory                                          | reports/     |
+| `--format`                | Output formats (json, html, csv)                          | json,html    |
+| `--interactive`           | Interactive prompt mode                                   | false        |
+| `--config`                | Path to YAML config file                                  | —            |
+
+Note: `--query-log-days` implies `--include-query-logs` automatically.
+
+## Output
+
+- `assessment-<id>.json` — full assessment with per-table details
+- `assessment-<id>.html` — visual report for customer walkthroughs
+- `tables-auto.csv` — tables safe for automated migration
+- `tables-review.csv` — tables needing review
+- `tables-manual.csv` — tables requiring manual effort
+
+## Query Logs
+
+Without query logs, the tool uses heuristics for DISTKEY/SORTKEY recommendations (LOW confidence).
+
+With `--include-query-logs`, it analyzes `INFORMATION_SCHEMA.JOBS` for JOIN patterns and hub tables (HIGH confidence). Requires `roles/bigquery.resourceViewer`.
+
+Alternatively, `--query-logs <path>` accepts an exported JSON file — a JSON array of objects with at least a `"query"` field. This bypasses the API entirely.

--- a/solution-architecture/clis/bq-assess/docs/MIGRATION_COMPLEXITY_GUIDE.md
+++ b/solution-architecture/clis/bq-assess/docs/MIGRATION_COMPLEXITY_GUIDE.md
@@ -1,0 +1,343 @@
+# BigQuery → S3 Tables + Redshift Serverless Migration Guide
+
+Understanding the two-axis scoring model: Migration Effort (data movement) and Query Complexity (SQL rewrite).
+
+---
+
+## Overview
+
+This tool uses a two-axis scoring model to capture different migration concerns:
+
+- **Axis 1: Migration Effort** — How hard is it to move data to S3 Tables (Apache Iceberg)?
+- **Axis 2: Query Complexity** — How hard is it to rewrite SQL for Redshift Serverless?
+
+These axes are independent. A table can be AUTO effort (small, clean schema) but REWRITE complexity (queries use JavaScript UDFs). Both scores matter, for different reasons.
+
+---
+
+## Part 1: Migration Effort (Data Movement)
+
+Scores difficulty of moving BigQuery data to S3 Tables (Iceberg). Categories: AUTO (0 points), ASSISTED (1-2 points), MANUAL (3+ points).
+
+### Volume (0, +1, or +2 points)
+
+**What it affects:**
+Time and cost to extract and load data.
+
+**Scoring:**
+
+- 0-1 GB: 0 points (trivial)
+- 1-100 GB: +1 point (manageable, but needs monitoring)
+- 100+ GB: +2 points (multi-hour exports, risk of timeout)
+
+**Example:**
+
+```
+clickstream_events: 2.5 TB → +2 points
+user_profiles: 50 GB → +1 point
+lookup_country_codes: 100 MB → 0 points
+```
+
+### Lossy Type Casts (+2 points each)
+
+**What it is:**
+BigQuery types that don't map cleanly to Iceberg/Redshift.
+
+**Common cases:**
+
+- `NUMERIC(38,9)` → Iceberg `decimal(18,2)` (precision loss)
+- `BIGNUMERIC` → no Iceberg equivalent (must pick a narrower decimal)
+- `GEOGRAPHY` → requires custom serialization (WKT/WKB)
+
+**Example:**
+
+```sql
+-- BigQuery
+CREATE TABLE financial_ledger (
+  transaction_id STRING,
+  amount NUMERIC(38, 9)  -- High precision for micro-transactions
+)
+
+-- Iceberg (lossy)
+CREATE TABLE financial_ledger (
+  transaction_id STRING,
+  amount DECIMAL(18, 2)  -- Lost 7 digits of precision + scale reduced
+)
+-- Score: +2 (requires validation that precision loss is acceptable)
+```
+
+### Ongoing Sync Signals (+1 point)
+
+**What it is:**
+Indicators that the table receives continuous updates (not one-time load).
+
+**Signals:**
+
+- Ingestion-time partitioning (`_PARTITIONTIME`, `_PARTITIONDATE`)
+- `updated_at`, `modified_at`, `last_synced_at` columns
+- Streaming buffer presence (data arriving continuously)
+
+**Why it matters:**
+One-time migration is different from setting up ongoing CDC/replication.
+
+**Example:**
+
+```sql
+-- BigQuery table with ongoing writes
+CREATE TABLE user_events
+PARTITION BY _PARTITIONDATE  -- New partitions added daily
+```
+
+Score: +1 (requires sync strategy, not just export-once)
+
+### Partition/Sort Decision Required (+1 point)
+
+**What it is:**
+BigQuery partitioning or clustering that needs mapping to Iceberg partition transforms.
+
+**Why it's not AUTO:**
+Iceberg supports partitioning (day, month, year, bucket, truncate), but the choice affects query performance. Requires understanding query patterns.
+
+**Example:**
+
+```sql
+-- BigQuery
+CREATE TABLE orders
+PARTITION BY DATE(order_timestamp)
+CLUSTER BY customer_id
+```
+
+**Iceberg options:**
+
+```sql
+-- Option 1: Partition by day (matches BigQuery)
+PARTITIONED BY (day(order_timestamp))
+
+-- Option 2: Partition by month (less granular, fewer files)
+PARTITIONED BY (month(order_timestamp))
+```
+
+Score: +1 (decision required based on query patterns)
+
+### Migration Effort Categories
+
+| Score | Category | Meaning                                                                                  |
+| ----- | -------- | ---------------------------------------------------------------------------------------- |
+| 0     | AUTO     | Small table, clean types, no sync needed. Export and load.                               |
+| 1-2   | ASSISTED | Moderate volume OR ongoing sync OR partition decision. Mostly automated with validation. |
+| 3+    | MANUAL   | Large volume + lossy casts + sync. Requires careful planning and monitoring.             |
+
+---
+
+## Part 2: Query Complexity (SQL Rewrite)
+
+Scores difficulty of adapting BigQuery SQL to Redshift Serverless. Categories: PORTABLE (0 points), ADAPT (1-3 points), REWRITE (4+ points).
+
+### JavaScript UDFs (+4 points)
+
+**What it is:**
+User-defined functions written in JavaScript.
+
+**BigQuery example:**
+
+```sql
+CREATE TEMP FUNCTION parse_user_agent(ua STRING)
+RETURNS STRUCT<browser STRING, os STRING>
+LANGUAGE js AS '''
+  const parsed = uaParser(ua);
+  return {browser: parsed.browser, os: parsed.os};
+''';
+
+SELECT parse_user_agent(user_agent) FROM events;
+```
+
+**Redshift:**
+No JavaScript UDF support. Must rewrite in Python UDF (slower, different runtime) or pre-process data.
+
+**Why +4:**
+High rewrite cost. JS UDFs often contain complex business logic that's hard to port.
+
+### UNNEST / Array Unnesting (+2 points)
+
+**What it is:**
+Flattening arrays into rows.
+
+**BigQuery example:**
+
+```sql
+SELECT order_id, item
+FROM orders, UNNEST(items) AS item
+```
+
+**Redshift:**
+Requires different syntax and performs worse:
+
+```sql
+SELECT order_id, item
+FROM orders o, o.items AS item  -- Partiql syntax, slower on SUPER type
+```
+
+**Why +2:**
+Syntax conversion required + potential performance degradation.
+
+### ARRAY_* Functions (+2 points)
+
+**What it is:**
+BigQuery array manipulation functions.
+
+**Examples:**
+
+```sql
+-- BigQuery
+ARRAY_LENGTH(items)
+ARRAY_AGG(product_id ORDER BY price DESC LIMIT 5)
+ARRAY_CONCAT(tags1, tags2)
+
+-- Redshift equivalents vary:
+JSON_ARRAY_LENGTH(items)  -- Only for SUPER type
+LISTAGG(product_id, ',') WITHIN GROUP (...)  -- Different aggregation
+-- ARRAY_CONCAT: no direct equivalent
+```
+
+**Why +2:**
+Function incompatibilities. Requires lookup + rewrite + testing.
+
+### Struct-Path Navigation (+1 point)
+
+**What it is:**
+Accessing nested fields in STRUCTs.
+
+**BigQuery example:**
+
+```sql
+SELECT user.profile.country, user.profile.tier
+FROM events
+```
+
+**Redshift:**
+Struct access exists but is less optimized:
+
+```sql
+SELECT user.profile.country::STRING, user.profile.tier::STRING
+FROM events
+-- Requires casting, slower than BigQuery's native columnar access
+```
+
+**Why +1:**
+Syntax adjustment + potential performance check.
+
+### Function-Name Drift (+1 point per distinct function)
+
+**What it is:**
+Functions with different names or argument order between BigQuery and Redshift.
+
+**Examples:**
+
+| BigQuery                            | Redshift                         | Issue                                     |
+| ----------------------------------- | -------------------------------- | ----------------------------------------- |
+| `DATE_DIFF(date1, date2, DAY)`      | `DATEDIFF(day, date2, date1)`    | Arguments reversed                        |
+| `TIMESTAMP_ADD(ts, INTERVAL 1 DAY)` | `ts + INTERVAL '1 day'`          | Different syntax                          |
+| `SAFE_CAST(x AS INT64)`             | `TRY_CAST(x AS INTEGER)`         | Different function name                   |
+| `REGEXP_CONTAINS(str, pattern)`     | `REGEXP_INSTR(str, pattern) > 0` | Different function, different return type |
+
+**Why +1 per function:**
+Each requires manual find-and-replace + validation.
+
+### Hub Entity Bonus (+1 point)
+
+**What it is:**
+Tables or views referenced by many other views (central in the dependency graph).
+
+**Why it matters:**
+Changes to hub entities propagate. A rewrite that breaks the hub schema impacts 10+ downstream views.
+
+**Example:**
+
+```
+user_facts → referenced by 15 views
+orders_enriched → referenced by 22 views
+```
+
+Score: +1 (extra caution required, high blast radius)
+
+### Query Complexity Categories
+
+| Score | Category | Meaning                                                                                     |
+| ----- | -------- | ------------------------------------------------------------------------------------------- |
+| 0     | PORTABLE | Standard SQL, minimal BigQuery-specific functions. Runs on Redshift with minor adjustments. |
+| 1-3   | ADAPT    | Function drift, struct access, array functions. Requires targeted rewrites and testing.     |
+| 4+    | REWRITE  | JavaScript UDFs, heavy UNNEST usage, complex array logic. Significant rewrite effort.       |
+
+---
+
+## Part 3: How the Two Axes Combine
+
+The axes address different concerns:
+
+- **Migration Effort** → "How hard is it to get the data into S3 Tables?"
+- **Query Complexity** → "How hard is it to rewrite the queries that use this table?"
+
+### Example Combinations
+
+**1. AUTO Effort + PORTABLE Complexity**
+
+```
+lookup_country_codes: 500 rows, no casts, no partitioning
+No views reference it
+Score: AUTO (0) / PORTABLE (0)
+```
+
+Low-touch migration. Export and load, queries work as-is.
+
+**2. AUTO Effort + REWRITE Complexity**
+
+```
+user_profiles: 10 GB, clean schema
+Referenced by view user_segments that uses JS UDF for geohashing
+Score: AUTO (0) / REWRITE (4)
+```
+
+Data migration is easy, but the view needs a major rewrite (port JS logic).
+
+**3. MANUAL Effort + PORTABLE Complexity**
+
+```
+clickstream_events: 2 TB, NUMERIC(38,9) columns, ingestion-time partitioning
+Queries are simple aggregations (COUNT, SUM)
+Score: MANUAL (5) / PORTABLE (0)
+```
+
+Hard to move (volume + casts + sync), but queries are straightforward.
+
+**4. ASSISTED Effort + ADAPT Complexity**
+
+```
+order_facts: 50 GB, partitioned by date
+Referenced by 5 views using DATE_DIFF and UNNEST
+Score: ASSISTED (2) / ADAPT (3)
+```
+
+Moderate effort both ways. Manageable with planning.
+
+---
+
+## Summary: Two-Axis Decision Matrix
+
+| Migration Effort | Query Complexity | Action                                         |
+| ---------------- | ---------------- | ---------------------------------------------- |
+| AUTO             | PORTABLE         | Low-touch: export, load, deploy                |
+| AUTO             | ADAPT/REWRITE    | Focus on SQL rewrite, data movement is trivial |
+| ASSISTED/MANUAL  | PORTABLE         | Focus on data pipeline, queries are fine       |
+| ASSISTED/MANUAL  | ADAPT/REWRITE    | Plan both: data movement + query rewrite       |
+
+---
+
+## The Core Principle
+
+**BigQuery** optimizes for: Nested, denormalized, schema-flexible analytics with rich SQL functions.
+
+**S3 Tables + Redshift Serverless** optimizes for: Open-format lakehouse storage (Iceberg) + ANSI-SQL compute with strong performance on flat/semi-structured data.
+
+**Migration requires mapping BigQuery's strengths to the lakehouse model's trade-offs.**
+
+The two-axis model makes those trade-offs explicit: you see both the data movement cost and the query rewrite cost, independently scored.

--- a/solution-architecture/clis/bq-assess/docs/adr/0001-iceberg-storage-redshift-as-engine.md
+++ b/solution-architecture/clis/bq-assess/docs/adr/0001-iceberg-storage-redshift-as-engine.md
@@ -1,0 +1,18 @@
+# Storage target is S3 Tables (Iceberg); Redshift is the query engine
+
+We pivoted the migration target from **Redshift-as-storage** (native tables sized by
+node count, with DISTKEY/SORTKEY) to a **decoupled lakehouse**: migrated data lives in
+**Amazon S3 Tables (managed Apache Iceberg)**, and **Amazon Redshift Serverless** is the
+query/compute engine over it. We chose this because storage and compute now decouple
+cleanly — Iceberg stores nested types natively (so STRUCT/ARRAY are no longer a migration
+obstacle), Redshift can run `UPDATE/DELETE/MERGE` directly on Iceberg (AWS, Apr 2026), and
+Serverless meters compute (RPU-hours) independently of stored volume. **Scope: Serverless
+only** — provisioned Redshift and its serverless-vs-provisioned advisor are out.
+
+## Consequences
+
+- Node-sizing-by-storage, DISTKEY/SORTKEY DDL, and the deployment advisor are retired.
+- Cost becomes a sum of independent lines (S3 storage + Serverless RPU) rather than node count.
+- "Migration complexity" can no longer be one number — see ADR-0002.
+- The old Redshift-native-storage path is dropped, not kept as a parallel target. Re-adding
+  it later would mean reintroducing a storage-coupled cost/DDL model.

--- a/solution-architecture/clis/bq-assess/docs/adr/0002-two-scoring-axes.md
+++ b/solution-architecture/clis/bq-assess/docs/adr/0002-two-scoring-axes.md
@@ -1,0 +1,20 @@
+# Two independent scoring axes, not one complexity score
+
+The assessment scores every entity on **two orthogonal axes** — **Migration Effort** (how
+hard to _move_ data into Iceberg) and **Query Complexity** (how hard to keep the existing
+query workload _running_ on Redshift over Iceberg) — instead of the original single
+AUTO/REVIEW/MANUAL score. We did this because the Iceberg pivot (ADR-0001) decoupled the
+two concerns: a flat table fed by an `UNNEST`-heavy view is now _trivial to move_ but
+_hard to keep queryable_. Collapsing those into one number hides exactly the signal a
+migration team needs. The axes use distinct label vocabularies (Effort: AUTO/ASSISTED/
+MANUAL; Query: PORTABLE/ADAPT/REWRITE) so "AUTO" can't be mistaken for "PORTABLE".
+
+## Consequences
+
+- The JSON and HTML are split into two interfaces; a table appears on both, a view/UDF
+  only on Query Complexity (see ADR-0004).
+- Query Complexity depends on capturing view/UDF SQL — a new scanner responsibility.
+- The old single-score scorer and its 24-property spec content are rewritten (the
+  property-based _form_ is kept).
+- Nesting (STRUCT depth, array-of-struct), formerly the two largest score drivers, drops
+  to ~0 on Effort and moves to Query Complexity as a query-ergonomics hint.

--- a/solution-architecture/clis/bq-assess/docs/adr/0003-partition-mapping-policy.md
+++ b/solution-architecture/clis/bq-assess/docs/adr/0003-partition-mapping-policy.md
@@ -1,0 +1,22 @@
+# Partition/sort mapping: clean mappings are annotations, non-clean are scored effort
+
+When mapping BigQuery partitioning/clustering to Iceberg partition transforms and sort
+order (S3 Tables `CreateTable` accepts both at create time), we treat **clean 1:1 mappings
+as zero-effort annotations the tool derives automatically**, and **non-clean mappings as
+scored Migration Effort with a "review this transform" flag**. Clean = explicit-field time
+partitioning (DAY/HOUR/MONTH/YEAR → `day/hour/month/year(col)`) and multi-column sort
+order. Non-clean = **ingestion-time** partitioning (`_PARTITIONTIME`, no real column),
+**range** partitioning (no Iceberg range transform — `bucket`/`truncate` aren't
+equivalent), and ambiguous multi-column clustering intent.
+
+We did this because a blanket "partitioning is free on Iceberg" would silently mis-handle
+the cases where the tool genuinely _cannot_ derive the right layout and a human must decide
+— and a blanket "partitioning is always effort" would penalize the common clean case.
+
+## Consequences
+
+- The scanner must capture `range_partitioning` (today it reads only `time_partitioning`,
+  so range-partitioned tables currently look unpartitioned — a latent bug).
+- Effort scoring distinguishes partition _kinds_, not just presence/absence.
+- The slot↔transform mapping table and the exact non-clean set should be verified against
+  live S3 Tables transform support at implementation.

--- a/solution-architecture/clis/bq-assess/docs/adr/0004-per-entity-placement-no-default.md
+++ b/solution-architecture/clis/bq-assess/docs/adr/0004-per-entity-placement-no-default.md
@@ -1,0 +1,24 @@
+# Views/MVs/UDFs are first-class entities; placement is recommended per-entity
+
+Views, materialized views, and UDFs are assessed as a **distinct entity type** from tables
+— scored only on Query Complexity (they are SQL behavior, rebuilt in the engine layer, not
+data that moves), with zero Migration Effort. **UDFs always land in Redshift** (Iceberg has
+no function concept; BigQuery JavaScript UDFs have no Redshift equivalent and are the
+hardest rewrite). For **views/MVs, the tool recommends a home per entity** — Redshift-local
+vs Iceberg-catalog object — from signals like multi-engine consumption and refresh needs,
+rather than applying a blanket default.
+
+We chose per-entity recommendation because a view consumed only by a Redshift dashboard and
+one consumed by Athena+Spark+Redshift genuinely want different homes; a blanket default
+would be wrong for half of them. We rejected keeping everything table-keyed because it
+causes attribution collisions (which of a 5-table view's tables "owns" its complexity?) and
+produces nonsensical `CREATE TABLE` DDL for views.
+
+## Consequences
+
+- The JSON schema carries an `entity_type`; the two interfaces list different populations
+  (Effort = tables; Query Complexity = tables + views + MVs + UDFs).
+- The scanner must read `table_type`, `view_query`, `mview_query`, and routines — today it
+  treats views as tables and would emit rows=0 `CREATE TABLE` DDL for them.
+- Iceberg materialized-view _refresh_ mechanics are unverified and must be confirmed before
+  appearing in migration instructions.

--- a/solution-architecture/clis/bq-assess/packaging/collector/README.md
+++ b/solution-architecture/clis/bq-assess/packaging/collector/README.md
@@ -1,0 +1,52 @@
+# bq-collect (beta)
+
+Read-only BigQuery metadata collector. Runs in your GCP environment and produces an
+auditable **bundle** — a directory of plain JSON files — that an AWS migration
+specialist turns into a full lakehouse-migration assessment report on your behalf.
+
+## What it does
+
+- Scans BigQuery **metadata only** (schemas, partitioning, view/routine definitions,
+  table sizes from `INFORMATION_SCHEMA`). It never reads table data contents.
+- Aggregates workload statistics (slot utilization, query counts) from
+  `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
+- Collects **anonymized** query statements (all string and numeric literals are
+  stripped and replaced with `?` before anything is written to disk). Disable
+  entirely with `--exclude-query-text`.
+- Snapshots public AWS/GCP pricing rates so the assessment is priced for your region.
+
+## Usage
+
+```bash
+pip install bq-collect
+
+# With Application Default Credentials:
+bq-collect --gcp-project my-project --use-adc --output bundle-out/
+
+# Or with a service-account key:
+bq-collect --gcp-project my-project --credentials sa.json --output bundle-out/
+
+# Privacy opt-out (no query text at all, only aggregated statistics):
+bq-collect --gcp-project my-project --use-adc --exclude-query-text
+```
+
+Then review the JSON files in `bundle-out/bundle/` — everything is plain text — zip
+the directory, and send it to your AWS contact:
+
+```bash
+zip -r bundle.zip bundle-out/bundle/
+```
+
+## Required permissions
+
+- `roles/bigquery.metadataViewer` (or equivalent) on the project — metadata scan.
+- `bigquery.jobs.listAll` — workload statistics and query statements (optional;
+  collection degrades gracefully without it).
+
+## Disclaimer
+
+This tool is in **beta**. It performs read-only operations. All downstream cost
+figures are directional estimates, not a quote, offer, or commitment from Amazon Web
+Services or Google. The software is provided "AS IS" per the Apache License 2.0. You
+are responsible for reviewing bundle contents before transmitting them outside your
+environment.

--- a/solution-architecture/clis/bq-assess/packaging/collector/pyproject.toml
+++ b/solution-architecture/clis/bq-assess/packaging/collector/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bq-collect"
+version = "0.3.1"
+description = "Read-only BigQuery metadata collector (beta): runs in the customer environment and produces an auditable bundle for offline lakehouse-migration assessment. No report generation, scoring, or conversion code included."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+]
+# Deliberately minimal: no jinja2 (report rendering) and no sqlglot (SQL translation).
+# The import-isolation CI check installs this wheel in a clean venv and runs bq-collect
+# --help to prove no excluded dependency leaks in.
+dependencies = [
+    "click>=8.1",
+    "rich>=13.0",
+    "pyyaml>=6.0",
+    "google-cloud-bigquery>=3.11",
+]
+
+[project.scripts]
+bq-collect = "bq_assess.collect_cli:main"
+
+[tool.setuptools]
+# Built from the repo root's src/ tree (pip install ./packaging/collector uses
+# package-dir below). Only the collection-side modules ship; report/, scoring/,
+# targets/, and engine/ are excluded by NOT being listed.
+package-dir = {"" = "../../src"}
+packages = [
+    "bq_assess",
+    "bq_assess.bundle",
+    "bq_assess.core",
+]
+
+[tool.setuptools.package-data]
+bq_assess = ["py.typed"]

--- a/solution-architecture/clis/bq-assess/pyproject.toml
+++ b/solution-architecture/clis/bq-assess/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bq-assess"
+version = "0.3.1"
+description = "Read-only BigQuery migration assessment CLI: profiles a Source and assesses migrating it to an AWS lakehouse (S3 Tables / Apache Iceberg storage, Amazon Redshift Serverless query engine)."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+]
+dependencies = [
+    "click>=8.1",
+    "rich>=13.0",
+    "jinja2>=3.1",
+    "pyyaml>=6.0",
+    "google-cloud-bigquery>=3.11",
+    "sqlglot>=25.0",
+]
+
+[project.scripts]
+bq-assess = "bq_assess.cli:main"
+bq-collect = "bq_assess.collect_cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "hypothesis>=6.82",
+    "pytest-cov>=4.1",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+# The HTML report templates ship as data files — without this the wheel renders
+# JSON fine but dies on TemplateNotFound (dev editable installs mask it).
+"bq_assess.report" = ["templates/*.j2"]
+bq_assess = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/SKILL.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: bq-assess
+description: "Assess BigQuery warehouses for migration to AWS.
+  Triggers on: assess BigQuery migration, BigQuery to Redshift,
+  BigQuery to AWS lakehouse, estimate migration complexity from BigQuery,
+  analyze BigQuery warehouse for migration, migrate BQ to Redshift.
+  Runs a 3-phase process: preflight environment check, scan via
+  the bq-assess CLI, interpret the JSON assessment report and point
+  the user to the generated HTML report.
+  Do not use for: general BigQuery query tuning, Redshift administration,
+  AWS-to-GCP reverse migrations, non-GCP warehouse assessments, Phase 2
+  migration execution (data load DML or Iceberg DDL deployment)."
+---
+
+# bq-assess Skill
+
+## Philosophy
+
+- **Read-only.** No AWS commitment required. The assessment scans metadata and query logs; it does not provision resources or modify the BigQuery project.
+- **Directional cost numbers.** Savings estimates are conversation starters, not authoritative quotes. Always present them as approximate.
+- **Query logs are optional.** When logs are unavailable, confidence drops to LOW. Surface this explicitly — never hide the gap.
+- **Defer architectural redesign.** Schema changes, Iceberg partition/sort-order decisions, and migration execution belong to the user and the AWS account team, not this skill.
+
+## Definitions
+
+- **"Load"** = read the file with the Read tool and follow its instructions.
+- **`$REPORTS_DIR`** = output directory for CLI run (default `reports/`).
+
+## Prerequisites
+
+Before running, the user must have:
+
+- `bq-assess` on PATH (or be willing to install it)
+- `gcloud` on PATH with ADC configured (`gcloud auth application-default login`)
+
+## State Machine
+
+After every phase completion, consult this table to determine the next action. Each row maps to loading exactly one phase file.
+
+| Current state | Condition to leave                              | Next state     | Phase file to load                                       |
+| ------------- | ----------------------------------------------- | -------------- | -------------------------------------------------------- |
+| `preflight`   | Env checks pass AND `gcp_project` collected     | `scan`         | Load `references/phases/scan.md`                         |
+| `scan`        | CLI exits 0 AND landing JSON report exists      | `interpret`    | Load `references/phases/interpret.md`                    |
+| `scan`        | CLI exits non-zero                              | stay in `scan` | Follow Error Routing below                               |
+| `interpret`   | Summary presented AND HTML report path surfaced | terminal       | Skill complete                                           |
+| **any**       | **User says "stop" or "cancel"**                | **terminal**   | **Exit immediately. Do not run the CLI or write files.** |
+
+**Entry points:**
+
+- **Any trigger phrase** → load `references/phases/preflight.md` to begin the `preflight` phase.
+
+**Phase order is monotonic:** phases advance strictly forward (preflight → scan → interpret). The only backward edge is error routing from `scan` back to `preflight` for credential failures. Cancellation exits from any phase.
+
+## Error Routing
+
+When the CLI exits non-zero during the `scan` phase, match stderr against these patterns in order. On the first match, take the listed action.
+
+| Condition                         | Detection                                              | Skill action                                                                                                                                                                                                                               |
+| --------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Missing `bigquery.jobs.listAll`   | `AnalyzerError` substring `"bigquery.jobs.listAll"`    | Present three options: (1) grant IAM permission — show pre-formatted `gcloud` command from `references/iam-roles.md`, (2) re-run without query logs (omit `--include-query-logs`), (3) export logs manually and pass `--query-logs <path>` |
+| Missing `bigquery.metadataViewer` | `ScannerError` from `validate_credentials()`           | Route back to `preflight` auth step. Load `references/phases/preflight.md` and resume at authentication verification.                                                                                                                      |
+| ADC expired                       | `google.auth.exceptions.RefreshError` in stderr        | Route back to `preflight`. Show: `gcloud auth application-default login`                                                                                                                                                                   |
+| No tables found                   | CLI exits with `"No tables found. Nothing to assess."` | Prompt user to check the `--datasets` filter or verify the project ID is correct.                                                                                                                                                          |
+| Unknown fatal                     | Non-zero exit, no pattern match above                  | Show stderr verbatim. Offer two choices: retry or cancel.                                                                                                                                                                                  |

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/iam-roles.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/iam-roles.md
@@ -1,0 +1,70 @@
+# IAM Roles for bq-assess
+
+This document lists the minimum GCP IAM roles required for each assessment mode and the exact commands to grant them.
+
+## Finding Your User Email
+
+To find the email associated with your active `gcloud` account:
+
+```bash
+gcloud auth list
+```
+
+Use the email shown as the `ACTIVE ACCOUNT` in the commands below.
+
+---
+
+## Metadata-Only Assessment (no query logs)
+
+Use this mode when you want a quick structural assessment without analyzing query patterns.
+
+### Required Role
+
+| Role                            | Purpose                                                               |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `roles/bigquery.metadataViewer` | Read table schemas, row counts, partitioning, and clustering metadata |
+
+### Grant Command
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="user:USER_EMAIL" \
+  --role="roles/bigquery.metadataViewer"
+```
+
+Replace `PROJECT_ID` with the customer's GCP project ID and `USER_EMAIL` with the email from `gcloud auth list`.
+
+---
+
+## With Query Log Analysis
+
+Use this mode for higher-confidence scoring. Query logs enable detection of join patterns, hub tables, and query frequency — which feed into the `many_join_partners` and `hub_table` complexity flags.
+
+### Required Roles
+
+| Role                            | Purpose                                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `roles/bigquery.metadataViewer` | Read table schemas, row counts, partitioning, and clustering metadata                                   |
+| `roles/bigquery.resourceViewer` | Read query job history from `INFORMATION_SCHEMA.JOBS` (includes the `bigquery.jobs.listAll` permission) |
+
+### Grant Commands
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="user:USER_EMAIL" \
+  --role="roles/bigquery.metadataViewer"
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="user:USER_EMAIL" \
+  --role="roles/bigquery.resourceViewer"
+```
+
+Replace `PROJECT_ID` with the customer's GCP project ID and `USER_EMAIL` with the email from `gcloud auth list`.
+
+---
+
+## Notes
+
+- The `bigquery.resourceViewer` role includes the `bigquery.jobs.listAll` permission, which is specifically needed to read `INFORMATION_SCHEMA.JOBS` across all users in the project.
+- If the `bigquery.jobs.listAll` permission is missing during a scan with query logs enabled, the CLI will return a permission error. The Scan phase presents three options: grant the role, re-run without query logs, or export logs manually.
+- These are the **minimum** roles. Broader roles like `roles/bigquery.dataViewer` or `roles/bigquery.admin` also work but grant more access than necessary.

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/interpret.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/interpret.md
@@ -1,0 +1,167 @@
+# Interpret Phase
+
+## Entry Assertions
+
+The Scan (or Demo) phase has completed successfully. All of the following are true:
+
+- `landing_json` is set and points to a valid, non-empty `assessment-landing-*.json` file (holds `summary` + `cost`).
+- `effort_json` (`assessment-effort-*.json`) and `query_json` (`assessment-query-*.json`) are set if present — they hold per-entity `entities[]`.
+- The JSON files were produced by the `bq-assess` CLI during the Scan phase.
+- If the user says "stop" or "cancel" at any point during this phase, exit the skill immediately without producing further output.
+
+## Step 1: Read the JSON Reports
+
+The report is split across **three mirrored files** — read each with the Read tool:
+
+- **`landing_json`** → parse `summary` and `cost`. Required. If it cannot be read or is not valid JSON, tell the user: "The assessment summary could not be read. The file may be corrupted or incomplete." Offer to re-run the Scan phase.
+- **`effort_json`** → parse `entities[]` (each carries `effort`, `conversion`, `load_sync_dml`). Tables only.
+- **`query_json`** → parse `entities[]` (each carries `complexity`, `rewrite_guidance`). All entities with SQL surface.
+
+To build a per-entity view, **merge effort and query entities by `full_name`** — an entity's Migration Effort comes from `effort_json`, its Query Complexity from `query_json`. If `effort_json` or `query_json` is missing, present the headline (Step 3) from `landing_json` and note that per-entity detail for the missing axis is unavailable.
+
+## Step 2: Extract Key Metrics
+
+Extract the following fields from **`landing_json`** (`summary.*` and `cost.*`). Use **exactly** these paths — do not guess or infer values from other fields:
+
+| Metric                 | JSON path                            | Description                         |
+| ---------------------- | ------------------------------------ | ----------------------------------- |
+| Total entities         | `summary.total_entities`             | Number of BigQuery entities scanned |
+| Total tables           | `summary.total_tables`               | Tables (vs views/routines)          |
+| Total data size        | `summary.total_size_gb`              | Combined size in GB                 |
+| Effort: AUTO           | `summary.effort_counts.AUTO`         | Tables migrated automatically       |
+| Effort: ASSISTED       | `summary.effort_counts.ASSISTED`     | Tables needing sign-off             |
+| Effort: MANUAL         | `summary.effort_counts.MANUAL`       | Tables needing manual design        |
+| Complexity: PORTABLE   | `summary.complexity_counts.PORTABLE` | Queries running as-is               |
+| Complexity: ADAPT      | `summary.complexity_counts.ADAPT`    | Queries needing minor adaptation    |
+| Complexity: REWRITE    | `summary.complexity_counts.REWRITE`  | Queries needing full rewrite        |
+| SQL surface confidence | `summary.sql_surface_confidence`     | HIGH/MEDIUM/LOW                     |
+| BQ monthly cost        | `cost.bigquery_monthly`              | Current BigQuery run-rate           |
+| AWS monthly (low)      | `cost.aws_monthly_low`               | Estimated AWS cost (low end)        |
+| AWS monthly (high)     | `cost.aws_monthly_high`              | Estimated AWS cost (high end)       |
+| Monthly savings (low)  | `cost.monthly_delta_low`             | Savings delta (low end)             |
+| Monthly savings (high) | `cost.monthly_delta_high`            | Savings delta (high end)            |
+| Annual savings (low)   | `cost.annual_savings_low`            | Annual projection (low)             |
+| Annual savings (high)  | `cost.annual_savings_high`           | Annual projection (high)            |
+| Breakeven (low)        | `cost.breakeven_months_low`          | Months to recoup (low)              |
+| Breakeven (high)       | `cost.breakeven_months_high`         | Months to recoup (high)             |
+| Compute confidence     | `cost.compute_confidence`            | HIGH/MEDIUM/LOW                     |
+
+If any field is missing from the JSON, note it as "not available in this report" when presenting the summary. Do **NOT** estimate or fill in missing values.
+
+## Step 3: Present Summary
+
+Present a plain-English summary to the user covering the extracted metrics. Structure it as follows:
+
+1. **Scope:** "Assessed {total_entities} entities ({total_tables} tables) totaling {total_size_gb} GB in project {project_id}."
+2. **Migration Effort:** "{AUTO} tables auto-migrate, {ASSISTED} need sign-off, {MANUAL} need manual design."
+3. **Query Complexity:** "{PORTABLE} portable, {ADAPT} need adaptation, {REWRITE} need full rewrite."
+4. **Cost:** "Monthly savings: ${monthly_delta_low}–${monthly_delta_high}. Annual: ${annual_savings_low}–${annual_savings_high}." Add the caveat: "These are directional estimates based on current usage patterns, not a pricing commitment."
+5. **Confidence:** "SQL surface: {sql_surface_confidence}. Compute: {compute_confidence}."
+
+Every number and label in this summary **must** come directly from the JSON fields extracted in Step 2.
+
+## Step 4: High-Effort Entities
+
+Identify the entities that require the most migration effort:
+
+1. Build the merged entity set by joining `effort_json.entities[]` and `query_json.entities[]` on `full_name` (effort fields from the effort file, complexity fields from the query file).
+2. Filter to entries where `effort.category` equals `"MANUAL"` OR `complexity.category` equals `"REWRITE"`.
+3. Sort by `effort.score + complexity.score` (combined) in **descending** order.
+4. Take the **top 5** results (or fewer if less than 5 exist).
+
+For each entity, present:
+
+- **Entity name** — from `full_name`
+- **Entity type** — from `entity_type` (TABLE, VIEW, MATERIALIZED_VIEW, ROUTINE)
+- **Effort** — `effort.category` (score: `effort.score`) with flags from `effort.flags[]`
+- **Complexity** — `complexity.category` (score: `complexity.score`) with flags from `complexity.flags[]`
+
+Plain-language explanations for common flags:
+
+- `JS_UDF` — "Uses JavaScript UDF that has no Redshift equivalent — requires full rewrite"
+- `UNNEST` — "Uses UNNEST/array unnesting that needs Redshift SUPER type handling"
+- `ARRAY_FUNCTIONS` — "Uses ARRAY_* functions that differ between BigQuery and Redshift"
+- `STRUCT_NAVIGATION` — "Uses struct-path navigation (dot notation) that maps to SUPER extraction"
+- `FUNCTION_DRIFT` — "Uses function names that exist in both dialects but behave differently"
+- `partition_decision_required` — "Partition scheme needs human design for Iceberg"
+- `sort_decision_required` — "Sort order needs human design for Iceberg"
+- `lossy_cast` — "Type mapping loses precision (e.g., NUMERIC → DECIMAL)"
+
+If the user asks follow-up questions about scoring, load `references/scoring-rules.md` for the full factor-to-point-value mapping.
+
+If no entities match, say: "No entities scored as MANUAL effort or REWRITE complexity — all entities are low-effort and portable."
+
+## Step 5: Top Tables by Size
+
+Identify the largest tables regardless of effort/complexity:
+
+1. Sort `effort_json.entities[]` (tables) by size (use `size_gb`, or `num_bytes` if present) in **descending** order.
+2. Take the **top 3** results.
+
+For each table, present:
+
+- **Table name** — from `full_name`
+- **Size** — formatted in GB
+- **Effort category** — from `effort.category`
+- **Complexity category** — from `complexity.category`
+
+Add context: "These are the largest tables by data volume. They drive customer attention during migration planning because data transfer time and storage costs scale with size."
+
+## Step 6: LOW Confidence Callout
+
+Check the `summary.sql_surface_confidence` and `cost.compute_confidence` fields.
+
+**If `sql_surface_confidence` is `LOW`:**
+
+> ⚠️ **LOW SQL Confidence:** This assessment ran **without query logs or view definitions**. Complexity scoring is based on metadata heuristics only.
+>
+> For higher-confidence complexity scoring, re-run with query logs:
+>
+> ```
+> bq-assess --gcp-project {project_id} --use-adc --format json,html --output reports/
+> ```
+
+**If `compute_confidence` is `LOW`:**
+
+> ⚠️ **LOW Compute Confidence:** The cost comparison uses default assumptions for compute sizing. Provide a `--reservation-config` file with actual slot usage for higher-confidence estimates.
+
+## Step 7: HTML Report Path
+
+The HTML report is generated alongside the JSON report in the same output directory. The output includes multiple HTML files (landing page, effort detail, query detail).
+
+Derive the HTML directory from `landing_json` by looking at the same output directory.
+
+Tell the user:
+
+> "The full HTML report is available in the same output directory. Open the landing page in a browser to see the visual effort/complexity breakdown, per-entity details, and cost comparison."
+
+---
+
+> **🔒 GROUNDING RULE — Do Not Fabricate**
+>
+> Every number, entity name, flag, cost estimate, and confidence level in this summary **MUST** come directly from the JSON assessment reports (`landing_json` / `effort_json` / `query_json`). Do **NOT**:
+>
+> - Fabricate or invent entity names, scores, or flags
+> - Estimate values that are not present in the report
+> - Infer recommendations beyond what the JSON contains
+> - Round or adjust numbers unless explicitly formatting for display
+>
+> If a field is missing from the JSON, say **"not available in this report"** rather than guessing. The user is presenting these numbers to a customer — accuracy is non-negotiable.
+
+---
+
+## Cancellation
+
+If the user says "stop" or "cancel" at any point during this phase — while reading the report, during the summary, or after presenting findings — exit the skill immediately. Do not produce further output.
+
+## Exit Conditions
+
+The Interpret phase is complete when:
+
+1. The plain-English summary has been presented (Step 3).
+2. High-effort entities have been shown, or noted as absent (Step 4).
+3. Top tables by size have been shown (Step 5).
+4. The LOW confidence callout has been shown if applicable (Step 6).
+5. The HTML report path has been provided (Step 7).
+
+This is the **terminal phase**. The skill is complete after the summary has been presented. No further phases follow.

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/preflight.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/preflight.md
@@ -1,0 +1,117 @@
+# Preflight Phase
+
+## Entry Assertions
+
+This is the first phase of the bq-assess skill. No prior state is required.
+
+- Triggered when the user prompt matches a trigger phrase in SKILL.md (e.g., "assess BigQuery migration").
+- No files, credentials, or prior CLI runs are assumed.
+- If the user says "stop" or "cancel" at any point during this phase, exit the skill immediately without running any commands or writing any files.
+
+## Step 1: Run Preflight Script
+
+Execute the environment check script from the skill's `scripts/` directory:
+
+```bash
+bash scripts/preflight.sh
+```
+
+Parse the JSON output. The script returns:
+
+```json
+{
+  "bq_assess_installed": true | false,
+  "gcloud_installed": true | false,
+  "adc_present": true | false,
+  "adc_path": "/path/to/application_default_credentials.json"
+}
+```
+
+If the script exits non-zero, do **NOT** advance to the Scan phase. Report the error to the user and offer to retry.
+
+## Step 2: Handle Missing Tools
+
+### If `bq_assess_installed` is `false`
+
+Tell the user that the `bq-assess` CLI is not found on PATH. Provide the exact install commands:
+
+```bash
+pip3 install "git+https://github.com/awslabs/startups.git#subdirectory=solution-architecture/clis/bq-assess"
+```
+
+Then ask: **"Would you like me to run these commands, or will you handle the installation manually?"**
+
+- If the user asks you to run them, execute the commands.
+- If the user prefers to handle it manually, wait for them to confirm the install is complete.
+- After installation, re-run `bash scripts/preflight.sh` to verify `bq_assess_installed` is now `true`.
+
+### If `gcloud_installed` is `false`
+
+Tell the user that the `gcloud` CLI is required for GCP authentication. Direct them to install it:
+
+- Installation guide: https://cloud.google.com/sdk/docs/install
+
+Wait for the user to confirm `gcloud` is installed, then re-run `bash scripts/preflight.sh` to verify.
+
+## Step 3: Handle Missing ADC
+
+### If `adc_present` is `false`
+
+Tell the user that Application Default Credentials are not configured. Provide the exact command:
+
+```bash
+gcloud auth application-default login
+```
+
+Ask the user to run this command and confirm when authentication is complete. Do **NOT** run this command automatically — it requires interactive browser-based login.
+
+After the user confirms, re-run `bash scripts/preflight.sh` to verify `adc_present` is now `true`.
+
+## Step 4: Collect Inputs
+
+Once all preflight checks pass (`bq_assess_installed`, `gcloud_installed`, and `adc_present` are all `true`), collect the following inputs from the user:
+
+### Required
+
+- **`gcp_project`** — Ask: "What is the GCP project ID for this assessment?"
+  - This is required. Do not proceed without it.
+
+### Optional
+
+- **`datasets`** — Ask: "Any specific datasets to scope? Leave blank for all."
+  - Accepts a comma-separated list of dataset names.
+  - If left blank, the CLI scans all datasets in the project.
+
+- **`include_query_logs`** — Ask: "Include query log analysis for higher confidence? (yes/no)"
+  - Default: **yes**
+  - If the user declines, note that the assessment will run with LOW confidence (heuristic-only scoring).
+
+- **`query_log_days`** — Only ask if `include_query_logs` is yes.
+  - Ask: "How many days of query logs to analyze? (default: 30, range: 1–90)"
+  - Default: **30**
+  - Accepted range: 1 to 90. If the user provides a value outside this range, ask them to correct it.
+
+## Exit Conditions
+
+All of the following must be true before advancing to the Scan phase:
+
+1. `bq_assess_installed` is `true`
+2. `gcloud_installed` is `true`
+3. `adc_present` is `true`
+4. `gcp_project` is non-empty
+
+If any condition is not met, do **NOT** advance. Loop back to the relevant step above and resolve the issue.
+
+When all conditions are satisfied, pass the collected parameters to the Scan phase:
+
+- `gcp_project`
+- `datasets` (if provided)
+- `include_query_logs`
+- `query_log_days` (if applicable)
+
+## Critical Constraints
+
+- Do **NOT** execute `bq-assess` during this phase. The CLI runs only in the Scan phase.
+- Do **NOT** install packages without explicit SA confirmation.
+- Do **NOT** write files outside the current working directory.
+- If the preflight script exits non-zero, do **NOT** advance to the Scan phase.

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/scan.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/phases/scan.md
@@ -1,0 +1,183 @@
+# Scan Phase
+
+## Entry Assertions
+
+The Preflight phase has completed successfully. All of the following are true:
+
+- `gcp_project` is set and non-empty.
+- GCP authentication is confirmed (`adc_present` was `true` in preflight).
+- `bq-assess` CLI is installed and on PATH.
+- Optional parameters may also be present: `datasets`, `include_query_logs`, `query_log_days`.
+- If the user says "stop" or "cancel" at any point during this phase, exit the skill immediately without running any further commands.
+
+## Step 1: Construct CLI Command
+
+Build the `bq-assess` command from the parameters collected during Preflight.
+
+**Base command:**
+
+```
+bq-assess --gcp-project {gcp_project} --use-adc --format json,html --output reports/
+```
+
+**Append optional flags based on Preflight output:**
+
+- If `datasets` was provided:
+
+  ```
+  --datasets {datasets}
+  ```
+
+- If `include_query_logs` is `false`: do NOT append any query-log flag. The CLI defaults to not analyzing query logs when `--include-query-logs` is absent. (The CLI does NOT have a `--no-query-logs` flag — do not invent one.)
+
+- If `include_query_logs` is `true`:
+
+  ```
+  --include-query-logs
+  ```
+
+- If `include_query_logs` is `true` AND `query_log_days` was provided:
+
+  ```
+  --query-log-days {query_log_days}
+  ```
+
+**Example — full command with all options:**
+
+```bash
+bq-assess --gcp-project my-project --use-adc --format json,html --output reports/ --datasets prod_data,analytics --include-query-logs --query-log-days 60
+```
+
+**Example — minimal command (no query logs, no dataset filter):**
+
+```bash
+bq-assess --gcp-project my-project --use-adc --format json,html --output reports/
+```
+
+Show the constructed command to the user before executing so they can confirm or adjust.
+
+## Step 2: Execute CLI
+
+Run the constructed command using the Bash tool.
+
+**Critical: Display the CLI's Rich progress output directly to the user.** The CLI uses Rich to render stage-by-stage progress (scanning metadata, analyzing query logs, scoring complexity, generating reports). Do **NOT** suppress, parse, or reformat these progress messages. Let them stream through as-is so the user can follow along and explain progress if a customer is watching.
+
+## Step 3: Handle Results
+
+After the CLI exits, inspect the exit code and output to determine the next action.
+
+---
+
+### Success (exit code 0)
+
+The CLI has completed successfully and written reports to the output directory. The run produces **three mirrored JSON files** (not one) — capture all three:
+
+1. Locate the three report files in the output directory:
+   - `landing_json` — matches `reports/assessment-landing-*.json` (holds `summary` + `cost`)
+   - `effort_json` — matches `reports/assessment-effort-*.json` (holds Migration Effort `entities[]` + Iceberg DDL)
+   - `query_json` — matches `reports/assessment-query-*.json` (holds Query Complexity `entities[]`)
+2. Verify each file exists and is non-empty. If `landing_json` is missing or empty, treat this as a generic fatal error (see below). If only `effort_json`/`query_json` is missing, note it and continue with what is present.
+3. Tell the user the assessment completed successfully and show the output directory path.
+4. Advance to the **Interpret phase**, passing `landing_json`, `effort_json`, and `query_json`.
+
+---
+
+### Permission Denied — Missing `bigquery.jobs.listAll`
+
+**Detection:** stderr contains `AnalyzerError` AND the string `bigquery.jobs.listAll`.
+
+This means the authenticated account lacks the IAM permission needed to read query logs from `INFORMATION_SCHEMA.JOBS`.
+
+Present the user with **three options:**
+
+#### Option 1: Grant the IAM permission and retry
+
+Show the user the exact command to grant the required role:
+
+```bash
+gcloud projects add-iam-policy-binding {gcp_project} \
+  --member="user:{sa_email}" \
+  --role="roles/bigquery.resourceViewer"
+```
+
+> Replace `{sa_email}` with the user's GCP identity. They can find it with `gcloud auth list`.
+
+Ask the user to run this command, then **retry the same `bq-assess` command** from Step 2.
+
+#### Option 2: Re-run without query logs
+
+Re-run the CLI without the `--include-query-logs` flag (simply omit it from the original command). This skips query log analysis entirely — the CLI defaults to metadata-only when the flag is absent.
+
+Warn the user: "The assessment will still run, but the **cost comparison drops to a LOW-confidence range** (no observed slot usage), and Query Complexity confidence is lower without query history. Iceberg partition/sort-order and placement hints will be heuristic-only."
+
+#### Option 3: Export logs manually and pass them to the CLI
+
+The user can export query logs to a JSON file themselves and provide the path. Steps:
+
+1. The user exports query logs from BigQuery (e.g., via `bq query` or the BigQuery console) to a local JSON file.
+2. Re-run the CLI with `--query-logs {path_to_exported_logs}` instead of relying on the API.
+
+Ask: **"Which option would you like? (1) Grant the permission, (2) Re-run without query logs, or (3) Export logs manually?"**
+
+---
+
+### Credential Error
+
+**Detection:** stderr contains `ScannerError` from `validate_credentials()` **OR** stderr contains `google.auth.exceptions.RefreshError`.
+
+The GCP credentials are invalid, expired, or not properly configured.
+
+Tell the user: "Your GCP credentials appear to be invalid or expired. Let's go back to the authentication step."
+
+Route back to the **Preflight phase** — specifically, load `references/phases/preflight.md` and resume at **Step 3: Handle Missing ADC**. The user will need to re-run:
+
+```bash
+gcloud auth application-default login
+```
+
+After re-authentication, return to this Scan phase and retry the CLI command.
+
+---
+
+### No Tables Found
+
+**Detection:** CLI output contains `"No tables found. Nothing to assess."`.
+
+The CLI found no BigQuery tables to assess in the specified project/datasets.
+
+Tell the user: "The CLI found no tables to assess. This usually means the `--datasets` filter is too narrow or the project ID is incorrect."
+
+Prompt the user to:
+
+1. Double-check the `gcp_project` value.
+2. If `datasets` was specified, verify the dataset names exist in the project.
+3. Try running without the `--datasets` filter to scan all datasets.
+
+Do **NOT** advance to the Interpret phase. Offer to re-run with corrected parameters.
+
+---
+
+### Generic Fatal Error
+
+**Detection:** Non-zero exit code AND none of the specific patterns above matched.
+
+Display the error message **verbatim** to the user. Do not summarize, truncate, or reformat it — the user may need the full output for debugging or to share with the tool maintainer.
+
+Then ask: **"Would you like to retry the assessment, or cancel?"**
+
+- If **retry**: re-run the same command from Step 2.
+- If **cancel**: exit the skill.
+
+## Cancellation
+
+If the user says "stop" or "cancel" at any point during this phase — including while the CLI is running, while reviewing error options, or after seeing results — exit the skill immediately. Do not run additional commands or write files.
+
+## Exit Conditions
+
+The Scan phase is complete when **all** of the following are true:
+
+1. The CLI exited with code 0.
+2. `landing_json` is set to a valid file path that exists and is non-empty.
+3. `effort_json` and `query_json` are captured if present (note any that are missing).
+
+Pass `landing_json`, `effort_json`, and `query_json` to the **Interpret phase**.

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/sample-report.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/sample-report.md
@@ -1,0 +1,156 @@
+# Sample Assessment Report
+
+> Annotated excerpt from a `bq-assess` JSON report (lakehouse target, two-axis model).
+> Use this reference to explain report fields without re-running the CLI.
+> Field names match what the Interpret phase reads — keep the two in sync.
+
+## Output File Structure
+
+A run with `--format json,html` writes **three mirrored JSON files** plus the HTML report:
+
+| File                        | Top-level keys                                                               | Holds                                                      |
+| --------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `assessment-landing-*.json` | `assessment_id`, `generated_at`, `project_id`, `summary`, `cost`, `failures` | Headline summary + cost comparison                         |
+| `assessment-effort-*.json`  | `assessment_id`, `entities[]`                                                | Per-**table** Migration Effort, Iceberg DDL, load/sync DML |
+| `assessment-query-*.json`   | `assessment_id`, `entities[]`                                                | Per-entity Query Complexity + rewrite guidance             |
+
+The Interpret phase reads `summary` and `cost` from the **landing** file, and per-entity detail from the **effort** / **query** files.
+
+A raw metadata export is also written under `<output>/metadata/` (`tables.json`, `routines.json`, `jobs.jsonl`, `workload_summary.json`, `pricing_detection.json`) for verification.
+
+---
+
+## Landing File — Annotated
+
+```jsonc
+{
+  "assessment_id": "assess-20260626-16ba999b",
+  "generated_at": "2026-06-26T...+00:00",
+  "project_id": "my-project",
+
+  // ── SUMMARY ──────────────────────────────────────────────────
+  "summary": {
+    "total_entities": 13, // tables + views + MVs + routines scanned
+    "total_tables": 10, // tables only (Migration Effort is tables-only)
+    "total_size_gb": 0.0264, // combined data size
+
+    // Axis 1 — Migration Effort (how hard the DATA is to move)
+    "effort_counts": { "AUTO": 8, "ASSISTED": 2, "MANUAL": 0 },
+
+    // Axis 2 — Query Complexity (how much the SQL must change)
+    "complexity_counts": { "PORTABLE": 7, "ADAPT": 6, "REWRITE": 0 },
+
+    "sql_surface_confidence": "HIGH" // HIGH/MEDIUM/LOW — drives the LOW-confidence callout
+  },
+
+  // ── COST ─────────────────────────────────────────────────────
+  // AWS run-rate is a RANGE (low/high). Negative delta = AWS costs more
+  // (common for tiny datasets). Recommendation picks the best-fit scenario.
+  "cost": {
+    "bq_pricing_model": "ON_DEMAND", // ON_DEMAND | CAPACITY (detected)
+    "bigquery_monthly": 0.0151, // BQ run-rate (computed list-price unless overridden)
+    "bigquery_breakdown": [/* storage + bytes-scanned lines */],
+    "aws_lines": [/* lines of the recommended scenario */],
+    "aws_monthly_low": 0.1151,
+    "aws_monthly_high": 0.1151,
+    "monthly_delta_low": -0.10, // bigquery_monthly - aws_monthly_high
+    "monthly_delta_high": -0.10,
+    "annual_savings_low": -1.20,
+    "annual_savings_high": -1.20,
+    "migration_onetime": 0.0, // from aggregate Migration Effort (not shown in HTML)
+    "breakeven_months_low": 9999.0, // 9999 = "never recoups"
+    "breakeven_months_high": 9999.0,
+    "compute_confidence": "HIGH", // HIGH/MEDIUM/LOW for the compute line
+    "aws_scenarios": [ // all six evaluated options
+      {
+        "label": "Redshift Serverless",
+        "category": "SERVERLESS",
+        "monthly_total": 0.1151,
+        "confidence": "HIGH",
+        "is_recommended": true,
+        "lines": [/* S3 Tables storage + Serverless compute */]
+      }
+      // + Serverless Reserved 1yr/3yr, Provisioned RG On-Demand/1yr/3yr.
+      // All scenarios share the userME S3 Tables storage basis (decoupled lakehouse).
+    ],
+    "recommendation": {
+      "recommended_scenario": "Redshift Serverless",
+      "reasoning": "Serverless at $0.12/month beats Provisioned 1yr RI ...",
+      "alternatives_considered": [/* other scenario labels */]
+    }
+  },
+
+  "failures": [] // entities that failed to process (empty when all succeed)
+}
+```
+
+---
+
+## Entity (effort / query files) — Annotated
+
+```jsonc
+{
+  "full_name": "sample_dataset.analytics_summary",
+  "entity_type": "TABLE", // TABLE | VIEW | MATERIALIZED_VIEW | ROUTINE
+  "population": "TABLE", // TABLE (migrate data) | REBUILT (views/MVs/UDFs)
+  "rows": 10000,
+  "size_gb": 0.0047,
+  "depends_on": [],
+
+  // Axis 1 — Migration Effort (tables only)
+  "effort": {
+    "category": "AUTO", // AUTO | ASSISTED | MANUAL
+    "score": 0,
+    "flags": [], // e.g. lossy_casts, partition_decision_required, ongoing_sync
+    "reasoning": "No effort factors detected — fully automatable.",
+    "confidence": "HIGH"
+  },
+
+  // Iceberg conversion (NOT Redshift-native DDL — no DISTKEY/SORTKEY)
+  "conversion": {
+    "ddl": "CREATE TABLE ... PARTITION BY (day(summary_date)) SORT BY (region);",
+    "partition_mapping": {
+      "iceberg_transforms": ["day(summary_date)"],
+      "sort_order": ["region"],
+      "auto_derived": true,
+      "decision_flags": []
+    },
+    "lossy_casts": [], // never silent — each lossy type is recorded
+    "warnings": [],
+    "success": true
+  },
+  "load_sync_dml": "INSERT INTO ...", // load/sync SQL (null for REBUILT entities)
+
+  // Axis 2 — Query Complexity (any entity with SQL surface)
+  "complexity": {
+    "category": "PORTABLE", // PORTABLE | ADAPT | REWRITE
+    "score": 0,
+    "constructs": [], // detected BQ-specific constructs (UNNEST, JS_UDF, ...)
+    "flags": [],
+    "reasoning": "...",
+    "confidence": "HIGH"
+  },
+  "rewrite_guidance": [/* per-construct, human-readable change notes */]
+}
+```
+
+---
+
+## How the Interpret Phase Uses Each Field
+
+| Field                                                            | Source file  | Interpret usage                     |
+| ---------------------------------------------------------------- | ------------ | ----------------------------------- |
+| `summary.total_entities` / `total_tables` / `total_size_gb`      | landing      | Scope headline                      |
+| `summary.effort_counts.{AUTO,ASSISTED,MANUAL}`                   | landing      | Migration Effort breakdown          |
+| `summary.complexity_counts.{PORTABLE,ADAPT,REWRITE}`             | landing      | Query Complexity breakdown          |
+| `summary.sql_surface_confidence`                                 | landing      | LOW-confidence callout              |
+| `cost.bigquery_monthly` / `aws_monthly_low` / `aws_monthly_high` | landing      | Cost comparison                     |
+| `cost.monthly_delta_*` / `annual_savings_*`                      | landing      | Business-case framing (directional) |
+| `cost.compute_confidence`                                        | landing      | Qualifies the AWS compute estimate  |
+| `cost.recommendation.recommended_scenario` / `reasoning`         | landing      | Recommended engine + why            |
+| `entities[].full_name` / `entity_type`                           | effort/query | Identifies entities in top lists    |
+| `entities[].effort.{category,score,flags}`                       | effort       | MANUAL filtering + sizing           |
+| `entities[].complexity.{category,score,flags}`                   | query        | REWRITE filtering + rewrite notes   |
+| `entities[].conversion.ddl`                                      | effort       | Generated Iceberg DDL               |
+
+> **Grounding:** every value presented to a customer must come directly from these JSON fields — never estimated or inferred.

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/references/scoring-rules.md
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/references/scoring-rules.md
@@ -1,0 +1,61 @@
+# Scoring Rules
+
+> Source of truth: `src/bq_assess/scoring/effort.py` and `src/bq_assess/scoring/complexity.py`
+
+## Two-Axis Model (ADR-0002)
+
+Every entity is scored on two independent axes:
+
+### Axis 1: Migration Effort (Tables only)
+
+Scores the labor required to move data to S3 Tables (Iceberg).
+
+| Factor              | Condition                                            | Points  |
+| ------------------- | ---------------------------------------------------- | ------- |
+| Data volume (large) | 1–100 GB                                             | +1      |
+| Data volume (huge)  | >100 GB                                              | +2      |
+| Lossy casts         | Per lossy type mapping                               | +1 each |
+| Ongoing sync        | Ingestion-time partition or `updated_at`-like column | +1      |
+| Partition decision  | `partition_decision_required` flag                   | +1      |
+| Sort decision       | `sort_decision_required` flag                        | +1      |
+
+**NOT scored:** nesting depth, clean partitioning, clean clustering.
+
+| Score | Category     | Meaning                                 |
+| ----- | ------------ | --------------------------------------- |
+| 0     | **AUTO**     | Tool's DML moves it with no human input |
+| 1–2   | **ASSISTED** | Flagged decisions need sign-off         |
+| 3+    | **MANUAL**   | Human must design the load strategy     |
+
+**Confidence:** HIGH when `num_bytes` is known, LOW when `num_bytes` is None.
+
+### Axis 2: Query Complexity (all entities with SQL surface)
+
+Scores the rewrite effort for BigQuery-specific SQL constructs.
+
+| Factor                                      | Points  |
+| ------------------------------------------- | ------- |
+| JavaScript UDF invocation                   | +4      |
+| UNNEST / array unnesting                    | +2      |
+| ARRAY_* functions                           | +2      |
+| Struct-path navigation                      | +1      |
+| Function-name drift (per distinct function) | +1 each |
+| Hub entity (≥3 dependents)                  | +1      |
+
+| Score | Category     | Meaning                    |
+| ----- | ------------ | -------------------------- |
+| 0     | **PORTABLE** | Runs on Redshift as-is     |
+| 1–3   | **ADAPT**    | Minor dialect adaptation   |
+| 4+    | **REWRITE**  | Full manual rewrite needed |
+
+**Confidence ladder:**
+
+- **LOW:** No SQL surface and no logs
+- **MEDIUM:** Auto-captured view/UDF definitions present
+- **HIGH:** Query logs add observed workload
+
+## Placement (Views/MVs/UDFs)
+
+- UDF → always Redshift (Iceberg has no function concept)
+- View/MV → signal-based (default: Redshift with LOW confidence)
+- MV with Iceberg placement → `refresh_unverified=True`

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/scripts/preflight.sh
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/scripts/preflight.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preflight environment check for the bq-assess Claude Code skill.
+# Emits a JSON object to stdout with tool/auth status.
+# No side effects — checks only; does not install or modify anything (Req 4.6).
+
+has() { command -v "$1" >/dev/null 2>&1 && echo true || echo false; }
+
+adc_path="${HOME}/.config/gcloud/application_default_credentials.json"
+adc_present=$([ -f "$adc_path" ] && echo true || echo false)
+
+cat <<EOF
+{
+  "bq_assess_installed": $(has bq-assess),
+  "gcloud_installed": $(has gcloud),
+  "adc_present": $adc_present,
+  "adc_path": "$adc_path"
+}
+EOF

--- a/solution-architecture/clis/bq-assess/skills/bq-assess/templates/config.yaml
+++ b/solution-architecture/clis/bq-assess/skills/bq-assess/templates/config.yaml
@@ -1,0 +1,40 @@
+# bq-assess configuration
+# All flags are optional except gcp.project_id.
+# Uncomment and edit any line to override the default.
+# Usage: bq-assess --config config.yaml
+
+# --- GCP connection ---
+gcp:
+  project_id: my-project             # GCP project ID (required)
+  use_adc: true                      # Use Application Default Credentials (recommended)
+  # credentials: /path/to/sa.json    # Path to service account JSON (alternative to ADC)
+  # datasets:                        # Comma-separated dataset filter (default: all datasets)
+  #   - prod_data
+  #   - analytics
+
+# --- Query log analysis ---
+query_logs:
+  enabled: true                      # Analyze INFORMATION_SCHEMA.JOBS (--include-query-logs).
+                                     # NOTE: workload analysis also runs automatically when a
+                                     # BigQuery capacity/reservation pricing model is detected,
+                                     # even without this flag. Opt out with --skip-workload.
+  days: 30                           # Lookback window in days, 1-90 (--query-log-days)
+  # file: exported-logs.json         # Path to exported query logs JSON (--query-logs)
+
+# --- Cost inputs ---
+cost:
+  # bigquery_monthly: 450            # Monthly BigQuery spend in USD; omit for estimated (--bigquery-monthly-cost)
+  # reservation_config: reservations.yaml  # Capacity slot figures for accurate cost (--reservation-config)
+
+# --- Output options ---
+options:
+  output: reports/                   # Output directory (--output)
+  format: [json, html]               # Output formats: json, html (--format; no CSV — R20.8)
+
+# --- CLI-only flags (not config keys — pass on the command line) ---
+# --concurrency N        Max parallel metadata API requests (default 50)
+# --skip-translation     Skip best-effort SQL translation stage (faster)
+# --offline-pricing      Use hardcoded AWS rates, skip live pricing lookup
+# --no-cache             Force a fresh metadata scan (DEFAULT — always on)
+# --use-cache            Opt back into cached metadata (offline re-analysis only)
+# --skip-workload        Skip workload analysis even when pricing is detected

--- a/solution-architecture/clis/bq-assess/src/bq_assess/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/__init__.py
@@ -1,0 +1,3 @@
+"""BigQuery to Redshift migration assessment tool."""
+
+__version__ = "0.3.1"

--- a/solution-architecture/clis/bq-assess/src/bq_assess/bundle/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/bundle/__init__.py
@@ -1,0 +1,7 @@
+"""Bundle package — the serializable hand-off artifact between collector and report."""
+
+from bq_assess.bundle.models import Bundle, SCHEMA_VERSION
+from bq_assess.bundle.writer import BundleWriter
+from bq_assess.bundle.loader import BundleLoader
+
+__all__ = ["Bundle", "BundleWriter", "BundleLoader", "SCHEMA_VERSION"]

--- a/solution-architecture/clis/bq-assess/src/bq_assess/bundle/loader.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/bundle/loader.py
@@ -1,0 +1,359 @@
+"""Bundle loader — directory or .zip → Bundle, with strict manifest verification.
+
+Verification order is deliberate: manifest first (schema_version, then per-file
+checksums), THEN deserialization. A corrupt or version-skewed bundle fails loudly
+before any of its content is trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from bq_assess.bundle.models import Bundle, SCHEMA_VERSION, QueryRecord, sha256_file
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    FailureRecord,
+    PricingDetection,
+    BQPricingModel,
+    ConfidenceLevel,
+    RangePartitionConfig,
+    RoutineMetadata,
+    SlotUtilization,
+    TimePartitionConfig,
+)
+
+# Files every manifest must list. queries.jsonl is optional: its optionality is
+# expressed by absence from the manifest — once listed, it must exist and match.
+REQUIRED_FILES = (
+    "tables.json",
+    "routines.json",
+    "workload.json",
+    "pricing.json",
+    "rates.json",
+    "failures.json",
+)
+
+
+class BundleError(Exception):
+    """Raised when a bundle fails verification or deserialization."""
+
+
+class BundleLoader:
+    """Load and strictly verify a bundle directory or zip."""
+
+    def load(self, bundle_path: str) -> Bundle:
+        """Load a bundle from a directory or .zip; verify manifest first.
+
+        Zip inputs are extracted to a temp dir that is removed before returning —
+        the Bundle is fully materialized in memory, so nothing references the
+        extracted files afterwards (and error paths must not leak them either).
+        """
+        path = Path(bundle_path)
+        if not path.exists():
+            raise BundleError(f"Bundle path not found: {bundle_path}")
+
+        self._tmp_dir: Path | None = None
+        try:
+            if path.is_file() and path.suffix.lower() == ".zip":
+                bundle_dir = self._extract_zip(path)
+            elif path.is_dir():
+                bundle_dir = path
+            else:
+                raise BundleError(
+                    f"Bundle path must be a directory or .zip file: {bundle_path}"
+                )
+
+            manifest = self._verify_manifest(bundle_dir)
+            return self._deserialize(bundle_dir, manifest)
+        finally:
+            if self._tmp_dir is not None:
+                shutil.rmtree(self._tmp_dir, ignore_errors=True)
+                self._tmp_dir = None
+
+    # ------------------------------------------------------------------
+    # Zip handling
+    # ------------------------------------------------------------------
+
+    def _extract_zip(self, zip_path: Path) -> Path:
+        """Extract a bundle zip to a temp dir; find the manifest at any depth.
+
+        Customers zip with arbitrary nesting (`zip -r bundle.zip bundle-out/bundle`
+        stores entries two levels deep) — search recursively rather than guessing.
+        The temp dir is tracked on self and removed by load()'s finally block.
+        """
+        tmp_dir = Path(tempfile.mkdtemp(prefix="bq-assess-bundle-"))
+        self._tmp_dir = tmp_dir
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                zf.extractall(tmp_dir)
+        except zipfile.BadZipFile as exc:
+            raise BundleError(f"Not a valid zip file: {zip_path}") from exc
+
+        manifests = sorted(tmp_dir.rglob("manifest.json"))
+        if not manifests:
+            raise BundleError(f"No manifest.json found anywhere in zip: {zip_path}")
+        if len(manifests) > 1:
+            raise BundleError(
+                f"Multiple manifest.json files found in zip ({len(manifests)}) — "
+                f"zip exactly one bundle directory: {zip_path}"
+            )
+        return manifests[0].parent
+
+    # ------------------------------------------------------------------
+    # Manifest verification (strict)
+    # ------------------------------------------------------------------
+
+    def _verify_manifest(self, bundle_dir: Path) -> dict:
+        manifest_path = bundle_dir / "manifest.json"
+        if not manifest_path.exists():
+            raise BundleError(f"manifest.json not found in bundle: {bundle_dir}")
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise BundleError(f"Failed to parse manifest.json: {exc}") from exc
+
+        version = manifest.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raise BundleError(
+                f"Bundle schema version mismatch: bundle is v{version} "
+                f"(collector {manifest.get('collector_version', 'unknown')}), "
+                f"this tool expects v{SCHEMA_VERSION}. "
+                f"Re-collect with a matching collector version or use a matching bq-assess."
+            )
+
+        files: dict = manifest.get("files", {})
+        for filename in REQUIRED_FILES:
+            if filename not in files:
+                raise BundleError(f"manifest.json is missing required file entry: {filename}")
+
+        # Every manifest-listed file must exist and match. Optionality is expressed
+        # by ABSENCE from the manifest (the writer only lists queries.jsonl when it
+        # wrote it) — a listed-but-missing file is always truncation or tampering,
+        # and silently skipping it would let a stripped bundle pass "strict"
+        # verification while the report quietly degrades.
+        for filename, expected_sha in files.items():
+            fpath = bundle_dir / filename
+            if not fpath.exists():
+                raise BundleError(
+                    f"Bundle file listed in manifest is missing: {filename} — "
+                    f"the bundle is incomplete (truncated zip or partial copy). "
+                    f"Ask the bundle provider to re-send it."
+                )
+            actual_sha = sha256_file(fpath)
+            if actual_sha != expected_sha:
+                raise BundleError(
+                    f"Checksum mismatch for {filename}: bundle may be corrupt or "
+                    f"tampered (expected {expected_sha[:12]}…, got {actual_sha[:12]}…). "
+                    f"Ask the bundle provider to re-send the bundle."
+                )
+
+        return manifest
+
+    # ------------------------------------------------------------------
+    # Deserialization
+    # ------------------------------------------------------------------
+
+    def _deserialize(self, bundle_dir: Path, manifest: dict) -> Bundle:
+        entities = self._load_entities(bundle_dir)
+        failures = self._load_failures(bundle_dir)
+        workload = self._load_workload(bundle_dir)
+        pricing = self._load_pricing(bundle_dir)
+        rates = self._load_json(bundle_dir / "rates.json")
+        queries = self._load_queries(bundle_dir)
+
+        return Bundle(
+            project_id=manifest.get("project_id", ""),
+            bq_location=manifest.get("bq_location", "US"),
+            aws_region=manifest.get("aws_region", "us-east-1"),
+            entities=entities,
+            failures=failures,
+            workload=workload,
+            pricing=pricing,
+            rates=rates,
+            queries=queries,
+            storage_basis=manifest.get("storage_basis", "assumed"),
+            collector_version=manifest.get("collector_version", ""),
+            created_at=manifest.get("created_at", ""),
+        )
+
+    def _load_entities(self, bundle_dir: Path) -> list[EntityMetadata]:
+        entities: list[EntityMetadata] = []
+
+        tables = self._load_json(bundle_dir / "tables.json") or []
+        for t in tables:
+            try:
+                entities.append(EntityMetadata(
+                    entity_id=t.get("entity_id", t["full_name"].split(".")[-1]),
+                    dataset_id=t.get("dataset_id", t["full_name"].split(".")[0]),
+                    full_name=t["full_name"],
+                    entity_type=EntityType(t["entity_type"]),
+                    population=EntityPopulation(t.get("population", "TABLE")),
+                    num_rows=t.get("num_rows") or 0,
+                    num_bytes=t.get("num_bytes") or 0,
+                    columns=[self._dict_to_col(c) for c in t.get("columns", [])],
+                    time_partitioning=self._dict_to_tp(t.get("time_partitioning")),
+                    range_partitioning=self._dict_to_rp(t.get("range_partitioning")),
+                    clustering_fields=t.get("clustering_fields"),
+                    view_query=t.get("view_query"),
+                    mview_query=t.get("mview_query"),
+                    routine=None,
+                    depends_on=t.get("depends_on", []),
+                    last_modified=self._parse_dt(t.get("last_modified")),
+                    physical_bytes=t.get("physical_bytes"),
+                ))
+            except (KeyError, ValueError) as exc:
+                raise BundleError(f"Malformed table entry in tables.json: {exc}") from exc
+
+        routines = self._load_json(bundle_dir / "routines.json") or []
+        for r in routines:
+            try:
+                entities.append(EntityMetadata(
+                    entity_id=r.get("entity_id", r["full_name"].split(".")[-1]),
+                    dataset_id=r.get("dataset_id", r["full_name"].split(".")[0]),
+                    full_name=r["full_name"],
+                    entity_type=EntityType.ROUTINE,
+                    population=EntityPopulation(r.get("population", "REBUILT")),
+                    num_rows=r.get("num_rows") or 0,
+                    num_bytes=r.get("num_bytes") or 0,
+                    columns=[self._dict_to_col(c) for c in r.get("columns", [])],
+                    time_partitioning=None,
+                    range_partitioning=None,
+                    clustering_fields=None,
+                    view_query=None,
+                    mview_query=None,
+                    routine=RoutineMetadata(
+                        name=r.get("name", r["full_name"].split(".")[-1]),
+                        language=r.get("language", "SQL"),
+                        arguments=r.get("arguments", []),
+                        body=r.get("body", ""),
+                        routine_type=r.get("routine_type", "SCALAR_FUNCTION"),
+                    ),
+                    depends_on=r.get("depends_on", []),
+                    last_modified=self._parse_dt(r.get("last_modified")),
+                    physical_bytes=r.get("physical_bytes"),
+                ))
+            except (KeyError, ValueError) as exc:
+                raise BundleError(f"Malformed routine entry in routines.json: {exc}") from exc
+
+        return entities
+
+    def _load_failures(self, bundle_dir: Path) -> list[FailureRecord]:
+        data = self._load_json(bundle_dir / "failures.json") or []
+        return [
+            FailureRecord(
+                entity_name=f.get("entity_name", ""),
+                stage=f.get("stage", ""),
+                error=f.get("error", ""),
+            )
+            for f in data
+        ]
+
+    def _load_workload(self, bundle_dir: Path) -> SlotUtilization | None:
+        data = self._load_json(bundle_dir / "workload.json")
+        if data is None:
+            return None
+        valid = {f for f in SlotUtilization.__dataclass_fields__}
+        try:
+            return SlotUtilization(**{k: v for k, v in data.items() if k in valid})
+        except TypeError as exc:
+            # Missing required field — a hand-edited or version-skewed workload.json
+            # must fail as a bundle error (with re-collect guidance), not a traceback.
+            raise BundleError(
+                f"Malformed workload.json (missing/invalid fields): {exc}. "
+                f"Re-collect the bundle with a matching collector version."
+            ) from exc
+
+    def _load_pricing(self, bundle_dir: Path) -> PricingDetection | None:
+        data = self._load_json(bundle_dir / "pricing.json")
+        if data is None:
+            return None
+        try:
+            return PricingDetection(
+                model=BQPricingModel(data.get("model", "UNKNOWN")),
+                confidence=ConfidenceLevel(data.get("confidence", "LOW")),
+                source_note=data.get("source_note", ""),
+                edition=data.get("edition"),
+                baseline_slots=data.get("baseline_slots"),
+                max_slots=data.get("max_slots"),
+                commitment_slots=data.get("commitment_slots"),
+                commitment_plan=data.get("commitment_plan"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise BundleError(f"Malformed pricing.json: {exc}") from exc
+
+    def _load_queries(self, bundle_dir: Path) -> list[QueryRecord] | None:
+        path = bundle_dir / "queries.jsonl"
+        if not path.exists():
+            return None
+        records: list[QueryRecord] = []
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # skip malformed lines rather than fail the whole load
+                records.append(QueryRecord(
+                    query=row.get("query", ""),
+                    total_slot_ms=row.get("total_slot_ms", 0),
+                    total_bytes_processed=row.get("total_bytes_processed", 0),
+                    total_bytes_billed=row.get("total_bytes_billed"),
+                    statement_type=row.get("statement_type"),
+                    creation_time=row.get("creation_time"),
+                ))
+        return records
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _load_json(self, path: Path):
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except (json.JSONDecodeError, OSError) as exc:
+            raise BundleError(f"Failed to parse {path.name}: {exc}") from exc
+
+    def _dict_to_col(self, d: dict) -> ColumnSchema:
+        return ColumnSchema(
+            name=d["name"],
+            field_type=d["field_type"],
+            mode=d["mode"],
+            fields=[self._dict_to_col(f) for f in d.get("fields", [])],
+        )
+
+    @staticmethod
+    def _dict_to_tp(d: dict | None) -> TimePartitionConfig | None:
+        if d is None:
+            return None
+        return TimePartitionConfig(type=d["type"], field=d.get("field"))
+
+    @staticmethod
+    def _dict_to_rp(d: dict | None) -> RangePartitionConfig | None:
+        if d is None:
+            return None
+        return RangePartitionConfig(
+            field=d["field"], start=d["start"], end=d["end"], interval=d["interval"]
+        )
+
+    @staticmethod
+    def _parse_dt(raw: str | None) -> datetime | None:
+        if not raw:
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except (ValueError, TypeError):
+            return None
+

--- a/solution-architecture/clis/bq-assess/src/bq_assess/bundle/models.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/bundle/models.py
@@ -1,0 +1,53 @@
+"""Bundle data model — the typed hand-off artifact."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bq_assess.models import (
+    EntityMetadata,
+    FailureRecord,
+    PricingDetection,
+    SlotUtilization,
+)
+
+SCHEMA_VERSION = 1
+
+
+def sha256_file(path: str | Path) -> str:
+    """Checksum a file — the bundle's integrity contract, shared by writer + loader."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass
+class QueryRecord:
+    """One anonymized query + per-job stats (queries.jsonl row)."""
+    query: str
+    total_slot_ms: int = 0
+    total_bytes_processed: int = 0
+    total_bytes_billed: int | None = None  # None = column unavailable
+    statement_type: str | None = None
+    creation_time: str | None = None
+
+
+@dataclass
+class Bundle:
+    """The complete hand-off artifact between collector and report generator."""
+    project_id: str
+    bq_location: str
+    aws_region: str
+    entities: list[EntityMetadata]
+    failures: list[FailureRecord] = field(default_factory=list)
+    workload: SlotUtilization | None = None
+    pricing: PricingDetection | None = None
+    rates: dict | None = None  # PricingRates serialized via price_lookup.rates_to_dict
+    queries: list[QueryRecord] | None = None
+    storage_basis: str = "assumed"  # measured | mixed | assumed (from StorageStats.basis)
+    collector_version: str = ""
+    created_at: str = ""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/bundle/writer.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/bundle/writer.py
@@ -1,0 +1,164 @@
+"""Bundle writer — serializes a Bundle to a directory with checksummed manifest."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from datetime import datetime
+from enum import Enum
+
+from bq_assess.bundle.models import Bundle, SCHEMA_VERSION, sha256_file
+from bq_assess.core.disclaimer import FULL_DISCLAIMER, DISCLAIMER_VERSION
+from bq_assess.models import EntityType
+
+
+class BundleWriter:
+    """Write a Bundle to a directory with a versioned, checksummed manifest."""
+
+    def write(self, bundle: Bundle, out_dir: str) -> str:
+        """Write the bundle; return the bundle directory path."""
+        bundle_dir = os.path.join(out_dir, "bundle")
+        os.makedirs(bundle_dir, exist_ok=True)
+
+        files: dict[str, str] = {}  # filename -> sha256
+
+        files["tables.json"] = self._write_tables(bundle, bundle_dir)
+        files["routines.json"] = self._write_routines(bundle, bundle_dir)
+        files["workload.json"] = self._write_workload(bundle, bundle_dir)
+        files["pricing.json"] = self._write_pricing(bundle, bundle_dir)
+        files["rates.json"] = self._write_rates(bundle, bundle_dir)
+        files["failures.json"] = self._write_failures(bundle, bundle_dir)
+
+        if bundle.queries is not None:
+            files["queries.jsonl"] = self._write_queries(bundle, bundle_dir)
+
+        self._write_manifest(bundle, files, bundle_dir)
+        return bundle_dir
+
+    def _write_tables(self, bundle: Bundle, bundle_dir: str) -> str:
+        tables = []
+        for e in bundle.entities:
+            if e.entity_type == EntityType.ROUTINE:
+                continue
+            tables.append({
+                "full_name": e.full_name,
+                "dataset_id": e.dataset_id,
+                "entity_id": e.entity_id,
+                "entity_type": e.entity_type.value,
+                "population": e.population.value,
+                "num_rows": e.num_rows,
+                "num_bytes": e.num_bytes,
+                "physical_bytes": e.physical_bytes,
+                "columns": [self._col_to_dict(c) for c in e.columns],
+                "time_partitioning": self._tp_to_dict(e.time_partitioning),
+                "range_partitioning": self._rp_to_dict(e.range_partitioning),
+                "clustering_fields": e.clustering_fields,
+                "view_query": e.view_query,
+                "mview_query": e.mview_query,
+                "depends_on": e.depends_on,
+                "last_modified": e.last_modified.isoformat() if e.last_modified else None,
+            })
+        return self._dump_json(tables, bundle_dir, "tables.json")
+
+    def _write_routines(self, bundle: Bundle, bundle_dir: str) -> str:
+        routines = []
+        for e in bundle.entities:
+            if e.entity_type != EntityType.ROUTINE or e.routine is None:
+                continue
+            routines.append({
+                "full_name": e.full_name,
+                "dataset_id": e.dataset_id,
+                "entity_id": e.entity_id,
+                "population": e.population.value,
+                "routine_type": e.routine.routine_type,
+                "language": e.routine.language,
+                "name": e.routine.name,
+                "arguments": e.routine.arguments,
+                "body": e.routine.body,
+                "depends_on": e.depends_on,
+                # Round-trip losslessness: the scanner may attach columns (TVF outputs),
+                # sizes, and last_modified to routine entities — preserve them.
+                "columns": [self._col_to_dict(c) for c in e.columns],
+                "num_rows": e.num_rows,
+                "num_bytes": e.num_bytes,
+                "physical_bytes": e.physical_bytes,
+                "last_modified": e.last_modified.isoformat() if e.last_modified else None,
+            })
+        return self._dump_json(routines, bundle_dir, "routines.json")
+
+    def _write_workload(self, bundle: Bundle, bundle_dir: str) -> str:
+        if bundle.workload is None:
+            return self._dump_json(None, bundle_dir, "workload.json")
+        return self._dump_json(asdict(bundle.workload), bundle_dir, "workload.json")
+
+    def _write_pricing(self, bundle: Bundle, bundle_dir: str) -> str:
+        if bundle.pricing is None:
+            return self._dump_json(None, bundle_dir, "pricing.json")
+        data = asdict(bundle.pricing)
+        data = {k: (v.value if isinstance(v, Enum) else v) for k, v in data.items()}
+        return self._dump_json(data, bundle_dir, "pricing.json")
+
+    def _write_rates(self, bundle: Bundle, bundle_dir: str) -> str:
+        return self._dump_json(bundle.rates, bundle_dir, "rates.json")
+
+    def _write_failures(self, bundle: Bundle, bundle_dir: str) -> str:
+        data = [asdict(f) for f in bundle.failures]
+        return self._dump_json(data, bundle_dir, "failures.json")
+
+    def _write_queries(self, bundle: Bundle, bundle_dir: str) -> str:
+        path = os.path.join(bundle_dir, "queries.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            for q in bundle.queries:
+                row = {
+                    "query": q.query,
+                    "total_slot_ms": q.total_slot_ms,
+                    "total_bytes_processed": q.total_bytes_processed,
+                    "creation_time": q.creation_time,
+                    "statement_type": q.statement_type,
+                }
+                if q.total_bytes_billed is not None:
+                    row["total_bytes_billed"] = q.total_bytes_billed
+                f.write(json.dumps(row, separators=(",", ":")) + "\n")
+        return sha256_file(path)
+
+    def _write_manifest(self, bundle: Bundle, files: dict[str, str], bundle_dir: str) -> None:
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "collector_version": bundle.collector_version,
+            "project_id": bundle.project_id,
+            "bq_location": bundle.bq_location,
+            "aws_region": bundle.aws_region,
+            "entity_count": len(bundle.entities),
+            "storage_basis": bundle.storage_basis,
+            "created_at": bundle.created_at or datetime.utcnow().isoformat(),
+            "disclaimer_version": DISCLAIMER_VERSION,
+            "disclaimer": FULL_DISCLAIMER,
+            "files": files,
+        }
+        path = os.path.join(bundle_dir, "manifest.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+
+    def _col_to_dict(self, col) -> dict:
+        d = {"name": col.name, "field_type": col.field_type, "mode": col.mode}
+        if col.fields:
+            d["fields"] = [self._col_to_dict(f) for f in col.fields]
+        return d
+
+    def _tp_to_dict(self, tp) -> dict | None:
+        if tp is None:
+            return None
+        return {"type": tp.type, "field": tp.field}
+
+    def _rp_to_dict(self, rp) -> dict | None:
+        if rp is None:
+            return None
+        return {"field": rp.field, "start": rp.start, "end": rp.end, "interval": rp.interval}
+
+    def _dump_json(self, obj, bundle_dir: str, filename: str) -> str:
+        path = os.path.join(bundle_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2, ensure_ascii=False, default=str)
+        return sha256_file(path)
+

--- a/solution-architecture/clis/bq-assess/src/bq_assess/cli.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/cli.py
@@ -1,0 +1,1028 @@
+"""CLI interface and pipeline orchestration for bq-assess.
+
+Entry point for the BigQuery migration assessment tool. The pipeline is split at the
+collection seam (2026-07-08 collector/report design):
+
+- ``collect(params) -> Bundle`` (collector.py) — every stage that touches GCP.
+- ``analyze_and_report(bundle, params)`` (here) — pure computation + report writing.
+
+``bq-assess assess`` composes both in-process (behavior unchanged); ``bq-assess report
+--bundle`` runs the analysis half offline on a customer bundle produced by bq-collect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+import yaml
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+from bq_assess import __version__
+from bq_assess.bundle import Bundle, BundleLoader, BundleWriter
+from bq_assess.bundle.loader import BundleError
+from bq_assess.collector import collect
+from bq_assess.core.disclaimer import CLI_ONE_LINER
+from bq_assess.core.sql_surface import SQLSurfaceAnalyzer
+from bq_assess.core.relationships import RelationshipInferrer
+from bq_assess.core.price_lookup import (
+    PriceLookup, PricingTimeout, apply_live_rates, fetch_live_rates_with_timeout,
+    rates_from_dict,
+)
+from bq_assess.core.storage_stats import effective_physical_bytes
+from bq_assess.targets.iceberg.converter import IcebergConverter
+from bq_assess.targets.iceberg.dml import DMLGenerator
+from bq_assess.scoring.effort import EffortScorer
+from bq_assess.scoring.complexity import ComplexityScorer
+from bq_assess.engine.redshift.rewrite import RewriteGuide
+from bq_assess.engine.redshift.placement import PlacementAdvisor
+from bq_assess.engine.redshift.cost import CostEstimator
+from bq_assess.report.json_writer import JSONWriter
+from bq_assess.report.html_writer import HTMLWriter
+from bq_assess.models import (
+    Assessment, AssessmentSummary, EntityReport, EntityPopulation,
+    EffortResult, ComplexityResult, PlacementRecommendation, TranslationResult,
+    FailureRecord, ConfidenceLevel, CostComparison, BQPricingModel,
+)
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def _load_config(config_path: str) -> dict:
+    """Load a YAML config file and return a flat dict of values."""
+    path = Path(config_path)
+    if not path.exists():
+        console.print(f"[red]Config file not found: {config_path}[/red]")
+        sys.exit(1)
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except yaml.YAMLError as exc:
+        console.print(f"[red]Invalid YAML in config file: {exc}[/red]")
+        sys.exit(1)
+
+    result: dict = {}
+    gcp = raw.get("gcp", {})
+    if gcp.get("project_id"):
+        result["gcp_project"] = gcp["project_id"]
+    if gcp.get("credentials"):
+        result["credentials"] = gcp["credentials"]
+    if gcp.get("use_adc") is not None:
+        result["use_adc"] = bool(gcp["use_adc"])
+    if gcp.get("datasets"):
+        datasets = gcp["datasets"]
+        result["datasets"] = ",".join(datasets) if isinstance(datasets, list) else str(datasets)
+
+    ql = raw.get("query_logs", {})
+    if ql.get("enabled") is not None:
+        result["include_query_logs"] = bool(ql["enabled"])
+    if ql.get("file"):
+        result["query_logs"] = ql["file"]
+    if ql.get("days") is not None:
+        result["query_log_days"] = int(ql["days"])
+
+    cost = raw.get("cost", {})
+    if cost.get("bigquery_monthly") is not None:
+        result["bigquery_monthly_cost"] = float(cost["bigquery_monthly"])
+    if cost.get("reservation_config"):
+        result["reservation_config"] = cost["reservation_config"]
+
+    opts = raw.get("options", {})
+    if opts.get("output"):
+        result["output"] = opts["output"]
+    if opts.get("format"):
+        fmt = opts["format"]
+        result["format"] = ",".join(fmt) if isinstance(fmt, list) else str(fmt)
+
+    return result
+
+
+def _merge_config(cli_params: dict, config_values: dict) -> dict:
+    """Merge CLI params with config file values. CLI args take precedence."""
+    merged = dict(config_values)
+    for key, value in cli_params.items():
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
+def _interactive_prompts(params: dict) -> dict:
+    """Prompt the user for missing values using Rich prompts."""
+    console.print("\n[bold cyan]Interactive configuration mode[/bold cyan]\n")
+
+    if not params.get("gcp_project"):
+        params["gcp_project"] = Prompt.ask("GCP Project ID")
+
+    if not params.get("credentials") and not params.get("use_adc"):
+        cred_choice = Prompt.ask(
+            "Authentication method",
+            choices=["credentials", "adc"],
+            default="adc",
+        )
+        if cred_choice == "credentials":
+            params["credentials"] = Prompt.ask("Path to service account JSON")
+        else:
+            params["use_adc"] = True
+
+    if not params.get("datasets"):
+        ds = Prompt.ask("Datasets to scan (comma-separated, or empty for all)", default="")
+        if ds.strip():
+            params["datasets"] = ds.strip()
+
+    params["include_query_logs"] = params.get("include_query_logs") or Confirm.ask(
+        "Include query log analysis?", default=False
+    )
+
+    if params.get("include_query_logs") and not params.get("query_logs"):
+        ql = Prompt.ask("Path to exported query logs JSON (or empty for API)", default="")
+        if ql.strip():
+            params["query_logs"] = ql.strip()
+
+    if params.get("include_query_logs") and not params.get("query_logs") and params.get("query_log_days") is None:
+        qld = Prompt.ask("Query log lookback window in days (1-90)", default="30")
+        try:
+            qld_int = int(qld.strip())
+            if 1 <= qld_int <= 90:
+                params["query_log_days"] = qld_int
+            else:
+                console.print("[yellow]Out of range, using default 30 days.[/yellow]")
+        except ValueError:
+            console.print("[yellow]Invalid value, using default 30 days.[/yellow]")
+
+    if params.get("bigquery_monthly_cost") is None:
+        bq_cost = Prompt.ask("Monthly BigQuery cost override (or empty to calculate)", default="")
+        if bq_cost.strip():
+            try:
+                params["bigquery_monthly_cost"] = float(bq_cost.strip())
+            except ValueError:
+                console.print("[yellow]Invalid cost value, will calculate automatically.[/yellow]")
+
+    if not params.get("output"):
+        params["output"] = Prompt.ask("Output directory", default="reports/")
+
+    if not params.get("format"):
+        params["format"] = Prompt.ask("Output formats (json,html)", default="json,html")
+
+    return params
+
+
+
+
+def _validate_report_params(params: dict) -> list[str]:
+    """Validate output format params; return the parsed formats list. Exits on error."""
+    output_format: str = params.get("format", "json,html")
+    formats = [f.strip().lower() for f in output_format.split(",") if f.strip()]
+    for fmt in formats:
+        if fmt not in ("json", "html"):
+            console.print(f"[red]Error: format '{fmt}' not supported. Use 'json' or 'html'.[/red]")
+            sys.exit(1)
+    return formats
+
+
+def _validate_collect_params(params: dict) -> None:
+    """Validate credential params and load reservation config. Exits on error."""
+    credentials: str | None = params.get("credentials")
+    use_adc: bool = params.get("use_adc", False)
+
+    if credentials and use_adc:
+        console.print("[red]Error: --credentials and --use-adc are mutually exclusive[/red]")
+        sys.exit(1)
+    if not credentials and not use_adc:
+        console.print("[red]Error: provide --credentials or --use-adc[/red]")
+        sys.exit(1)
+
+    # Load reservation config if provided (parsed here so collect() stays file-free)
+    reservation_config_path: str | None = params.get("reservation_config")
+    if reservation_config_path:
+        try:
+            with open(reservation_config_path, encoding="utf-8") as f:
+                if reservation_config_path.endswith(".json"):
+                    import json
+                    params["reservation_config_data"] = json.load(f)
+                else:
+                    params["reservation_config_data"] = yaml.safe_load(f)
+            console.print(f"[green]✓ Loaded reservation config: {reservation_config_path}[/green]")
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Failed to load reservation config: {exc}[/yellow]")
+
+
+def analyze_and_report(bundle: Bundle, params: dict) -> Assessment:
+    """Run the pure-computation stages (3-16) on a Bundle and write reports.
+
+    Works identically whether the Bundle came from an in-process collect() (assess)
+    or was loaded from disk (report --bundle) — the anti-drift guarantee.
+    """
+    entities = bundle.entities
+    failures = list(bundle.failures)
+    gcp_project = bundle.project_id
+    detected_location = bundle.bq_location
+    slots = bundle.workload
+    pricing = bundle.pricing
+    storage_basis = bundle.storage_basis
+
+    bigquery_monthly_cost: float | None = params.get("bigquery_monthly_cost")
+    output_dir: str = params.get("output", "reports/")
+    formats = _validate_report_params(params)
+
+    if not entities:
+        console.print("[red]Bundle contains no entities. Nothing to assess.[/red]")
+        sys.exit(1)
+
+    # ── Stage 3: SQL Surface Detection ─────────────────────────────
+    console.print("\n[bold]Stage 3:[/bold] Detecting SQL surface constructs...")
+    sql_analyzer = SQLSurfaceAnalyzer()
+    query_log_text: list[str] | None = None
+
+    # Anonymized statements from the bundle (queries.jsonl or in-process collection)
+    if bundle.queries:
+        query_log_text = [q.query for q in bundle.queries if q.query]
+        console.print(f"[green]✓ {len(query_log_text)} anonymized statements available for analysis.[/green]")
+
+    constructs_by_entity = sql_analyzer.detect_for_entities(entities, query_log_text)
+    console.print(f"[green]✓ Detected SQL constructs for {len(constructs_by_entity)} entities.[/green]")
+
+    # ── Stage 4: Iceberg Conversion ────────────────────────────────
+    console.print("\n[bold]Stage 4:[/bold] Converting TABLE entities to Iceberg schemas...")
+    converter = IcebergConverter()
+    conversion_results: dict[str, object] = {}
+
+    table_entities = [e for e in entities if e.population == EntityPopulation.TABLE]
+    for entity in table_entities:
+        try:
+            result = converter.convert(entity)
+            conversion_results[entity.full_name] = result
+            if not result.success:
+                failures.append(FailureRecord(
+                    entity_name=entity.full_name,
+                    stage="convert",
+                    error="; ".join(result.warnings),
+                ))
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Conversion failed for {entity.full_name}: {exc}[/yellow]")
+            failures.append(FailureRecord(
+                entity_name=entity.full_name,
+                stage="convert",
+                error=str(exc),
+            ))
+
+    console.print(f"[green]✓ Converted {len(conversion_results)} schemas.[/green]")
+
+    # ── Stage 5: Score Effort ──────────────────────────────────────
+    console.print("\n[bold]Stage 5:[/bold] Scoring migration effort for TABLE entities...")
+    effort_scorer = EffortScorer()
+    effort_results: dict[str, EffortResult] = {}
+
+    for entity in table_entities:
+        try:
+            conversion = conversion_results.get(entity.full_name)
+            if conversion:
+                result = effort_scorer.score(entity, conversion)
+                effort_results[entity.full_name] = result
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Effort scoring failed for {entity.full_name}: {exc}[/yellow]")
+            failures.append(FailureRecord(
+                entity_name=entity.full_name,
+                stage="score_effort",
+                error=str(exc),
+            ))
+
+    console.print(f"[green]✓ Scored effort for {len(effort_results)} tables.[/green]")
+
+    # ── Stage 6: Relationships ─────────────────────────────────────
+    console.print("\n[bold]Stage 6:[/bold] Inferring table relationships...")
+    inferrer = RelationshipInferrer()
+
+    # View SQL is already scanned — feed it to the JOIN-clause inference path
+    # (was passed as None until the 2026-07-08 collector/report split; SCRUM_NOTES).
+    view_definitions = {
+        e.full_name: (e.view_query or e.mview_query)
+        for e in entities
+        if e.view_query or e.mview_query
+    }
+
+    try:
+        rel_result = inferrer.infer(entities, query_analysis=None, view_definitions=view_definitions or None)
+        console.print(
+            f"[green]✓ Found {len(rel_result.relationships)} relationships.[/green]"
+        )
+    except Exception as exc:
+        console.print(f"[yellow]⚠ Relationship inference failed: {exc}[/yellow]")
+        rel_result = None
+
+    # ── Stage 7: Score Complexity ──────────────────────────────────
+    console.print("\n[bold]Stage 7:[/bold] Scoring query complexity...")
+    complexity_scorer = ComplexityScorer()
+    complexity_results: dict[str, ComplexityResult] = {}
+    has_query_logs = bool(bundle.queries)
+    dep_counts = ComplexityScorer.build_dep_counts(rel_result)
+
+    with Progress(
+        SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
+        BarColumn(), TaskProgressColumn(), console=console,
+    ) as progress:
+        task = progress.add_task("Scoring complexity...", total=len(entities))
+        for entity in entities:
+            try:
+                constructs = constructs_by_entity.get(entity.full_name, [])
+                result = complexity_scorer.score(entity, constructs, has_logs=has_query_logs, dep_counts=dep_counts)
+                complexity_results[entity.full_name] = result
+            except Exception as exc:
+                console.print(f"[yellow]⚠ Complexity scoring failed for {entity.full_name}: {exc}[/yellow]")
+                failures.append(FailureRecord(
+                    entity_name=entity.full_name,
+                    stage="score_complexity",
+                    error=str(exc),
+                ))
+            progress.advance(task)
+
+    console.print(f"[green]✓ Scored complexity for {len(complexity_results)} entities.[/green]")
+
+    # ── Stage 8: Region + Rates Replay ─────────────────────────────
+    # Re-point the rate tables at the Source's geography recorded in the bundle, then
+    # apply the collection-time rate snapshot. Fully offline — the report side never
+    # hits GCP or the pricing APIs unless --refresh-pricing explicitly asks for it.
+    console.print("\n[bold]Stage 8:[/bold] Applying region and pricing snapshot...")
+    from bq_assess.core import pricing_constants as _v4
+    from bq_assess.engine.redshift import cost_constants as _k
+    if _v4.apply_bq_region(detected_location):
+        console.print(f"[green]✓ BigQuery priced for region: {detected_location}[/green]")
+    else:
+        console.print(
+            f"[yellow]⚠ No verified rate table for BigQuery location "
+            f"'{detected_location}' — using US multi-region rates (may understate cost).[/yellow]"
+        )
+    aws_region = bundle.aws_region or _k.bq_location_to_aws_region(detected_location)
+    _k.apply_aws_region(aws_region)
+    console.print(f"[green]✓ AWS priced for region: {aws_region}[/green]")
+
+    if params.get("refresh_pricing", False):
+        try:
+            price_lookup = PriceLookup(
+                aws_region=aws_region, bq_location=detected_location,
+                use_cache=not params.get("no_cache", True),
+            )
+            # No GCP client in report mode — only the AWS half (public Price List
+            # API) can actually refresh; say so rather than claiming both.
+            with console.status("[dim]Fetching live AWS pricing…[/dim]", spinner="dots"):
+                live_rates = fetch_live_rates_with_timeout(price_lookup, gcp_client=None)
+            if live_rates.is_live:
+                # Bundle snapshot first (GCP half), then the fresh AWS fetch on top —
+                # reversed order would let the older snapshot clobber the refresh.
+                _apply_bundle_rates(bundle, aws_region, detected_location)
+                apply_live_rates(live_rates)
+                console.print(
+                    f"[green]✓ AWS pricing refreshed ({live_rates.aws.fetched_at}).[/green] "
+                    f"[dim]GCP rates cannot be refreshed offline — using bundle snapshot/regional rates.[/dim]"
+                )
+            else:
+                console.print("[dim]  Refresh returned no live rates — falling back to bundle snapshot.[/dim]")
+                _apply_bundle_rates(bundle, aws_region, detected_location)
+        except PricingTimeout as exc:
+            console.print(f"[yellow]⚠ {exc} — falling back to bundle snapshot.[/yellow]")
+            _apply_bundle_rates(bundle, aws_region, detected_location)
+        except Exception as exc:
+            console.print(f"[dim]  Pricing refresh skipped: {exc}[/dim]")
+            _apply_bundle_rates(bundle, aws_region, detected_location)
+    else:
+        _apply_bundle_rates(bundle, aws_region, detected_location)
+
+    # ── Stage 10: Cost Estimation ──────────────────────────────────
+    console.print("\n[bold]Stage 10:[/bold] Estimating costs...")
+    if pricing:
+        cost_estimator = CostEstimator(skip_live_pricing=True)
+        effort_total = sum(er.score for er in effort_results.values())
+
+        try:
+            cost_comparison = cost_estimator.estimate(
+                entities, pricing, slots, bigquery_monthly_cost, effort_total,
+                location=detected_location,
+                storage_basis=storage_basis,
+            )
+            console.print("[green]✓ Cost estimation complete.[/green]")
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Cost estimation failed: {exc}[/yellow]")
+            # Fix 2: Create sentinel CostComparison on failure
+            cost_comparison = CostComparison(
+                bq_pricing_model=BQPricingModel.ON_DEMAND,
+                bigquery_monthly=0.0,
+                bigquery_breakdown=[],
+                aws_lines=[],
+                aws_monthly_low=0.0,
+                aws_monthly_high=0.0,
+                monthly_delta_low=0.0,
+                monthly_delta_high=0.0,
+                annual_savings_low=0.0,
+                annual_savings_high=0.0,
+                migration_onetime=0.0,
+                breakeven_months_low=9999.0,
+                breakeven_months_high=9999.0,
+                compute_confidence=ConfidenceLevel.LOW,
+            )
+    else:
+        console.print("[yellow]⚠ Skipping cost estimation (no pricing data).[/yellow]")
+        # Fix 2: Create sentinel CostComparison when no pricing data
+        cost_comparison = CostComparison(
+            bq_pricing_model=BQPricingModel.UNKNOWN,
+            bigquery_monthly=0.0,
+            bigquery_breakdown=[],
+            aws_lines=[],
+            aws_monthly_low=0.0,
+            aws_monthly_high=0.0,
+            monthly_delta_low=0.0,
+            monthly_delta_high=0.0,
+            annual_savings_low=0.0,
+            annual_savings_high=0.0,
+            migration_onetime=0.0,
+            breakeven_months_low=9999.0,
+            breakeven_months_high=9999.0,
+            compute_confidence=ConfidenceLevel.LOW,
+        )
+
+    # ── Stage 11: DML Generation ───────────────────────────────────
+    console.print("\n[bold]Stage 11:[/bold] Generating DML for TABLE entities...")
+    dml_generator = DMLGenerator()
+    dml_results: dict[str, str | None] = {}
+
+    for entity in table_entities:
+        try:
+            effort = effort_results.get(entity.full_name)
+            conversion = conversion_results.get(entity.full_name)
+            if effort and conversion:
+                dml = dml_generator.generate(entity, effort, conversion)
+                dml_results[entity.full_name] = dml
+        except Exception as exc:
+            console.print(f"[yellow]⚠ DML generation failed for {entity.full_name}: {exc}[/yellow]")
+
+    console.print(f"[green]✓ Generated DML for {len([d for d in dml_results.values() if d])} tables.[/green]")
+
+    # ── Stage 12: Rewrite Guidance ─────────────────────────────────
+    console.print("\n[bold]Stage 12:[/bold] Generating rewrite guidance...")
+    rewrite_guide = RewriteGuide()
+    guidance_results: dict[str, list[str]] = {}
+
+    for entity in entities:
+        try:
+            constructs = constructs_by_entity.get(entity.full_name, [])
+            if constructs:
+                guidance = rewrite_guide.guide(entity, constructs)
+                guidance_results[entity.full_name] = guidance
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Guidance generation failed for {entity.full_name}: {exc}[/yellow]")
+
+    console.print(f"[green]✓ Generated guidance for {len(guidance_results)} entities.[/green]")
+
+    # ── Stage 12b: Best-Effort SQL Translation ─────────────────────
+    translation_results: dict[str, TranslationResult] = {}
+
+    if params.get("skip_translation"):
+        console.print("\n[bold]Stage 12b:[/bold] SQL translation [yellow]skipped[/yellow] (--skip-translation).")
+    else:
+        console.print("\n[bold]Stage 12b:[/bold] Translating SQL to Redshift...")
+        translation_cache: dict[str, TranslationResult] = {}
+
+        with Progress(
+            SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
+            BarColumn(), TaskProgressColumn(), console=console,
+        ) as progress:
+            task = progress.add_task("Translating...", total=len(entities))
+            for entity in entities:
+                try:
+                    sql = entity.view_query or entity.mview_query or (entity.routine.body if entity.routine else None)
+                    if sql:
+                        if sql in translation_cache:
+                            translation_results[entity.full_name] = translation_cache[sql]
+                        else:
+                            result = rewrite_guide.translate(sql)
+                            translation_cache[sql] = result
+                            translation_results[entity.full_name] = result
+                except Exception as exc:
+                    console.print(f"[yellow]⚠ Translation failed for {entity.full_name}: {exc}[/yellow]")
+                progress.advance(task)
+
+        console.print(f"[green]✓ Translated SQL for {len(translation_results)} entities.[/green]")
+
+    # ── Stage 13: Placement ────────────────────────────────────────
+    console.print("\n[bold]Stage 13:[/bold] Recommending placement for REBUILT entities...")
+    placement_advisor = PlacementAdvisor()
+    placement_results: dict[str, PlacementRecommendation] = {}
+
+    rebuilt_entities = [e for e in entities if e.population == EntityPopulation.REBUILT]
+    for entity in rebuilt_entities:
+        try:
+            placement = placement_advisor.recommend(entity, rel_result, has_query_logs)
+            if placement:
+                placement_results[entity.full_name] = placement
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Placement recommendation failed for {entity.full_name}: {exc}[/yellow]")
+
+    console.print(f"[green]✓ Recommended placement for {len(placement_results)} entities.[/green]")
+
+    # ── Stage 14: Assemble Assessment ──────────────────────────────
+    console.print("\n[bold]Stage 14:[/bold] Assembling assessment report...")
+
+    # Build summary
+    effort_counts = {"AUTO": 0, "ASSISTED": 0, "MANUAL": 0}
+    complexity_counts = {"PORTABLE": 0, "ADAPT": 0, "REWRITE": 0}
+    total_size_gb = 0.0
+    total_logical_size_gb = 0.0
+
+    for entity in entities:
+        total_size_gb += effective_physical_bytes(entity.num_bytes, entity.physical_bytes) / (1024 ** 3)
+        total_logical_size_gb += entity.num_bytes / (1024 ** 3)
+
+        if entity.full_name in effort_results:
+            effort = effort_results[entity.full_name]
+            effort_counts[effort.category.value] += 1
+
+        if entity.full_name in complexity_results:
+            comp = complexity_results[entity.full_name]
+            complexity_counts[comp.category.value] += 1
+
+    # Determine overall SQL surface confidence
+    complexity_confidences = [cr.confidence for cr in complexity_results.values()]
+    if not complexity_confidences:
+        sql_confidence = ConfidenceLevel.LOW
+    elif any(c == ConfidenceLevel.HIGH for c in complexity_confidences):
+        sql_confidence = ConfidenceLevel.HIGH
+    elif any(c == ConfidenceLevel.MEDIUM for c in complexity_confidences):
+        sql_confidence = ConfidenceLevel.MEDIUM
+    else:
+        sql_confidence = ConfidenceLevel.LOW
+
+    summary = AssessmentSummary(
+        total_entities=len(entities),
+        total_tables=len(table_entities),
+        total_size_gb=round(total_size_gb, 4),
+        effort_counts=effort_counts,
+        complexity_counts=complexity_counts,
+        sql_surface_confidence=sql_confidence,
+        total_logical_size_gb=round(total_logical_size_gb, 4),
+    )
+
+    # Build entity reports
+    entity_reports = []
+    for entity in entities:
+        effort = effort_results.get(entity.full_name)
+        conversion = conversion_results.get(entity.full_name)
+        complexity = complexity_results.get(entity.full_name)
+        dml = dml_results.get(entity.full_name)
+        guidance = guidance_results.get(entity.full_name, [])
+        placement = placement_results.get(entity.full_name)
+
+        entity_reports.append(EntityReport(
+            full_name=entity.full_name,
+            entity_type=entity.entity_type,
+            population=entity.population,
+            rows=entity.num_rows,
+            size_gb=round(entity.num_bytes / (1024 ** 3), 4),
+            depends_on=entity.depends_on,
+            effort=effort,
+            conversion=conversion,
+            load_sync_dml=dml,
+            complexity=complexity,
+            rewrite_guidance=guidance,
+            translated_sql=translation_results.get(entity.full_name),
+            placement=placement,
+            physical_bytes=entity.physical_bytes,
+        ))
+
+    # Generate assessment ID
+    now = datetime.now(timezone.utc)
+    hash_input = f"{gcp_project}-{now.isoformat()}"
+    short_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
+    assessment_id = f"assess-{now.strftime('%Y%m%d')}-{short_hash}"
+
+    assessment = Assessment(
+        assessment_id=assessment_id,
+        generated_at=now,
+        project_id=gcp_project,
+        summary=summary,
+        cost=cost_comparison,
+        entities=entity_reports,
+        failures=failures,
+    )
+
+    console.print("[green]✓ Assessment assembled.[/green]")
+
+    # ── Stage 15: Write Reports ────────────────────────────────────
+    console.print("\n[bold]Stage 15:[/bold] Writing reports...")
+
+    # Ensure output directory exists
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    output_files: list[str] = []
+
+    if "json" in formats:
+        json_writer = JSONWriter()
+        paths = json_writer.write(assessment, output_dir)
+        output_files.extend(paths)
+        for path in paths:
+            console.print(f"  [green]✓ JSON report: {path}[/green]")
+
+    if "html" in formats:
+        html_writer = HTMLWriter()
+        paths = html_writer.write(assessment, output_dir, storage_basis=storage_basis)
+        output_files.extend(paths)
+        for path in paths:
+            console.print(f"  [green]✓ HTML report: {path}[/green]")
+
+    # Bundle export (replaces the pre-0.3 metadata/ export — the bundle is a strict
+    # superset and is re-processable by `bq-assess report`).
+    if params.get("export_bundle", True):
+        writer = BundleWriter()
+        bundle_dir = writer.write(bundle, output_dir)
+        output_files.append(bundle_dir)
+        console.print(f"  [green]✓ Bundle exported: {bundle_dir}[/green]")
+
+    # ── Stage 16: Terminal Summary ─────────────────────────────────
+    _print_summary(assessment, output_files)
+    return assessment
+
+
+def _apply_bundle_rates(bundle: Bundle, aws_region: str, bq_location: str) -> None:
+    """Apply the bundle's collection-time rate snapshot (offline pricing replay).
+
+    apply_live_rates gates per half: only genuinely LIVE halves overwrite the
+    region-cascaded constants Stage 8 installed. A hardcoded-fallback half was
+    captured from the collector's un-cascaded default constants — applying it
+    would price the report in the wrong geography (the Sydney-as-US class).
+    """
+    if not bundle.rates:
+        console.print("[dim]  No rate snapshot in bundle — using region-adjusted hardcoded rates.[/dim]")
+        return
+    try:
+        rates = rates_from_dict(
+            bundle.rates, default_aws_region=aws_region, default_bq_location=bq_location
+        )
+        # apply_live_rates reports which halves it actually applied — the message
+        # derives from that, never from a re-derived live-ness predicate.
+        aws_live, gcp_live = apply_live_rates(rates)
+        if aws_live and gcp_live:
+            console.print(
+                f"[green]✓ Bundle rate snapshot applied "
+                f"(AWS: {rates.aws.fetched_at}, GCP: {rates.gcp.fetched_at}).[/green]"
+            )
+        elif aws_live or gcp_live:
+            live_half = "AWS" if aws_live else "GCP"
+            console.print(
+                f"[yellow]⚠ Bundle snapshot is part-live — applied {live_half} half only; "
+                f"the other side uses region-adjusted hardcoded rates.[/yellow]"
+            )
+        else:
+            console.print(
+                "[dim]  Bundle snapshot carries hardcoded fallback rates — "
+                "keeping region-adjusted rates instead.[/dim]"
+            )
+    except Exception as exc:
+        console.print(f"[yellow]⚠ Could not apply bundle rate snapshot: {exc} — using hardcoded rates.[/yellow]")
+
+
+def _print_summary(assessment: Assessment, output_files: list[str]) -> None:
+    """Print a Rich summary table to the terminal."""
+    console.print("\n")
+    console.rule("[bold cyan]Assessment Summary[/bold cyan]")
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Metric", style="bold")
+    table.add_column("Value")
+
+    table.add_row("Total entities scanned", str(assessment.summary.total_entities))
+    table.add_row("Total tables", str(assessment.summary.total_tables))
+    table.add_row("Total data size (BigQuery logical)", f"{assessment.summary.total_logical_size_gb:.2f} GB")
+    table.add_row("Projected size on S3 Iceberg", f"{assessment.summary.total_size_gb:.2f} GB")
+
+    effort_counts = assessment.summary.effort_counts
+    table.add_row(
+        "Migration effort",
+        f"[green]AUTO: {effort_counts['AUTO']}[/green]  "
+        f"[yellow]ASSISTED: {effort_counts['ASSISTED']}[/yellow]  "
+        f"[red]MANUAL: {effort_counts['MANUAL']}[/red]",
+    )
+
+    complexity_counts = assessment.summary.complexity_counts
+    table.add_row(
+        "Query complexity",
+        f"[green]PORTABLE: {complexity_counts['PORTABLE']}[/green]  "
+        f"[yellow]ADAPT: {complexity_counts['ADAPT']}[/yellow]  "
+        f"[red]REWRITE: {complexity_counts['REWRITE']}[/red]",
+    )
+
+    if assessment.cost:
+        cost = assessment.cost
+        if cost.monthly_delta_low == cost.monthly_delta_high:
+            delta_str = f"${cost.monthly_delta_low:,.2f}"
+        else:
+            delta_str = f"${cost.monthly_delta_low:,.2f} - ${cost.monthly_delta_high:,.2f}"
+
+        table.add_row("Monthly cost delta", delta_str)
+
+        confidence_color = {"LOW": "red", "MEDIUM": "yellow", "HIGH": "green"}
+        color = confidence_color.get(cost.compute_confidence.value, "white")
+        table.add_row("Cost confidence", f"[{color}]{cost.compute_confidence.value}[/{color}]")
+
+    sql_confidence_color = {"LOW": "red", "MEDIUM": "yellow", "HIGH": "green"}
+    sql_color = sql_confidence_color.get(assessment.summary.sql_surface_confidence.value, "white")
+    table.add_row("SQL surface confidence", f"[{sql_color}]{assessment.summary.sql_surface_confidence.value}[/{sql_color}]")
+
+    if assessment.failures:
+        table.add_row("Failed entities", f"[yellow]{len(assessment.failures)}[/yellow]")
+
+    console.print(table)
+
+    if output_files:
+        console.print("\n[bold]Output files:[/bold]")
+        for f in output_files:
+            console.print(f"  • {f}")
+
+    console.print(f"\n[dim]{CLI_ONE_LINER}[/dim]\n")
+
+
+class _DefaultToAssessGroup(click.Group):
+    """Click group that routes unrecognized invocations to `assess`.
+
+    Backward compatibility for the pre-0.3 single-command CLI: when the first
+    token is not a known subcommand or a group-level option (derived from the
+    group's OWN params — never a hardcoded list, so adding a group option can't
+    silently reroute it), "assess" is prepended and its parser handles every
+    option. Options are registered once, on the subcommands, so
+    `bq-assess --gcp-project p assess` errors instead of dropping flags.
+    """
+
+    def parse_args(self, ctx, args):
+        if not args:
+            return super().parse_args(ctx, ["assess"])
+        # Group-level options = declared params + the auto-added help option
+        # (click injects it at parse time, so it is not in self.params).
+        group_opts = {opt for p in self.params for opt in (*p.opts, *p.secondary_opts)}
+        group_opts.update(ctx.help_option_names)
+        first = args[0].split("=", 1)[0]
+        if first.startswith("-") and first not in group_opts:
+            args = ["assess", *args]
+        return super().parse_args(ctx, args)
+
+
+@click.group(
+    "bq-assess",
+    cls=_DefaultToAssessGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.version_option(__version__, message=f"bq-assess %(version)s (beta)\n{CLI_ONE_LINER}")
+def main() -> None:
+    """BigQuery migration assessment tool.
+
+    Scans BigQuery metadata and generates a comprehensive lakehouse migration
+    assessment report with effort scoring, complexity scoring, cost estimates,
+    and Iceberg DDL.
+
+    Bare invocation runs `assess` (backward compatible). Use `report` to generate
+    a report from a customer bundle produced by bq-collect.
+    """
+
+
+def _assess_options(f):
+    """Click options for the assess subcommand (registered once, here only)."""
+    options = [
+        click.option("--gcp-project", default=None, help="GCP project ID (required)."),
+        click.option("--credentials", default=None, help="Path to service account JSON."),
+        click.option("--use-adc", is_flag=True, default=False, help="Use Application Default Credentials."),
+        click.option("--datasets", default=None, help="Comma-separated dataset filter."),
+        click.option("--include-query-logs", is_flag=True, default=False, help="Analyze INFORMATION_SCHEMA.JOBS."),
+        click.option("--query-logs", default=None, help="Path to exported query logs JSON."),
+        click.option(
+            "--query-log-days",
+            type=click.IntRange(1, 90),
+            default=None,
+            help="Lookback window for INFORMATION_SCHEMA.JOBS in days (1-90, default: 30).",
+        ),
+        click.option("--bigquery-monthly-cost", type=float, default=None, help="Monthly BigQuery spend override."),
+        click.option("--reservation-config", default=None, help="Path to BigQuery reservation config YAML/JSON."),
+        click.option("--output", default=None, help="Output directory (default: reports/)."),
+        click.option("--format", "output_format", default=None, help="Output formats: json,html (default: json,html)."),
+        click.option("--interactive", is_flag=True, default=False, help="Interactive prompt mode."),
+        click.option(
+            "--export-bundle/--no-export-bundle", "export_bundle", default=True,
+            help="Write the re-processable bundle/ next to the report (default: enabled).",
+        ),
+        click.option(
+            "--exclude-query-text", is_flag=True, default=False,
+            help="Omit anonymized query statements from the bundle (privacy opt-out).",
+        ),
+        click.option("--concurrency", type=int, default=50, show_default=True, help="Max parallel API requests for metadata scanning."),
+        click.option("--skip-translation", is_flag=True, default=False, help="Skip SQL translation stage for faster runs."),
+        click.option("--skip-workload", is_flag=True, default=False, help="Skip workload analysis even when pricing is detected."),
+        click.option("--offline-pricing", is_flag=True, default=False, help="Skip live pricing lookup (use hardcoded rates)."),
+        click.option(
+            "--no-cache/--use-cache", "no_cache", default=True, show_default=True,
+            help="Force a fresh metadata scan (default — stale cached metadata produced wrong "
+                 "customer-facing numbers). Pass --use-cache to reuse cached metadata offline.",
+        ),
+        click.option("--config", default=None, help="Path to YAML config file."),
+    ]
+    for option in reversed(options):
+        f = option(f)
+    return f
+
+
+@main.command("assess")
+@_assess_options
+def assess_cmd(
+    gcp_project: str | None,
+    credentials: str | None,
+    use_adc: bool,
+    datasets: str | None,
+    include_query_logs: bool,
+    query_logs: str | None,
+    query_log_days: int | None,
+    bigquery_monthly_cost: float | None,
+    reservation_config: str | None,
+    output: str | None,
+    output_format: str | None,
+    interactive: bool,
+    export_bundle: bool,
+    exclude_query_text: bool,
+    concurrency: int,
+    skip_translation: bool,
+    skip_workload: bool,
+    offline_pricing: bool,
+    no_cache: bool,
+    config: str | None,
+) -> None:
+    """Full end-to-end assessment: scan the Source, analyze, write reports + bundle."""
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+
+    params = _build_params(
+        gcp_project=gcp_project, credentials=credentials, use_adc=use_adc,
+        datasets=datasets, include_query_logs=include_query_logs, query_logs=query_logs,
+        query_log_days=query_log_days, bigquery_monthly_cost=bigquery_monthly_cost,
+        reservation_config=reservation_config, output=output, output_format=output_format,
+        interactive=interactive, export_bundle=export_bundle,
+        exclude_query_text=exclude_query_text, concurrency=concurrency,
+        skip_translation=skip_translation, skip_workload=skip_workload,
+        offline_pricing=offline_pricing, no_cache=no_cache, config=config,
+    )
+
+    try:
+        _validate_collect_params(params)
+        _validate_report_params(params)
+        bundle = collect(params)
+        analyze_and_report(bundle, params)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Assessment interrupted by user.[/yellow]")
+        sys.exit(1)
+    except Exception as exc:
+        console.print(f"\n[red]Fatal error: {exc}[/red]")
+        logger.exception("Fatal error during assessment")
+        sys.exit(1)
+
+
+@main.command("report")
+@click.option(
+    "--bundle", "bundle_path", required=True,
+    help="Path to a bundle directory or .zip produced by bq-collect (or bq-assess assess).",
+)
+@click.option("--output", default=None, help="Output directory (default: reports/).")
+@click.option("--format", "output_format", default=None, help="Output formats: json,html (default: json,html).")
+@click.option("--bigquery-monthly-cost", type=float, default=None, help="Monthly BigQuery spend override.")
+@click.option("--skip-translation", is_flag=True, default=False, help="Skip SQL translation stage for faster runs.")
+@click.option(
+    "--refresh-pricing", is_flag=True, default=False,
+    help="Re-fetch live AWS/GCP rates instead of using the bundle's snapshot (needs network).",
+)
+@click.option(
+    "--export-bundle/--no-export-bundle", "export_bundle", default=False,
+    help="Re-write the bundle next to the report (default: off — the input bundle already exists).",
+)
+def report_cmd(
+    bundle_path: str,
+    output: str | None,
+    output_format: str | None,
+    bigquery_monthly_cost: float | None,
+    skip_translation: bool,
+    refresh_pricing: bool,
+    export_bundle: bool,
+) -> None:
+    """Generate the assessment report from a customer bundle — fully offline."""
+    logging.basicConfig(level=logging.WARNING)
+
+    params: dict = {
+        "output": output or "reports/",
+        "format": output_format or "json,html",
+        "export_bundle": export_bundle,
+        "refresh_pricing": refresh_pricing,
+    }
+    if bigquery_monthly_cost is not None:
+        params["bigquery_monthly_cost"] = bigquery_monthly_cost
+    if skip_translation:
+        params["skip_translation"] = True
+
+    console.print(f"\n[bold]Loading bundle:[/bold] {bundle_path}")
+    try:
+        loader = BundleLoader()
+        bundle = loader.load(bundle_path)
+    except BundleError as exc:
+        console.print(f"[red]✗ Bundle verification failed: {exc}[/red]")
+        sys.exit(1)
+
+    console.print(
+        f"[green]✓ Bundle verified[/green] — project '{bundle.project_id}', "
+        f"{len(bundle.entities)} entities, collected {bundle.created_at or 'unknown'} "
+        f"by collector v{bundle.collector_version or '?'} "
+        f"(region: {bundle.bq_location} → {bundle.aws_region})"
+    )
+
+    try:
+        analyze_and_report(bundle, params)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Report generation interrupted by user.[/yellow]")
+        sys.exit(1)
+    except Exception as exc:
+        console.print(f"\n[red]Fatal error: {exc}[/red]")
+        logger.exception("Fatal error during report generation")
+        sys.exit(1)
+
+
+def _build_params(**kwargs) -> dict:
+    """Merge CLI args, config file, and defaults into the params dict (CLI wins)."""
+    cli_params: dict = {}
+    if kwargs.get("gcp_project") is not None:
+        cli_params["gcp_project"] = kwargs["gcp_project"]
+    if kwargs.get("credentials") is not None:
+        cli_params["credentials"] = kwargs["credentials"]
+    if kwargs.get("use_adc"):
+        cli_params["use_adc"] = True
+    if kwargs.get("datasets") is not None:
+        cli_params["datasets"] = kwargs["datasets"]
+    if kwargs.get("include_query_logs"):
+        cli_params["include_query_logs"] = True
+    if kwargs.get("query_logs") is not None:
+        cli_params["query_logs"] = kwargs["query_logs"]
+    if kwargs.get("query_log_days") is not None:
+        cli_params["query_log_days"] = kwargs["query_log_days"]
+    if kwargs.get("bigquery_monthly_cost") is not None:
+        cli_params["bigquery_monthly_cost"] = kwargs["bigquery_monthly_cost"]
+    if kwargs.get("reservation_config") is not None:
+        cli_params["reservation_config"] = kwargs["reservation_config"]
+    if kwargs.get("output") is not None:
+        cli_params["output"] = kwargs["output"]
+    if kwargs.get("output_format") is not None:
+        cli_params["format"] = kwargs["output_format"]
+    if kwargs.get("interactive"):
+        cli_params["interactive"] = True
+    cli_params["export_bundle"] = kwargs.get("export_bundle", True)
+    if kwargs.get("exclude_query_text"):
+        cli_params["exclude_query_text"] = True
+    cli_params["concurrency"] = kwargs.get("concurrency", 50)
+    if kwargs.get("skip_translation"):
+        cli_params["skip_translation"] = True
+    if kwargs.get("skip_workload"):
+        cli_params["skip_workload"] = True
+    if kwargs.get("offline_pricing"):
+        cli_params["offline_pricing"] = True
+    # Always set (default True): fresh scan unless --use-cache was passed explicitly.
+    cli_params["no_cache"] = kwargs.get("no_cache", True)
+
+    # Load config file if provided
+    config_values: dict = {}
+    if kwargs.get("config"):
+        config_values = _load_config(kwargs["config"])
+
+    # Merge: CLI args > config file > defaults
+    params = _merge_config(cli_params, config_values)
+
+    params.setdefault("use_adc", False)
+    params.setdefault("include_query_logs", False)
+    params.setdefault("output", "reports/")
+    params.setdefault("format", "json,html")
+    params.setdefault("interactive", False)
+
+    if params.get("interactive"):
+        params = _interactive_prompts(params)
+
+    if not params.get("gcp_project"):
+        console.print(
+            "[red]Error: --gcp-project is required.[/red]\n"
+            "Provide it via CLI argument, config file, or use --interactive mode."
+        )
+        sys.exit(1)
+
+    if not params.get("credentials") and not params.get("use_adc"):
+        console.print(
+            "[red]Error: Either --credentials or --use-adc is required.[/red]\n"
+            "Provide a service account JSON path or enable Application Default Credentials."
+        )
+        sys.exit(1)
+
+    return params
+
+
+if __name__ == "__main__":
+    main()

--- a/solution-architecture/clis/bq-assess/src/bq_assess/collect_cli.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/collect_cli.py
@@ -1,0 +1,162 @@
+"""bq-collect — the customer-environment collector CLI.
+
+Runs ONLY the collection half of the pipeline (collector.collect) and writes the
+bundle. Ships as its own slim distribution (packaging/collector/) with no report,
+scoring, conversion, or engine code — see the 2026-07-08 collector/report design.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+
+from bq_assess import __version__
+from bq_assess.bundle import BundleWriter
+from bq_assess.collector import collect
+from bq_assess.core.disclaimer import CLI_ONE_LINER, DATA_HANDLING
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+@click.command("bq-collect")
+@click.version_option(__version__, message=f"bq-collect %(version)s (beta)\n{CLI_ONE_LINER}")
+@click.option("--gcp-project", required=True, help="GCP project ID.")
+@click.option("--credentials", default=None, help="Path to service account JSON.")
+@click.option("--use-adc", is_flag=True, default=False, help="Use Application Default Credentials.")
+@click.option("--datasets", default=None, help="Comma-separated dataset filter.")
+@click.option(
+    "--query-log-days",
+    type=click.IntRange(1, 90),
+    default=30,
+    show_default=True,
+    help="Lookback window for INFORMATION_SCHEMA.JOBS in days.",
+)
+@click.option("--reservation-config", default=None, help="Path to BigQuery reservation config YAML/JSON.")
+@click.option("--output", default="bundle-out/", show_default=True, help="Directory the bundle/ is written into.")
+@click.option(
+    "--exclude-query-text", is_flag=True, default=False,
+    help="Omit anonymized query statements from the bundle (privacy opt-out).",
+)
+@click.option("--concurrency", type=int, default=50, show_default=True, help="Max parallel API requests for metadata scanning.")
+@click.option("--skip-workload", is_flag=True, default=False, help="Skip workload analysis.")
+@click.option("--offline-pricing", is_flag=True, default=False, help="Skip the live pricing snapshot.")
+@click.option(
+    "--no-cache/--use-cache", "no_cache", default=True, show_default=True,
+    help="Force a fresh metadata scan. Pass --use-cache to reuse cached metadata.",
+)
+def main(
+    gcp_project: str,
+    credentials: str | None,
+    use_adc: bool,
+    datasets: str | None,
+    query_log_days: int,
+    reservation_config: str | None,
+    output: str,
+    exclude_query_text: bool,
+    concurrency: int,
+    skip_workload: bool,
+    offline_pricing: bool,
+    no_cache: bool,
+) -> None:
+    """Collect BigQuery metadata into a bundle for offline assessment.
+
+    Read-only: scans metadata, INFORMATION_SCHEMA statistics, and (unless
+    --exclude-query-text) anonymized query statements. Review the bundle
+    contents before transmitting them outside your environment.
+    """
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+
+    if credentials and use_adc:
+        console.print("[red]Error: --credentials and --use-adc are mutually exclusive[/red]")
+        sys.exit(1)
+    if not credentials and not use_adc:
+        console.print("[red]Error: provide --credentials or --use-adc[/red]")
+        sys.exit(1)
+
+    params: dict = {
+        "gcp_project": gcp_project,
+        "credentials": credentials,
+        "use_adc": use_adc,
+        "datasets": datasets,
+        "query_log_days": query_log_days,
+        "reservation_config": reservation_config,
+        "exclude_query_text": exclude_query_text,
+        "concurrency": concurrency,
+        "skip_workload": skip_workload,
+        "offline_pricing": offline_pricing,
+        "no_cache": no_cache,
+    }
+
+    # Load reservation config if provided (kept file-free inside collect())
+    if reservation_config:
+        try:
+            with open(reservation_config, encoding="utf-8") as f:
+                if reservation_config.endswith(".json"):
+                    import json
+                    params["reservation_config_data"] = json.load(f)
+                else:
+                    import yaml
+                    params["reservation_config_data"] = yaml.safe_load(f)
+            console.print(f"[green]✓ Loaded reservation config: {reservation_config}[/green]")
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Failed to load reservation config: {exc}[/yellow]")
+
+    try:
+        bundle = collect(params)
+
+        console.print("\n[bold]Writing bundle...[/bold]")
+        writer = BundleWriter()
+        bundle_dir = writer.write(bundle, output)
+        console.print(f"[green]✓ Bundle written: {bundle_dir}[/green]")
+
+        _print_collection_summary(bundle, bundle_dir)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Collection interrupted by user.[/yellow]")
+        sys.exit(1)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"\n[red]Fatal error: {exc}[/red]")
+        logger.exception("Fatal error during collection")
+        sys.exit(1)
+
+
+def _print_collection_summary(bundle, bundle_dir: str) -> None:
+    """Show what was collected and what is leaving the environment."""
+    console.print()
+    console.rule("[bold cyan]Collection Summary[/bold cyan]")
+    console.print(f"  Project:            {bundle.project_id}")
+    console.print(f"  Entities:           {len(bundle.entities)}")
+    console.print(f"  Region:             {bundle.bq_location} (AWS: {bundle.aws_region})")
+    console.print(f"  Workload data:      {'yes' if bundle.workload else 'no'}")
+    console.print(f"  Pricing detection:  {'yes' if bundle.pricing else 'no'}")
+    console.print(f"  Rate snapshot:      {'yes' if bundle.rates else 'no'}")
+    console.print(
+        f"  Query statements:   "
+        f"{len(bundle.queries) if bundle.queries else 'none (excluded or unavailable)'}"
+        f"{' — anonymized, literals stripped' if bundle.queries else ''}"
+    )
+    console.print(f"  Scan failures:      {len(bundle.failures)}")
+    console.print(f"  Storage basis:      {bundle.storage_basis}")
+
+    console.print(Panel.fit(
+        f"[bold]Next steps[/bold]\n"
+        f"1. Review the JSON files in [cyan]{bundle_dir}[/cyan] — everything the bundle\n"
+        f"   contains is plain text you can audit.\n"
+        f"2. Zip the directory and send it to your AWS contact:\n"
+        f"   [dim]cd {os.path.dirname(bundle_dir) or '.'} && zip -r bundle.zip {os.path.basename(bundle_dir)}/[/dim]\n\n"
+        f"[dim]{DATA_HANDLING}[/dim]",
+        border_style="cyan",
+    ))
+    console.print(f"\n[dim]{CLI_ONE_LINER}[/dim]\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/solution-architecture/clis/bq-assess/src/bq_assess/collector.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/collector.py
@@ -1,0 +1,371 @@
+"""Collection pipeline — every stage that touches the customer's GCP environment.
+
+``collect(params)`` runs credential validation, metadata scan, pricing detection,
+workload analysis, anonymized query collection, live-rate snapshotting, and physical-
+bytes resolution, and returns a ``Bundle``. It deliberately imports NOTHING from
+``report/``, ``scoring/``, ``targets/``, or ``engine/`` — the collector distribution
+ships this module (with ``core/`` and ``bundle/``) and must run without them.
+
+``bq-assess assess`` composes ``collect()`` with ``analyze_and_report()`` in-process;
+``bq-collect`` runs ``collect()`` alone and writes the bundle. One code path, two
+distributions (docs/superpowers/specs/2026-07-08-collector-report-split-design.md).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timezone
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+from rich.prompt import Confirm
+
+from bq_assess import __version__
+from bq_assess.bundle.models import Bundle, QueryRecord
+from bq_assess.core.scanner import BigQueryScanner
+from bq_assess.core.cache import MetadataCache
+from bq_assess.core.analyzer import QueryAnalyzer
+from bq_assess.core.pricing import PricingDetector
+from bq_assess.core.workload import WorkloadAnalyzer
+from bq_assess.core.region_mapping import bq_location_to_aws_region
+from bq_assess.core.storage_stats import resolve_physical_bytes, effective_physical_bytes, ASSUMED_PHYSICAL_RATIO
+from bq_assess.core.jobs_query import read_jobs_queries, QUERIES_EXPORT_LIMIT
+from bq_assess.core.price_lookup import (
+    PriceLookup,
+    PricingTimeout,
+    fetch_live_rates_with_timeout,
+    rates_to_dict,
+)
+from bq_assess.models import EntityMetadata, FailureRecord
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def collect(params: dict) -> Bundle:
+    """Run all GCP-touching stages and return the Bundle. Exits(1) on fatal errors."""
+    gcp_project: str = params["gcp_project"]
+    credentials: str | None = params.get("credentials")
+    use_adc: bool = params.get("use_adc", False)
+    datasets_str: str | None = params.get("datasets")
+    include_query_logs: bool = params.get("include_query_logs", False)
+    query_logs_path: str | None = params.get("query_logs")
+    query_log_days: int = int(params.get("query_log_days") or 30)
+    reservation_config: dict | None = params.get("reservation_config_data")
+    exclude_query_text: bool = params.get("exclude_query_text", False)
+
+    dataset_filter: list[str] | None = None
+    if datasets_str:
+        dataset_filter = [d.strip() for d in datasets_str.split(",") if d.strip()]
+
+    failures: list[FailureRecord] = []
+
+    # ── Stage 1: Validate credentials ──────────────────────────────
+    console.print("\n[bold]Stage 1:[/bold] Validating BigQuery credentials...")
+    scanner = BigQueryScanner(
+        project_id=gcp_project,
+        credentials_path=credentials,
+        use_adc=use_adc,
+        max_concurrent_requests=params.get("concurrency", 16),
+    )
+    if not scanner.validate_credentials():
+        console.print("[red]✗ Credential validation failed.[/red]")
+        sys.exit(1)
+    console.print("[green]✓ Credentials validated successfully.[/green]")
+
+    # ── Stage 2: Scan or load from cache ───────────────────────────
+    cache = MetadataCache()
+    entities: list[EntityMetadata] | None = None
+
+    if not params.get("no_cache") and cache.has_cache(gcp_project):
+        use_cache = True
+        if params.get("interactive"):
+            use_cache = Confirm.ask(
+                f"Cached metadata found for project '{gcp_project}'. Use cached data?",
+                default=True,
+            )
+        else:
+            console.print(f"[cyan]Using cached metadata for project '{gcp_project}'.[/cyan]")
+
+        if use_cache:
+            entities = cache.load(gcp_project)
+            if entities:
+                console.print(f"[green]✓ Loaded {len(entities)} entities from cache.[/green]")
+            else:
+                console.print("[yellow]⚠ Cache is empty — rescanning.[/yellow]")
+                entities = None
+
+    if entities is None:
+        console.print("\n[bold]Stage 2:[/bold] Scanning BigQuery metadata...")
+        scanned_entities = []
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Scanning entities...", total=None)
+            for entity_meta in scanner.scan(dataset_filter=dataset_filter):
+                scanned_entities.append(entity_meta)
+                progress.update(task, description=f"Scanned {len(scanned_entities)} entities...")
+
+        failures.extend(scanner.failures)
+
+        entities = scanned_entities
+        console.print(f"[green]✓ Scanned {len(entities)} entities.[/green]")
+        if scanner.failures:
+            console.print(f"[yellow]⚠ {len(scanner.failures)} entities failed to scan.[/yellow]")
+
+        if entities:
+            console.print("[bold]Caching metadata...[/bold]")
+            cache.store(gcp_project, entities)
+            console.print("[green]✓ Metadata cached.[/green]")
+
+    if not entities:
+        console.print("[red]No entities found. Nothing to assess.[/red]")
+        sys.exit(1)
+
+    # ── Stage 3: Pricing Detection ─────────────────────────────────
+    console.print("\n[bold]Stage 3:[/bold] Detecting BigQuery pricing model...")
+    pricing_detector = PricingDetector()
+    client = scanner._get_client()
+
+    # Detect the dataset region from scanned entities so JOBS queries hit the right location.
+    detected_location = _detect_dataset_location(client, entities)
+
+    try:
+        pricing = pricing_detector.detect(client, gcp_project, reservation_config, location=detected_location)
+        console.print(f"[green]✓ Detected pricing model: {pricing.model.value}[/green]")
+    except Exception as exc:
+        console.print(f"[yellow]⚠ Pricing detection failed: {exc}[/yellow]")
+        pricing = None
+
+    # ── Stage 4: Workload Analysis ─────────────────────────────────
+    # The live path reads HOURLY aggregates (≤ 24×days rows server-side) — bounded memory
+    # and wall-clock regardless of the Source's query volume.
+    console.print("\n[bold]Stage 4:[/bold] Analyzing workload...")
+    workload_analyzer = WorkloadAnalyzer()
+    slots = None
+    skip_workload = params.get("skip_workload", False)
+
+    try:
+        if skip_workload:
+            console.print("[yellow]⚠ Workload analysis skipped (--skip-workload).[/yellow]")
+        elif query_logs_path:
+            slots, _ = workload_analyzer.analyze_from_file(query_logs_path)
+            if slots:
+                console.print("[green]✓ Workload analyzed from file.[/green]")
+        elif include_query_logs or pricing:
+            if pricing and not include_query_logs:
+                console.print("[dim]  Pricing detected — auto-running workload analysis for accurate cost (skip with --skip-workload)...[/dim]")
+            slots, _ = workload_analyzer.analyze_from_api(client, gcp_project, days=query_log_days, location=detected_location)
+            if slots:
+                console.print(f"[green]✓ Workload analyzed from API (last {query_log_days} days).[/green]")
+    except Exception as exc:
+        console.print(f"[yellow]⚠ Workload analysis failed: {exc}[/yellow]")
+
+    if not slots:
+        console.print("[yellow]⚠ No workload data available - cost will be estimated as range.[/yellow]")
+
+    # ── Stage 5: Anonymized Query Collection ───────────────────────
+    # Default ON (design decision 2, amending R22.4): anonymized statements + per-job
+    # stats ride on queries.jsonl. Literals are stripped BEFORE anything touches disk.
+    # --skip-workload also skips this stage: both read INFORMATION_SCHEMA.JOBS, and
+    # the flag's promise is "no project-wide JOBS scans".
+    queries: list[QueryRecord] | None = None
+    if exclude_query_text:
+        console.print("\n[bold]Stage 5:[/bold] Query collection [yellow]skipped[/yellow] (--exclude-query-text).")
+    elif skip_workload and not query_logs_path:
+        console.print("\n[bold]Stage 5:[/bold] Query collection [yellow]skipped[/yellow] (--skip-workload covers all JOBS reads).")
+    else:
+        console.print("\n[bold]Stage 5:[/bold] Collecting anonymized query statements...")
+        truncated = False
+        try:
+            if query_logs_path:
+                queries = _queries_from_file(query_logs_path)
+            elif include_query_logs or pricing:
+                queries, truncated = _queries_from_api(
+                    client, gcp_project, query_log_days, detected_location
+                )
+        except Exception as exc:
+            console.print(f"[yellow]⚠ Query collection failed: {exc}[/yellow]")
+            queries = None
+
+        if queries:
+            console.print(f"[green]✓ Collected {len(queries)} anonymized statements (literals stripped).[/green]")
+            if truncated:
+                console.print(
+                    f"[yellow]⚠ Statement export capped at {QUERIES_EXPORT_LIMIT:,} "
+                    f"(heaviest by slot-ms kept).[/yellow]"
+                )
+        else:
+            queries = None
+            console.print("[dim]  No query statements available (missing permission or no workload).[/dim]")
+
+    # ── Stage 6: Region Detection + Rate Snapshot ──────────────────
+    console.print("\n[bold]Stage 6:[/bold] Snapshotting pricing rates...")
+    aws_region = bq_location_to_aws_region(detected_location)
+    console.print(f"[dim]  Source region: {detected_location} → AWS region: {aws_region}[/dim]")
+
+    rates_snapshot: dict | None = None
+    if not params.get("offline_pricing", False):
+        try:
+            price_lookup = PriceLookup(
+                aws_region=aws_region, bq_location=detected_location,
+                use_cache=not params.get("no_cache", True),
+            )
+            with console.status("[dim]Fetching live pricing from AWS/GCP APIs…[/dim]", spinner="dots"):
+                live_rates = fetch_live_rates_with_timeout(price_lookup, gcp_client=client)
+            rates_snapshot = rates_to_dict(live_rates)
+            if live_rates.is_live:
+                console.print(f"[green]✓ Live rates snapshotted (AWS: {live_rates.aws.fetched_at}, GCP: {live_rates.gcp.fetched_at}).[/green]")
+            elif live_rates.staleness_warning:
+                console.print(f"[yellow]⚠ {live_rates.staleness_warning}[/yellow]")
+            else:
+                console.print("[dim]  Using cached/hardcoded pricing rates.[/dim]")
+        except PricingTimeout as exc:
+            console.print(f"[yellow]⚠ {exc} — bundle will carry no live snapshot; report prices with region-adjusted hardcoded rates.[/yellow]")
+        except Exception as exc:
+            console.print(f"[dim]  Pricing snapshot skipped: {exc}[/dim]")
+    else:
+        console.print("[dim]  Live pricing lookup skipped (--offline-pricing).[/dim]")
+
+    # ── Stage 7: Physical Storage Resolution ───────────────────────
+    console.print("\n[bold]Stage 7:[/bold] Resolving physical storage bytes...")
+    try:
+        storage_stats = resolve_physical_bytes(
+            client, gcp_project, detected_location, entities
+        )
+        for entity in entities:
+            entity.physical_bytes = storage_stats.physical_map.get(entity.full_name)
+
+        if storage_stats.basis == "measured":
+            console.print("[green]✓ Physical bytes measured from TABLE_STORAGE.[/green]")
+        elif storage_stats.basis == "mixed":
+            console.print(f"[yellow]⚠ Partial TABLE_STORAGE coverage — {storage_stats.source_note}[/yellow]")
+        else:  # assumed
+            console.print(f"[yellow]⚠ TABLE_STORAGE unavailable — using {ASSUMED_PHYSICAL_RATIO}× logical fallback.[/yellow]")
+    except Exception as exc:
+        console.print(f"[yellow]⚠ Physical storage resolution failed: {exc}[/yellow]")
+        storage_stats = None
+    finally:
+        # Guarantee population even on failure — backfill any unpopulated physical_bytes
+        for entity in entities:
+            if entity.physical_bytes is None:
+                entity.physical_bytes = effective_physical_bytes(entity.num_bytes, None)
+
+    storage_basis = storage_stats.basis if storage_stats else "assumed"
+
+    return Bundle(
+        project_id=gcp_project,
+        bq_location=detected_location,
+        aws_region=aws_region,
+        entities=entities,
+        failures=failures,
+        workload=slots,
+        pricing=pricing,
+        rates=rates_snapshot,
+        queries=queries,
+        storage_basis=storage_basis,
+        collector_version=__version__,
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _queries_from_api(
+    client, project_id: str, days: int, location: str
+) -> tuple[list[QueryRecord], bool]:
+    """Read distinct statements from JOBS (bounded), anonymize BEFORE returning.
+
+    Returns ``(records, truncated)``. Reads limit+1 rows so truncation is PROVEN
+    from the RAW row count — empty-text rows are filtered out of the records, so
+    the caller's list length alone can't distinguish "hit the limit" from
+    "exactly at the limit" (review find: one empty-text group silently defeated
+    the boundary check).
+    """
+    analyzer = QueryAnalyzer()
+    rows = read_jobs_queries(
+        client, project_id, days=days, location=location,
+        limit=QUERIES_EXPORT_LIMIT + 1,
+    )
+    truncated = len(rows) > QUERIES_EXPORT_LIMIT
+    records: list[QueryRecord] = []
+    for row in rows:
+        text = _col(row, "query")
+        if not text:
+            continue
+        missing = _col(row, "missing_billed_jobs") or 0
+        billed = _col(row, "total_bytes_billed")
+        creation = _col(row, "creation_time")
+        records.append(QueryRecord(
+            query=analyzer.anonymize_query(text),
+            total_slot_ms=_col(row, "total_slot_ms") or 0,
+            total_bytes_processed=_col(row, "total_bytes_processed") or 0,
+            # Billed carried only when EVERY job in the statement group had the column —
+            # same all-or-nothing rule as the hourly workload read.
+            total_bytes_billed=billed if (billed is not None and not missing) else None,
+            statement_type=_col(row, "statement_type"),
+            creation_time=creation.isoformat() if isinstance(creation, datetime) else (str(creation) if creation else None),
+        ))
+    return records[:QUERIES_EXPORT_LIMIT], truncated
+
+
+def _queries_from_file(path: str) -> list[QueryRecord]:
+    """Extract per-job entries carrying query text from an exported query-log file.
+
+    Accepts the same formats as WorkloadAnalyzer.analyze_from_file (JSON array OR
+    JSONL) via the shared parser — the two stages read the same --query-logs file
+    and must never disagree on what parses.
+    """
+    from pathlib import Path as _Path
+
+    from bq_assess.core.workload import parse_json_or_jsonl
+
+    analyzer = QueryAnalyzer()
+    try:
+        text = _Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    data = parse_json_or_jsonl(text)
+    if not data:
+        return []
+
+    records: list[QueryRecord] = []
+    for entry in data:
+        if not isinstance(entry, dict) or not entry.get("query"):
+            continue
+        billed = entry.get("total_bytes_billed")
+        records.append(QueryRecord(
+            query=analyzer.anonymize_query(entry["query"]),
+            total_slot_ms=int(entry.get("total_slot_ms") or 0),
+            total_bytes_processed=int(entry.get("total_bytes_processed") or 0),
+            total_bytes_billed=int(billed) if billed is not None else None,
+            statement_type=entry.get("statement_type"),
+            creation_time=str(entry["creation_time"]) if entry.get("creation_time") else None,
+        ))
+    return records
+
+
+def _col(row, key):
+    """Read a column from a dict (tests/files) or a BigQuery Row (live)."""
+    return row.get(key) if isinstance(row, dict) else getattr(row, key, None)
+
+
+def _detect_dataset_location(client, entities: list[EntityMetadata]) -> str:
+    """Return the BigQuery region of the scanned datasets (for JOBS queries).
+
+    Falls back to "US" if no dataset can be resolved — matches the previous default.
+    """
+    seen: set[str] = set()
+    for e in entities:
+        if e.dataset_id not in seen:
+            seen.add(e.dataset_id)
+            try:
+                ds = client.get_dataset(f"{client.project}.{e.dataset_id}")
+                if ds.location:
+                    return ds.location
+            except Exception:  # nosec B112 - best-effort location probe; fall through to next dataset
+                continue
+    return "US"

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core source-side modules: scanning, caching, analysis, relationships."""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/analyzer.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/analyzer.py
@@ -1,0 +1,400 @@
+"""Query log analyzer for BigQuery migration assessment.
+
+Analyzes BigQuery query logs (from INFORMATION_SCHEMA.JOBS or exported JSON)
+to extract table usage patterns, JOIN relationships, WHERE columns, and hub
+tables for DISTKEY/SORTKEY recommendations.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass
+class JoinPattern:
+    """A detected JOIN pattern between two tables."""
+
+    left_table: str
+    right_table: str
+    join_column: str
+    frequency: int
+
+
+@dataclass
+class WorkloadMetrics:
+    """Workload characteristics extracted from query logs."""
+
+    total_queries: int
+    avg_daily_queries: float
+    peak_hourly_queries: int
+    total_bytes_processed: int
+    avg_bytes_per_query: float
+    distinct_query_hours: int  # hours with at least one query (out of 24*days)
+    query_days_sampled: int
+
+
+@dataclass
+class QueryAnalysis:
+    """Results of query log analysis."""
+
+    table_query_counts: dict[str, int]
+    join_patterns: dict[str, list[JoinPattern]]
+    where_columns: dict[str, list[str]]
+    hub_tables: list[str]
+    anonymized: bool
+    workload_metrics: WorkloadMetrics | None = None
+
+
+class AnalyzerError(Exception):
+    """Raised when query analysis fails."""
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns for SQL parsing
+# ---------------------------------------------------------------------------
+
+# String literals: single-quoted values (handles escaped quotes)
+_STRING_LITERAL_RE = re.compile(r"'[^']*'")
+
+# Numeric literals after operators / keywords — avoids replacing numbers in
+# identifiers.  Matches integers and decimals that follow an operator, comma,
+# opening paren, or the keywords BETWEEN / AND / IN / LIMIT / OFFSET / THEN.
+_NUMERIC_LITERAL_RE = re.compile(
+    r"(?<=[\s=><!(,+\-*/])\d+\.?\d*(?=[\s,);]|$)"
+)
+
+# FROM / JOIN table references  (handles optional project.dataset.table)
+_TABLE_REF_RE = re.compile(
+    r"(?:FROM|JOIN)\s+`?([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+){0,2})`?",
+    re.IGNORECASE,
+)
+
+# JOIN … ON pattern:
+#   JOIN <table> ON <alias>.<col> = <alias>.<col>
+_JOIN_PATTERN_RE = re.compile(
+    r"JOIN\s+`?([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+){0,2})`?"
+    r"\s+(?:AS\s+)?(\w+)?\s*ON\s+"
+    r"(\w+)\.(\w+)\s*=\s*(\w+)\.(\w+)",
+    re.IGNORECASE,
+)
+
+# WHERE column references: WHERE <col> <op> or AND/OR <col> <op>
+_WHERE_COL_RE = re.compile(
+    r"(?:WHERE|AND|OR)\s+(\w+)\.?(\w+)?\s*(?:=|!=|<>|>=|<=|>|<|IN|LIKE|BETWEEN|IS)",
+    re.IGNORECASE,
+)
+
+
+class QueryAnalyzer:
+    """Analyzes BigQuery query logs for migration recommendations."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def analyze_from_api(
+        self,
+        client,  # google.cloud.bigquery.Client
+        project_id: str,
+        days: int = 30,
+    ) -> QueryAnalysis:
+        """Read and analyze query logs from INFORMATION_SCHEMA.JOBS.
+
+        Requires the ``bigquery.jobs.listAll`` permission at the project level.
+
+        Parameters
+        ----------
+        client:
+            An authenticated ``google.cloud.bigquery.Client``.
+        project_id:
+            GCP project whose query logs should be analysed.
+        days:
+            Number of days of history to read (default 30).
+
+        Returns
+        -------
+        QueryAnalysis
+            Aggregated analysis of the query logs.
+
+        Raises
+        ------
+        AnalyzerError
+            If the query fails (e.g. missing ``bigquery.jobs.listAll``).
+        """
+        sql = (
+            f"SELECT query, total_bytes_processed, creation_time "
+            f"FROM `{project_id}`.`region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT "
+            f"WHERE job_type = 'QUERY' "
+            f"AND state = 'DONE' "
+            f"AND creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days} DAY) "
+            f"AND statement_type != 'SCRIPT'"
+        )
+
+        try:
+            rows = client.query(sql).result()
+        except Exception as exc:
+            msg = str(exc)
+            if "Access Denied" in msg or "403" in msg or "permission" in msg.lower():
+                raise AnalyzerError(
+                    f"Missing required permission 'bigquery.jobs.listAll' on project '{project_id}'. "
+                    "This permission is needed to read query logs from INFORMATION_SCHEMA.JOBS. "
+                    "To fix this, either:\n"
+                    "  1. Grant the 'bigquery.jobs.listAll' permission to your service account, or\n"
+                    "  2. Export query logs manually and provide them via the --query-logs option."
+                ) from exc
+            raise AnalyzerError(
+                f"Failed to read query logs from INFORMATION_SCHEMA.JOBS: {msg}"
+            ) from exc
+
+        queries: list[str] = []
+        bytes_processed_list: list[int] = []
+        creation_times: list[datetime] = []
+        for row in rows:
+            query_text = row.query if hasattr(row, "query") else row[0]
+            if query_text:
+                queries.append(query_text)
+            bp = row.total_bytes_processed if hasattr(row, "total_bytes_processed") else row[1]
+            bytes_processed_list.append(bp or 0)
+            ct = row.creation_time if hasattr(row, "creation_time") else row[2]
+            if ct:
+                creation_times.append(ct)
+
+        workload = self._compute_workload_metrics(
+            bytes_processed_list, creation_times, days
+        )
+        result = self._analyze_queries(queries)
+        result.workload_metrics = workload
+        return result
+
+    def analyze_from_file(self, file_path: str) -> QueryAnalysis:
+        """Read and analyze query logs from an exported JSON file.
+
+        Expected format: a JSON array of objects, each with at least a
+        ``"query"`` field containing the SQL text.
+
+        Parameters
+        ----------
+        file_path:
+            Path to the exported JSON query log file.
+
+        Returns
+        -------
+        QueryAnalysis
+            Aggregated analysis of the query logs.
+
+        Raises
+        ------
+        AnalyzerError
+            If the file cannot be read or parsed.
+        """
+        path = Path(file_path)
+        if not path.exists():
+            raise AnalyzerError(f"Query log file not found: {file_path}")
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise AnalyzerError(
+                f"Failed to parse query log file '{file_path}': {exc}"
+            ) from exc
+
+        if not isinstance(data, list):
+            raise AnalyzerError(
+                f"Expected a JSON array in '{file_path}', got {type(data).__name__}"
+            )
+
+        queries: list[str] = []
+        bytes_processed_list: list[int] = []
+        creation_times: list[datetime] = []
+        for entry in data:
+            if isinstance(entry, dict) and entry.get("query"):
+                queries.append(entry["query"])
+                bp = entry.get("total_bytes_processed", 0)
+                bytes_processed_list.append(int(bp) if bp else 0)
+                ct = entry.get("creation_time")
+                if ct:
+                    try:
+                        creation_times.append(
+                            datetime.fromisoformat(str(ct))
+                        )
+                    except (ValueError, TypeError):
+                        pass
+
+        workload = self._compute_workload_metrics(
+            bytes_processed_list, creation_times, days=30
+        ) if bytes_processed_list else None
+
+        result = self._analyze_queries(queries)
+        result.workload_metrics = workload
+        return result
+
+    def anonymize_query(self, query_text: str) -> str:
+        """Replace literal values with placeholders.
+
+        - Single-quoted string literals → ``'?'``
+        - Numeric literals (integers and floats) appearing after operators
+          or SQL keywords → ``?``
+
+        Table and column names containing digits are preserved.
+        """
+        # First replace string literals
+        result = _STRING_LITERAL_RE.sub("'?'", query_text)
+        # Then replace numeric literals
+        result = _NUMERIC_LITERAL_RE.sub("?", result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_workload_metrics(
+        bytes_processed: list[int],
+        creation_times: list[datetime],
+        days: int,
+    ) -> WorkloadMetrics:
+        """Derive workload characteristics from raw job metadata."""
+        total_queries = len(bytes_processed)
+        total_bytes = sum(bytes_processed)
+        avg_bytes = total_bytes / max(total_queries, 1)
+        avg_daily = total_queries / max(days, 1)
+
+        # Count queries per hour-bucket and distinct active hours
+        hourly_counts: dict[str, int] = defaultdict(int)
+        for ct in creation_times:
+            bucket = ct.strftime("%Y-%m-%d-%H")
+            hourly_counts[bucket] += 1
+
+        peak_hourly = max(hourly_counts.values()) if hourly_counts else 0
+        distinct_hours = len(hourly_counts)
+
+        return WorkloadMetrics(
+            total_queries=total_queries,
+            avg_daily_queries=round(avg_daily, 1),
+            peak_hourly_queries=peak_hourly,
+            total_bytes_processed=total_bytes,
+            avg_bytes_per_query=round(avg_bytes, 0),
+            distinct_query_hours=distinct_hours,
+            query_days_sampled=days,
+        )
+
+    def _analyze_queries(self, queries: list[str]) -> QueryAnalysis:
+        """Shared analysis logic for both API and file-based query sources."""
+        table_query_counts: dict[str, int] = defaultdict(int)
+        join_counts: dict[tuple[str, str, str], int] = defaultdict(int)
+        where_cols: dict[str, set[str]] = defaultdict(set)
+
+        for raw_query in queries:
+            query = self.anonymize_query(raw_query)
+            self._extract_table_refs(query, table_query_counts)
+            self._extract_join_patterns(query, join_counts)
+            self._extract_where_columns(query, where_cols)
+
+        # Build JoinPattern objects grouped by left table
+        join_patterns: dict[str, list[JoinPattern]] = defaultdict(list)
+        for (left, right, col), freq in join_counts.items():
+            join_patterns[left].append(
+                JoinPattern(
+                    left_table=left,
+                    right_table=right,
+                    join_column=col,
+                    frequency=freq,
+                )
+            )
+
+        # Convert where_cols sets to sorted lists
+        where_columns: dict[str, list[str]] = {
+            t: sorted(cols) for t, cols in where_cols.items()
+        }
+
+        # Hub tables: tables with > 5 distinct join partners
+        join_partners: dict[str, set[str]] = defaultdict(set)
+        for (left, right, _col) in join_counts:
+            join_partners[left].add(right)
+            join_partners[right].add(left)
+
+        hub_tables = sorted(
+            t for t, partners in join_partners.items() if len(partners) > 5
+        )
+
+        return QueryAnalysis(
+            table_query_counts=dict(table_query_counts),
+            join_patterns=dict(join_patterns),
+            where_columns=where_columns,
+            hub_tables=hub_tables,
+            anonymized=True,
+        )
+
+    @staticmethod
+    def _extract_table_refs(
+        query: str, counts: dict[str, int]
+    ) -> None:
+        """Extract table references from FROM and JOIN clauses."""
+        for match in _TABLE_REF_RE.finditer(query):
+            table_name = match.group(1)
+            # Normalise: take the last two parts (dataset.table) if fully qualified
+            parts = table_name.split(".")
+            if len(parts) >= 2:
+                table_name = f"{parts[-2]}.{parts[-1]}"
+            counts[table_name] += 1
+
+    @staticmethod
+    def _extract_join_patterns(
+        query: str, counts: dict[tuple[str, str, str], int]
+    ) -> None:
+        """Extract JOIN … ON patterns.
+
+        We extract the right-side table from the JOIN clause and the join
+        column from the ON condition.  The left table is inferred from the
+        first FROM clause in the query.
+        """
+        # Determine the "left" (driving) table from the FROM clause
+        from_match = re.search(
+            r"\bFROM\s+`?([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+){0,2})`?",
+            query,
+            re.IGNORECASE,
+        )
+        left_table = ""
+        if from_match:
+            parts = from_match.group(1).split(".")
+            left_table = f"{parts[-2]}.{parts[-1]}" if len(parts) >= 2 else parts[-1]
+
+        for match in _JOIN_PATTERN_RE.finditer(query):
+            right_table = match.group(1)
+            parts = right_table.split(".")
+            if len(parts) >= 2:
+                right_table = f"{parts[-2]}.{parts[-1]}"
+
+            # The ON clause has alias.col = alias.col — use the column name
+            col_left = match.group(4)
+            col_right = match.group(6)
+            # Use the column from the right side of the join as the join column
+            join_col = col_right if col_left != col_right else col_left
+            counts[(left_table, right_table, join_col)] += 1
+
+    @staticmethod
+    def _extract_where_columns(
+        query: str, where_cols: dict[str, set[str]]
+    ) -> None:
+        """Extract columns referenced in WHERE clauses."""
+        # Find the WHERE clause portion
+        where_match = re.search(r"\bWHERE\b", query, re.IGNORECASE)
+        if not where_match:
+            return
+
+        where_clause = query[where_match.start():]
+        for match in _WHERE_COL_RE.finditer(where_clause):
+            # group(1) is the table alias or column, group(2) is the column if dotted
+            if match.group(2):
+                table_or_alias = match.group(1)
+                col = match.group(2)
+                where_cols[table_or_alias].add(col)
+            else:
+                col = match.group(1)
+                # Without a table qualifier, store under a generic key
+                where_cols["_unqualified"].add(col)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/cache.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/cache.py
@@ -1,0 +1,240 @@
+"""SQLite-based local metadata cache for scanned EntityMetadata (R5).
+
+Stores all scanned metadata — entity type, population, nested columns, BOTH partitionings,
+view/mview SQL, routines, and depends_on — so the Assessment can be regenerated offline
+without re-scanning the Source (R5.3). Schema follows design.md § SQLite Cache Schema.
+
+store/load round-trip is structurally lossless (R5.4 / property P8, owned by issue #10).
+Issue #9 / 1.4.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    RangePartitionConfig,
+    RoutineMetadata,
+    TimePartitionConfig,
+)
+
+_CREATE_SCAN_METADATA = """\
+CREATE TABLE IF NOT EXISTS scan_metadata (
+    project_id   TEXT PRIMARY KEY,
+    scanned_at   TIMESTAMP NOT NULL,
+    entity_count INTEGER  NOT NULL
+);
+"""
+
+_CREATE_ENTITIES = """\
+CREATE TABLE IF NOT EXISTS entities (
+    project_id        TEXT NOT NULL,
+    dataset_id        TEXT NOT NULL,
+    entity_id         TEXT NOT NULL,
+    full_name         TEXT NOT NULL,
+    entity_type       TEXT NOT NULL,
+    population        TEXT NOT NULL,
+    num_rows          INTEGER,
+    num_bytes         INTEGER,
+    columns_json      TEXT NOT NULL,
+    time_part_json    TEXT,
+    range_part_json   TEXT,
+    clustering_json   TEXT,
+    view_query        TEXT,
+    mview_query       TEXT,
+    routine_json      TEXT,
+    depends_on_json   TEXT,
+    last_modified     TIMESTAMP,
+    PRIMARY KEY (project_id, dataset_id, entity_id)
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# (De)serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _column_schema_to_dict(col: ColumnSchema) -> dict:
+    """Recursively serialize a ColumnSchema (nesting preserved)."""
+    return {
+        "name": col.name,
+        "field_type": col.field_type,
+        "mode": col.mode,
+        "fields": [_column_schema_to_dict(f) for f in col.fields],
+    }
+
+
+def _dict_to_column_schema(d: dict) -> ColumnSchema:
+    """Recursively deserialize a dict back to a ColumnSchema."""
+    return ColumnSchema(
+        name=d["name"],
+        field_type=d["field_type"],
+        mode=d["mode"],
+        fields=[_dict_to_column_schema(f) for f in d.get("fields", [])],
+    )
+
+
+def _routine_to_dict(r: RoutineMetadata) -> dict:
+    return {
+        "name": r.name,
+        "language": r.language,
+        "arguments": list(r.arguments),
+        "body": r.body,
+        "routine_type": r.routine_type,
+    }
+
+
+def _dict_to_routine(d: dict) -> RoutineMetadata:
+    return RoutineMetadata(
+        name=d["name"],
+        language=d["language"],
+        arguments=list(d.get("arguments", [])),
+        body=d["body"],
+        routine_type=d["routine_type"],
+    )
+
+
+class MetadataCache:
+    """SQLite-based local storage for scanned EntityMetadata."""
+
+    def __init__(self, db_path: str = ".bq-assess-cache.db") -> None:
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute("PRAGMA journal_mode=WAL;")
+        self._conn.execute(_CREATE_SCAN_METADATA)
+        self._conn.execute(_CREATE_ENTITIES)
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def store(self, project_id: str, entities: list[EntityMetadata]) -> None:
+        """Store scanned metadata, replacing any existing data for the project (R5.1)."""
+        cur = self._conn.cursor()
+        cur.execute("DELETE FROM entities WHERE project_id = ?", (project_id,))
+        cur.execute("DELETE FROM scan_metadata WHERE project_id = ?", (project_id,))
+
+        for e in entities:
+            cur.execute(
+                "INSERT INTO entities "
+                "(project_id, dataset_id, entity_id, full_name, entity_type, population, "
+                "num_rows, num_bytes, columns_json, time_part_json, range_part_json, "
+                "clustering_json, view_query, mview_query, routine_json, depends_on_json, "
+                "last_modified) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    project_id,
+                    e.dataset_id,
+                    e.entity_id,
+                    e.full_name,
+                    e.entity_type.value,
+                    e.population.value,
+                    e.num_rows,
+                    e.num_bytes,
+                    json.dumps([_column_schema_to_dict(c) for c in e.columns]),
+                    self._dump_time_part(e.time_partitioning),
+                    self._dump_range_part(e.range_partitioning),
+                    json.dumps(e.clustering_fields) if e.clustering_fields is not None else None,
+                    e.view_query,
+                    e.mview_query,
+                    json.dumps(_routine_to_dict(e.routine)) if e.routine is not None else None,
+                    json.dumps(e.depends_on),
+                    e.last_modified.isoformat() if e.last_modified is not None else None,
+                ),
+            )
+
+        cur.execute(
+            "INSERT INTO scan_metadata (project_id, scanned_at, entity_count) VALUES (?, ?, ?)",
+            (project_id, datetime.now(timezone.utc).isoformat(), len(entities)),
+        )
+        self._conn.commit()
+
+    def load(self, project_id: str) -> list[EntityMetadata] | None:
+        """Load cached metadata for a project; None if no cache exists (R5.3)."""
+        if not self.has_cache(project_id):
+            return None
+
+        cur = self._conn.cursor()
+        cur.execute(
+            "SELECT dataset_id, entity_id, full_name, entity_type, population, num_rows, "
+            "num_bytes, columns_json, time_part_json, range_part_json, clustering_json, "
+            "view_query, mview_query, routine_json, depends_on_json, last_modified "
+            "FROM entities WHERE project_id = ?",
+            (project_id,),
+        )
+
+        result: list[EntityMetadata] = []
+        for row in cur.fetchall():
+            (
+                dataset_id, entity_id, full_name, entity_type, population, num_rows,
+                num_bytes, columns_json, time_part_json, range_part_json, clustering_json,
+                view_query, mview_query, routine_json, depends_on_json, last_modified_str,
+            ) = row
+
+            result.append(EntityMetadata(
+                entity_id=entity_id,
+                dataset_id=dataset_id,
+                full_name=full_name,
+                entity_type=EntityType(entity_type),
+                population=EntityPopulation(population),
+                num_rows=num_rows,
+                num_bytes=num_bytes,
+                columns=[_dict_to_column_schema(d) for d in json.loads(columns_json)],
+                time_partitioning=self._load_time_part(time_part_json),
+                range_partitioning=self._load_range_part(range_part_json),
+                clustering_fields=json.loads(clustering_json) if clustering_json is not None else None,
+                view_query=view_query,
+                mview_query=mview_query,
+                routine=_dict_to_routine(json.loads(routine_json)) if routine_json is not None else None,
+                depends_on=json.loads(depends_on_json) if depends_on_json is not None else [],
+                last_modified=datetime.fromisoformat(last_modified_str) if last_modified_str else None,
+            ))
+
+        return result
+
+    def has_cache(self, project_id: str) -> bool:
+        """Check if cached data exists for a project (R5.2)."""
+        cur = self._conn.cursor()
+        cur.execute("SELECT 1 FROM scan_metadata WHERE project_id = ? LIMIT 1", (project_id,))
+        return cur.fetchone() is not None
+
+    # ------------------------------------------------------------------
+    # Partition (de)serialization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _dump_time_part(tp: TimePartitionConfig | None) -> str | None:
+        if tp is None:
+            return None
+        return json.dumps({"type": tp.type, "field": tp.field})
+
+    @staticmethod
+    def _load_time_part(raw: str | None) -> TimePartitionConfig | None:
+        if raw is None:
+            return None
+        d = json.loads(raw)
+        return TimePartitionConfig(type=d["type"], field=d["field"])
+
+    @staticmethod
+    def _dump_range_part(rp: RangePartitionConfig | None) -> str | None:
+        if rp is None:
+            return None
+        return json.dumps(
+            {"field": rp.field, "start": rp.start, "end": rp.end, "interval": rp.interval}
+        )
+
+    @staticmethod
+    def _load_range_part(raw: str | None) -> RangePartitionConfig | None:
+        if raw is None:
+            return None
+        d = json.loads(raw)
+        return RangePartitionConfig(
+            field=d["field"], start=d["start"], end=d["end"], interval=d["interval"]
+        )

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/classifier.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/classifier.py
@@ -1,0 +1,45 @@
+"""Entity classifier — EntityType → EntityPopulation (Table vs View/MV/UDF).
+
+Canonical, single source of truth for the population partition (R4.1-R4.3, property P5):
+- TABLE / EXTERNAL  → population TABLE   (entities that *move*; scored on both axes)
+- VIEW / MATERIALIZED_VIEW / ROUTINE → population REBUILT  (rebuilt; Query Complexity only)
+
+The mapping is **total** (every EntityType maps) and **disjoint** (exactly one population).
+
+Issue #7 / 1.2. NOTE: ``core/scanner.py`` (#6) currently carries a local ``population_for``
+helper; once both land on main it should delegate to ``classify_population`` here so there
+is one definition (see SCRUM_NOTES).
+"""
+
+from __future__ import annotations
+
+from bq_assess.models import EntityPopulation, EntityType
+
+# The entity types whose migration means *moving data* into the Storage Target (R4.2).
+# Everything else is *rebuilt* SQL behavior (R4.3). Kept as an explicit frozenset so the
+# partition is obvious and exhaustively testable.
+_TABLE_POPULATION_TYPES: frozenset[EntityType] = frozenset(
+    {EntityType.TABLE, EntityType.EXTERNAL}
+)
+
+
+def classify_population(entity_type: EntityType) -> EntityPopulation:
+    """Return the EntityPopulation for an EntityType (total, disjoint partition).
+
+    TABLE / EXTERNAL → ``EntityPopulation.TABLE``; VIEW / MATERIALIZED_VIEW / ROUTINE →
+    ``EntityPopulation.REBUILT`` (R4.2/R4.3). Raises ``TypeError`` if given something that
+    is not an ``EntityType``, so an unmapped future enum member fails loudly rather than
+    silently defaulting.
+    """
+    if not isinstance(entity_type, EntityType):
+        raise TypeError(f"expected EntityType, got {type(entity_type).__name__}")
+    return (
+        EntityPopulation.TABLE
+        if entity_type in _TABLE_POPULATION_TYPES
+        else EntityPopulation.REBUILT
+    )
+
+
+def is_table_population(entity_type: EntityType) -> bool:
+    """Convenience predicate: True iff *entity_type* belongs to the TABLE population."""
+    return entity_type in _TABLE_POPULATION_TYPES

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/disclaimer.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/disclaimer.py
@@ -1,0 +1,50 @@
+"""Single source of truth for beta/legal disclaimers (both distributions)."""
+
+DISCLAIMER_VERSION = 1
+
+BETA_STATUS = (
+    "This tool is in beta. Features, scoring models, and cost calculations are under "
+    "active development and may change without notice. Results should be independently "
+    "validated before being used for planning or budgeting decisions."
+)
+
+COST_NOT_QUOTE = (
+    "All cost figures are directional estimates based on published list pricing, "
+    "detected or assumed usage patterns, and stated assumptions at the time of "
+    "generation. They are not a quote, offer, or commitment from Amazon Web Services "
+    "or Google. Actual costs depend on final architecture, negotiated pricing, usage, "
+    "and region. Refer to official AWS and Google Cloud pricing for authoritative rates."
+)
+
+ADVISORY_GUIDANCE = (
+    "Migration effort scores, complexity classifications, generated DDL/DML, SQL "
+    "translations, and placement recommendations are automated, best-effort guidance. "
+    "They do not replace engineering review. Validate all generated code and "
+    "recommendations before use in any environment."
+)
+
+AS_IS = (
+    'This software is provided "AS IS", without warranties or conditions of any kind, '
+    "express or implied, per the Apache License 2.0. Use at your own risk."
+)
+
+DATA_HANDLING = (
+    "This tool performs read-only operations against BigQuery metadata and "
+    "INFORMATION_SCHEMA. It does not read table data contents. The output bundle "
+    "contains schema metadata, aggregated workload statistics, and anonymized query "
+    "text (literals stripped; disable with --exclude-query-text). You are responsible "
+    "for reviewing bundle contents before transmitting them outside your environment."
+)
+
+FULL_DISCLAIMER = "\n\n".join([
+    BETA_STATUS,
+    COST_NOT_QUOTE,
+    ADVISORY_GUIDANCE,
+    AS_IS,
+    DATA_HANDLING,
+])
+
+CLI_ONE_LINER = (
+    "⚠ BETA — estimates are directional, not a pricing quote. "
+    "See report footer for full disclaimer."
+)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/jobs_query.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/jobs_query.py
@@ -1,0 +1,177 @@
+"""Shared INFORMATION_SCHEMA.JOBS reader for the cost-input modules (R16/R17).
+
+``PricingDetector`` (5.1) and ``WorkloadAnalyzer`` (5.2) both read project-wide job history
+from BigQuery; this is the single place that builds the query and runs it, so the
+project/region qualification, the completed-query lookback filter, and the SCRIPT exclusion
+are defined once.
+
+Two corrections this consolidates (5.x review):
+- Uses ``INFORMATION_SCHEMA.JOBS_BY_PROJECT`` — the **whole-project** view — not the bare
+  ``JOBS`` alias, which is ``JOBS_BY_USER`` and returns only the *calling identity's* jobs. A
+  service account that did not submit the workload would otherwise see an empty job log and the
+  Source would be silently mis-assessed (false on-demand / no workload).
+- Always applies ``job_type='QUERY' AND state='DONE'`` and a ``creation_time`` lookback bound,
+  matching the legacy ``analyzer.py`` idiom; the caller supplies only the SELECT list.
+
+Degrades to ``[]`` on any error (e.g. missing ``bigquery.jobs.listAll``) — the callers treat
+no-signal as no-data and never raise (R16.3 / R17.3).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from google.api_core.exceptions import GoogleAPICallError
+
+from bq_assess.core import pricing_constants as k
+
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_CODES = {429, 500, 503}
+_MAX_RETRIES = 3
+_INITIAL_DELAY = 1.0
+
+DEFAULT_LOOKBACK_DAYS = 30
+
+
+def read_jobs(
+    client,
+    project_id: str,
+    select_clause: str,
+    *,
+    days: int = DEFAULT_LOOKBACK_DAYS,
+    location: str = "US",
+    group_by: str | None = None,
+) -> list:
+    """Run ``<select_clause> FROM <project>.<region>.JOBS_BY_PROJECT WHERE <completed-query>``.
+
+    ``select_clause`` is the full ``SELECT col, ...`` the caller needs (e.g.
+    ``"SELECT reservation_id, edition, statement_type"``). ``group_by`` appends
+    ``GROUP BY <expr>`` after the shared WHERE. Returns the row list, or ``[]`` if
+    the query cannot be run — never raises.
+    """
+    sql = (
+        f"{select_clause} "
+        f"FROM `{project_id}`.`region-{location.lower()}`.INFORMATION_SCHEMA.JOBS_BY_PROJECT "
+        f"WHERE job_type = 'QUERY' AND state = 'DONE' "
+        f"AND creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {int(days)} DAY) "
+        f"AND {k.V5_JOBS_STATEMENT_TYPE_COLUMN} != '{k.V5_JOBS_SCRIPT_STATEMENT_TYPE}'"
+    )
+    if group_by:
+        sql += f" GROUP BY {group_by}"
+    try:
+        return list(_retry_query(lambda: client.query(sql).result()))
+    except Exception as exc:  # missing perms / any error → no signal, not a failure
+        logger.warning("Could not read INFORMATION_SCHEMA.JOBS_BY_PROJECT: %s", exc)
+        return []
+
+
+def read_jobs_hourly(
+    client,
+    project_id: str,
+    *,
+    days: int = DEFAULT_LOOKBACK_DAYS,
+    location: str = "US",
+) -> list:
+    """Read the workload as HOURLY aggregates — ≤ 24×days rows regardless of query volume.
+
+    BigQuery collapses per-job rows server-side into the same UTC-hour buckets
+    ``WorkloadAnalyzer._compute`` previously built in Python, so a Source running millions
+    of queries/month costs the client ≤720 rows instead of a multi-GB row stream (the
+    10 PB-scale OOM found in the 2026-07-08 storm audit). ``missing_billed_jobs`` preserves
+    the all-or-nothing ``has_billed_bytes`` semantics: any NULL ``total_bytes_billed`` in
+    the window degrades the whole window to the processed-bytes fallback, exactly as the
+    per-job path did. Returns ``[]`` on any error — never raises (R17.3).
+    """
+    select = (
+        "SELECT TIMESTAMP_TRUNC(creation_time, HOUR) AS hour_bucket, "
+        "SUM(total_slot_ms) AS total_slot_ms, "
+        "COUNT(*) AS job_count, "
+        "SUM(total_bytes_processed) AS total_bytes_processed, "
+        "SUM(total_bytes_billed) AS total_bytes_billed, "
+        "COUNTIF(total_bytes_billed IS NULL) AS missing_billed_jobs"
+    )
+    return read_jobs(
+        client, project_id, select,
+        days=days, location=location, group_by="hour_bucket",
+    )
+
+
+# Cap on distinct query texts exported to queries.jsonl. Ordered by total slot-ms so the
+# heaviest statements always survive the cut; the collector logs when truncation occurs.
+# Bounds the export the same way read_jobs_hourly bounds the workload read (no per-job
+# row stream — the 2026-07-08 storm-audit OOM class).
+QUERIES_EXPORT_LIMIT = 50_000
+
+
+def read_jobs_queries(
+    client,
+    project_id: str,
+    *,
+    days: int = DEFAULT_LOOKBACK_DAYS,
+    location: str = "US",
+    limit: int = QUERIES_EXPORT_LIMIT,
+) -> list:
+    """Read DISTINCT query texts + aggregate per-statement stats (bounded).
+
+    Groups server-side by query text so the row count is bounded by workload
+    *diversity*, not volume, then caps at ``limit`` ordered by total slot-ms
+    (heaviest statements first). NULL-billed jobs are tracked per group via
+    ``missing_billed_jobs`` — same all-or-nothing billed semantics as the hourly
+    read. Returns ``[]`` on any error — never raises (R17.3).
+    """
+    select = (
+        "SELECT query, "
+        "SUM(total_slot_ms) AS total_slot_ms, "
+        "COUNT(*) AS job_count, "
+        "SUM(total_bytes_processed) AS total_bytes_processed, "
+        "SUM(total_bytes_billed) AS total_bytes_billed, "
+        "COUNTIF(total_bytes_billed IS NULL) AS missing_billed_jobs, "
+        "ANY_VALUE(statement_type) AS statement_type, "
+        "MAX(creation_time) AS creation_time"
+    )
+    return read_jobs(
+        client, project_id, select,
+        days=days, location=location,
+        group_by=f"query ORDER BY total_slot_ms DESC LIMIT {int(limit)}",
+    )
+
+
+def read_reservation_groups(
+    client,
+    project_id: str,
+    *,
+    days: int = DEFAULT_LOOKBACK_DAYS,
+    location: str = "US",
+) -> list:
+    """Read the pricing-model signal as ``GROUP BY reservation_id, edition`` counts.
+
+    A project has a handful of distinct (reservation_id, edition) pairs, so this returns
+    a handful of rows where the per-job read returned millions. NULL-ness of
+    ``reservation_id`` is preserved per group — the classification signal (V5) is intact.
+    Returns ``[]`` on any error — never raises (R16.3).
+    """
+    select = (
+        f"SELECT {k.V5_JOBS_RESERVATION_ID_COLUMN}, {k.V5_JOBS_EDITION_COLUMN}, "
+        f"COUNT(*) AS job_count"
+    )
+    return read_jobs(
+        client, project_id, select,
+        days=days, location=location,
+        group_by=f"{k.V5_JOBS_RESERVATION_ID_COLUMN}, {k.V5_JOBS_EDITION_COLUMN}",
+    )
+
+
+def _retry_query(fn):
+    """Execute fn with exponential-backoff retries on transient BigQuery errors."""
+    delay = _INITIAL_DELAY
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            return fn()
+        except GoogleAPICallError as exc:
+            if exc.code not in _RETRYABLE_CODES or attempt == _MAX_RETRIES:
+                raise
+            logger.warning("Retryable error (attempt %d): %s", attempt + 1, exc)
+            time.sleep(delay)
+            delay *= 2

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/price_lookup.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/price_lookup.py
@@ -1,0 +1,804 @@
+"""Live pricing lookup — AWS Price List API + GCP Cloud Billing Catalog.
+
+Queries public/authenticated pricing APIs at runtime to ensure cost estimates use
+current rates. Falls back to hardcoded constants (with staleness warning) when APIs
+are unreachable.
+
+Architecture:
+- AWS: Public Price List Bulk JSON API (no auth, ~2MB download per service, cached).
+  Regional offer files — the URL embeds ``aws_region`` so rates match the Source's geography.
+- GCP: Cloud Billing Catalog API via ADC (same auth the scanner uses). SKUs are matched on
+  ``serviceRegions`` against ``bq_location`` — the catalog returns every region's SKUs in one
+  list, so an unfiltered description match silently returns an arbitrary region's rate
+  (the bug behind the Montu Sydney-priced-as-US underestimate, fixed 2026-07-02).
+- Cache: JSON file in user's home dir, 24h TTL, keyed by (aws_region, bq_location)
+- Fallback: hardcoded constants in pricing_constants.py / cost_constants.py (which the
+  region cascade has already pointed at the right region before this lookup runs)
+
+The lookup returns a PricingRates dataclass that the CostEstimator consumes directly,
+replacing the module-level constants for the current run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+logger = logging.getLogger(__name__)
+
+_CACHE_DIR = Path.home() / ".bq-assess"
+_CACHE_FILE = _CACHE_DIR / "pricing-cache.json"
+_CACHE_TTL_SECONDS = 86_400  # 24 hours
+
+# Aggregate wall-clock budget for a full live lookup (AWS Redshift + AWS S3 + paginated
+# GCP catalog). Each individual HTTP call already has a 30s socket timeout, but a paginated
+# GCP fetch can chain several of those — this bounds the TOTAL so the CLI never stalls for
+# minutes on a slow API. On expiry we fall back to the region-cascaded hardcoded rates.
+_LIVE_FETCH_BUDGET_SECONDS = 45.0
+
+# AWS Price List API endpoint template (public, no auth). The pricing.us-east-1 host serves
+# ALL regions' offer files; the path segment selects the region.
+_AWS_OFFER_URL_TEMPLATE = (
+    "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/{service}/current/{region}/index.json"
+)
+
+# GCP Cloud Billing Catalog API
+_GCP_BILLING_CATALOG_URL = "https://cloudbilling.googleapis.com/v1/services"
+_GCP_BQ_SERVICE_NAME = "services/24E6-581D-38E5"  # BigQuery service ID
+
+
+@dataclass
+class AWSRates:
+    """Live AWS pricing rates for Redshift + S3."""
+    rpu_hour_usd: float = 0.0
+    managed_storage_usd_per_gb: float = 0.0
+    ra3_xlplus_ondemand: float = 0.0
+    ra3_xlplus_1yr: float = 0.0
+    ra3_xlplus_3yr: float = 0.0
+    ra3_4xl_ondemand: float = 0.0
+    ra3_4xl_1yr: float = 0.0
+    ra3_4xl_3yr: float = 0.0
+    ra3_16xl_ondemand: float = 0.0
+    ra3_16xl_1yr: float = 0.0
+    ra3_16xl_3yr: float = 0.0
+    # RG Graviton4 instances
+    rg_xl_ondemand: float = 0.0
+    rg_xl_1yr: float = 0.0
+    rg_xl_3yr: float = 0.0
+    rg_4xl_ondemand: float = 0.0
+    rg_4xl_1yr: float = 0.0
+    rg_4xl_3yr: float = 0.0
+    rg_16xl_ondemand: float = 0.0
+    rg_16xl_1yr: float = 0.0
+    rg_16xl_3yr: float = 0.0
+    s3_tables_tier1: float = 0.0
+    s3_tables_tier2: float = 0.0
+    s3_tables_tier3: float = 0.0
+    fetched_at: str = ""
+    source: str = "hardcoded"
+
+
+@dataclass
+class GCPRates:
+    """Live GCP pricing rates for BigQuery."""
+    ondemand_usd_per_tib: float = 0.0
+    storage_active_logical_usd_per_gib: float = 0.0
+    storage_longterm_logical_usd_per_gib: float = 0.0
+    fetched_at: str = ""
+    source: str = "hardcoded"
+
+
+@dataclass
+class PricingRates:
+    """Combined live pricing rates from both clouds.
+
+    ``aws_region`` / ``bq_location`` record WHICH geography the rates were fetched for —
+    apply_live_rates stamps the module region tags from them so the tags stay a true
+    invariant ("tag == region the constants reflect") across all writers.
+    """
+    aws: AWSRates = field(default_factory=AWSRates)
+    gcp: GCPRates = field(default_factory=GCPRates)
+    is_live: bool = False
+    staleness_warning: str = ""
+    aws_region: str = "us-east-1"
+    bq_location: str = "us"
+
+
+class PriceLookup:
+    """Fetch live pricing from AWS + GCP APIs with caching and graceful fallback.
+
+    ``aws_region`` selects the AWS Price List offer file; ``bq_location`` (a BigQuery
+    dataset location token like "us" or "australia-southeast1") filters GCP Billing
+    Catalog SKUs by ``serviceRegions``. Callers should pass the Source's detected
+    location and its mapped AWS region (``cost_constants.bq_location_to_aws_region``).
+    """
+
+    def __init__(self, aws_region: str = "us-east-1", bq_location: str = "us",
+                 use_cache: bool = True):
+        self._aws_region = aws_region
+        self._bq_location = (bq_location or "us").strip().lower()
+        self._use_cache = use_cache
+
+    def fetch(self, gcp_client=None) -> PricingRates:
+        """Fetch live rates from both APIs. Returns hardcoded fallback on failure."""
+        # Check cache first
+        if self._use_cache:
+            cached = self._read_cache()
+            if cached is not None:
+                return cached
+
+        rates = PricingRates(aws_region=self._aws_region, bq_location=self._bq_location)
+
+        # Fetch AWS rates (no auth needed)
+        aws_rates = self._fetch_aws_rates()
+        if aws_rates is not None:
+            rates.aws = aws_rates
+            rates.is_live = True
+
+        # Fetch GCP rates (needs ADC)
+        if gcp_client is not None:
+            gcp_rates = self._fetch_gcp_rates(gcp_client)
+            if gcp_rates is not None:
+                rates.gcp = gcp_rates
+
+        # Fall back to hardcoded if either failed
+        if rates.aws.source == "hardcoded":
+            rates.aws = self._hardcoded_aws()
+            rates.staleness_warning = self._staleness_note("AWS", rates.aws.fetched_at)
+        if rates.gcp.source == "hardcoded":
+            rates.gcp = self._hardcoded_gcp()
+            if not rates.staleness_warning:
+                rates.staleness_warning = self._staleness_note("GCP", rates.gcp.fetched_at)
+
+        # Cache the result — but ONLY when BOTH halves are genuinely live. Caching a
+        # mixed entry (AWS live + GCP hardcoded fallback) under a 24h TTL pins the
+        # fallback: every run that day would skip the GCP fetch even after a transient
+        # network/auth issue clears, while the console claims live pricing.
+        both_live = (
+            not rates.aws.source.startswith("hardcoded")
+            and not rates.gcp.source.startswith("hardcoded")
+        )
+        if self._use_cache and rates.is_live and both_live:
+            self._write_cache(rates)
+
+        return rates
+
+    # ================================================================ AWS
+
+    def _fetch_aws_rates(self) -> AWSRates | None:
+        """Query the AWS Price List API for Redshift rates (public, no auth)."""
+        import urllib.request
+        import urllib.error
+
+        try:
+            logger.info("Fetching AWS Redshift pricing from Price List API (%s)...", self._aws_region)
+            url = _AWS_OFFER_URL_TEMPLATE.format(service="AmazonRedshift", region=self._aws_region)
+            req = urllib.request.Request(url)
+            req.add_header("Accept-Encoding", "gzip")
+            with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310 - hardcoded https AWS Price List API URL, no user input
+                data = json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError, json.JSONDecodeError, TimeoutError) as exc:
+            logger.warning("AWS Price List API unreachable: %s — using hardcoded rates", exc)
+            return None
+
+        try:
+            return self._parse_aws_redshift(data)
+        except (KeyError, ValueError, TypeError) as exc:
+            logger.warning("Failed to parse AWS pricing response: %s", exc)
+            return None
+
+    def _parse_aws_redshift(self, data: dict) -> AWSRates:
+        """Extract Redshift rates from the Price List API JSON."""
+        products = data.get("products", {})
+        terms = data.get("terms", {})
+        on_demand_terms = terms.get("OnDemand", {})
+        reserved_terms = terms.get("Reserved", {})
+
+        rates = AWSRates(
+            fetched_at=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            source="AWS Price List API",
+        )
+
+        # Find Redshift Serverless RPU rate. Match the exact usagetype suffix: regional
+        # offer files also carry capacity-reservation SKUs like "ServerlessUsage-CR-1YR-AU"
+        # (an all-upfront $2,716/RPU figure) that a substring match would grab first.
+        for sku, product in products.items():
+            attrs = product.get("attributes", {})
+            usage_type = attrs.get("usagetype", "")
+            if usage_type.endswith("Redshift:ServerlessUsage") and attrs.get("locationType") == "AWS Region":
+                price = self._extract_ondemand_price(sku, on_demand_terms)
+                if price:
+                    rates.rpu_hour_usd = price
+                    break
+
+        # Find RA3 node rates
+        node_map = {
+            "ra3.xlplus": ("ra3_xlplus_ondemand", "ra3_xlplus_1yr", "ra3_xlplus_3yr"),
+            "ra3.4xlarge": ("ra3_4xl_ondemand", "ra3_4xl_1yr", "ra3_4xl_3yr"),
+            "ra3.16xlarge": ("ra3_16xl_ondemand", "ra3_16xl_1yr", "ra3_16xl_3yr"),
+        }
+
+        for sku, product in products.items():
+            attrs = product.get("attributes", {})
+            instance_type = attrs.get("instanceType", "")
+            usage_type = attrs.get("usagetype", "")
+
+            if instance_type not in node_map:
+                continue
+            if "Node" not in usage_type:
+                continue
+
+            od_field, ri1_field, ri3_field = node_map[instance_type]
+
+            # On-demand price
+            od_price = self._extract_ondemand_price(sku, on_demand_terms)
+            if od_price:
+                setattr(rates, od_field, od_price)
+
+            # Reserved prices
+            ri_prices = self._extract_reserved_prices(sku, reserved_terms)
+            if ri_prices.get("1yr"):
+                setattr(rates, ri1_field, ri_prices["1yr"])
+            if ri_prices.get("3yr"):
+                setattr(rates, ri3_field, ri_prices["3yr"])
+
+        # Managed storage
+        for sku, product in products.items():
+            attrs = product.get("attributes", {})
+            usage_type = attrs.get("usagetype", "")
+            if "RMS" in usage_type or "ManagedStorage" in usage_type:
+                price = self._extract_ondemand_price(sku, on_demand_terms)
+                if price:
+                    rates.managed_storage_usd_per_gb = price
+                    break
+
+        # Fetch S3 Tables pricing separately
+        s3_rates = self._fetch_s3_tables_rates()
+        if s3_rates:
+            rates.s3_tables_tier1 = s3_rates.get("tier1", 0)
+            rates.s3_tables_tier2 = s3_rates.get("tier2", 0)
+            rates.s3_tables_tier3 = s3_rates.get("tier3", 0)
+
+        return rates
+
+    def _fetch_s3_tables_rates(self) -> dict | None:
+        """Fetch S3 Tables storage rates from the S3 Price List API."""
+        import urllib.request
+        import urllib.error
+
+        try:
+            url = _AWS_OFFER_URL_TEMPLATE.format(service="AmazonS3", region=self._aws_region)
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310 - hardcoded https AWS Price List API URL, no user input
+                data = json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError, json.JSONDecodeError, TimeoutError):
+            return None
+
+        return self._parse_s3_tables_tiers(
+            data.get("products", {}), data.get("terms", {}).get("OnDemand", {})
+        )
+
+    @staticmethod
+    def _parse_s3_tables_tiers(products: dict, terms: dict) -> dict | None:
+        """Extract the three S3 Tables Standard storage tiers from an offer file."""
+        tiers = {}
+        for sku, product in products.items():
+            attrs = product.get("attributes", {})
+            usage_type = attrs.get("usagetype", "")
+
+            # Exact-suffix match: offer files also carry Intelligent-Tiering variants
+            # (…Tables-TimedStorage-INT-FA-ByteHrs etc.) that a substring match would
+            # conflate with the Standard tiers.
+            if not usage_type.endswith("Tables-TimedStorage-ByteHrs"):
+                continue
+
+            # One SKU carries all three tiers as separate priceDimensions — read each
+            # dimension's OWN price (a single extracted price assigned to every tier
+            # would bill tier-2/3 storage at the tier-1 rate).
+            for offer in terms.get(sku, {}).values():
+                for dim in offer.get("priceDimensions", {}).values():
+                    price = float(dim.get("pricePerUnit", {}).get("USD", "0") or "0")
+                    if price <= 0:
+                        continue
+                    begin = float(dim.get("beginRange", "0") or "0")
+                    if begin == 0:
+                        tiers["tier1"] = price
+                    elif begin <= 51200:  # 50 TB in GB
+                        tiers["tier2"] = price
+                    else:
+                        tiers["tier3"] = price
+
+        return tiers if tiers else None
+
+    def _extract_ondemand_price(self, sku: str, on_demand_terms: dict) -> float:
+        """Extract the hourly/monthly on-demand price for a SKU."""
+        sku_terms = on_demand_terms.get(sku, {})
+        for offer_term in sku_terms.values():
+            price_dims = offer_term.get("priceDimensions", {})
+            for dim in price_dims.values():
+                price_str = dim.get("pricePerUnit", {}).get("USD", "0")
+                price = float(price_str)
+                if price > 0:
+                    return price
+        return 0.0
+
+    def _extract_reserved_prices(self, sku: str, reserved_terms: dict) -> dict:
+        """Extract 1yr and 3yr no-upfront RI effective hourly rates."""
+        result = {}
+        sku_terms = reserved_terms.get(sku, {})
+
+        for offer_key, offer in sku_terms.items():
+            term_attrs = offer.get("termAttributes", {})
+            lease_length = term_attrs.get("LeaseContractLength", "")
+            purchase_option = term_attrs.get("PurchaseOption", "")
+
+            if purchase_option != "No Upfront":
+                continue
+
+            price_dims = offer.get("priceDimensions", {})
+            for dim in price_dims.values():
+                if dim.get("unit", "").lower() in ("hrs", "hr", "hour"):
+                    price_str = dim.get("pricePerUnit", {}).get("USD", "0")
+                    price = float(price_str)
+                    if price > 0:
+                        if "1yr" in lease_length or "1 yr" in lease_length.lower():
+                            result["1yr"] = price
+                        elif "3yr" in lease_length or "3 yr" in lease_length.lower():
+                            result["3yr"] = price
+
+        return result
+
+    # ================================================================ GCP
+
+    def _fetch_gcp_rates(self, client) -> GCPRates | None:
+        """Query GCP Cloud Billing Catalog for BigQuery rates using existing ADC."""
+        try:
+            from google.auth.transport.requests import AuthorizedSession
+            import google.auth
+
+            credentials = client._credentials if hasattr(client, "_credentials") else None
+            if credentials is None:
+                credentials, _ = google.auth.default(
+                    scopes=["https://www.googleapis.com/auth/cloud-billing.readonly"]
+                )
+
+            session = AuthorizedSession(credentials)
+            logger.info(
+                "Fetching GCP BigQuery pricing from Cloud Billing Catalog (%s)...",
+                self._bq_location,
+            )
+
+            # List ALL SKUs for the BigQuery service (paginated — a single unpaginated call
+            # returns only the first page and silently misses most regions' SKUs).
+            url = f"https://cloudbilling.googleapis.com/v1/{_GCP_BQ_SERVICE_NAME}/skus"
+            skus: list[dict] = []
+            page_token = None
+            while True:
+                params = {"currencyCode": "USD", "pageSize": 5000}
+                if page_token:
+                    params["pageToken"] = page_token
+                resp = session.get(url, params=params, timeout=30)
+                if resp.status_code != 200:
+                    logger.warning("GCP Billing API returned %d: %s", resp.status_code, resp.text[:200])
+                    return None
+                data = resp.json()
+                skus.extend(data.get("skus", []))
+                page_token = data.get("nextPageToken")
+                if not page_token:
+                    break
+
+            rates = self._parse_gcp_skus(skus)
+            # A parse that matched no analysis SKU is NOT a live result: returning it
+            # would skip the hardcoded fallback, stamp V4_CONFIRMED_DATE with today via
+            # apply_live_rates, and pin zeroed rates in the 24h cache. Treat as a miss.
+            if rates.ondemand_usd_per_tib <= 0:
+                logger.warning(
+                    "No on-demand analysis SKU matched region %r in the Billing Catalog "
+                    "— using hardcoded regional rates", self._bq_location,
+                )
+                return None
+            return rates
+        except Exception as exc:
+            logger.warning("GCP Billing API lookup failed: %s — using hardcoded rates", exc)
+            return None
+
+    def _gcp_region_tokens(self) -> tuple[str, ...]:
+        """serviceRegions tokens that identify the Source's location in the catalog.
+
+        The catalog labels the EU multi-region "europe" on analysis/storage SKUs (dataset
+        location token is "eu"); everything else matches the location token directly.
+        """
+        if self._bq_location == "eu":
+            return ("eu", "europe")
+        return (self._bq_location,)
+
+    def _parse_gcp_skus(self, skus: list[dict]) -> GCPRates:
+        """Extract BQ pricing for the Source's region from the Catalog SKU list.
+
+        Filters on ``serviceRegions`` — the catalog returns every region's SKUs, and the
+        description alone does not disambiguate ("Analysis" exists per-region). Matches on
+        the catalog's ``category.resourceGroup`` (OnDemandAnalysis / ActiveStorage /
+        LongTermStorage), which is stabler than description keywords.
+        """
+        rates = GCPRates(
+            fetched_at=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            source=f"GCP Cloud Billing Catalog API ({self._bq_location})",
+        )
+        region_tokens = self._gcp_region_tokens()
+
+        for sku in skus:
+            regions = sku.get("serviceRegions", [])
+            if not any(tok in regions for tok in region_tokens):
+                continue
+
+            desc = sku.get("description", "").lower()
+            group = sku.get("category", {}).get("resourceGroup", "")
+
+            pricing_info = sku.get("pricingInfo", [])
+            if not pricing_info:
+                continue
+            price_expr = pricing_info[0].get("pricingExpression", {})
+            tiered_rates = price_expr.get("tieredRates", [])
+            if not tiered_rates:
+                continue
+
+            # Use the last tier (the rate after any free tier)
+            rate = tiered_rates[-1] if len(tiered_rates) > 1 else tiered_rates[0]
+            unit_price = rate.get("unitPrice", {})
+            nanos = unit_price.get("nanos", 0)
+            units = int(unit_price.get("units", "0") or "0")
+            price = units + nanos / 1_000_000_000
+            if price <= 0:
+                continue
+
+            usage_unit = price_expr.get("usageUnit", "").lower()
+
+            if group == "OnDemandAnalysis" and desc.startswith("analysis"):
+                # Catalog unit is TiBy (per-TiB); normalize other units defensively.
+                if usage_unit == "tiby" or "tebibyte" in usage_unit:
+                    rates.ondemand_usd_per_tib = price
+                elif "miby" in usage_unit or "mebibyte" in usage_unit:
+                    rates.ondemand_usd_per_tib = price * (1024 ** 2)
+                elif usage_unit in ("by", "byte", "bytes"):
+                    rates.ondemand_usd_per_tib = price * (1024 ** 4)
+                else:
+                    rates.ondemand_usd_per_tib = price
+
+            elif group == "ActiveStorage" and "logical" in desc:
+                if usage_unit in ("by", "byte", "bytes"):
+                    rates.storage_active_logical_usd_per_gib = price * (1024 ** 3)
+                else:  # GiBy.mo
+                    rates.storage_active_logical_usd_per_gib = price
+
+            elif group == "LongTermStorage" and "logical" in desc:
+                if usage_unit in ("by", "byte", "bytes"):
+                    rates.storage_longterm_logical_usd_per_gib = price * (1024 ** 3)
+                else:
+                    rates.storage_longterm_logical_usd_per_gib = price
+
+        return rates
+
+    # ================================================================ Hardcoded Fallback
+
+    def _hardcoded_aws(self) -> AWSRates:
+        """Return hardcoded AWS rates from cost_constants.py.
+
+        The collector distribution ships without bq_assess.engine — there the
+        fallback returns a default-valued AWSRates still marked hardcoded. Safe:
+        apply_live_rates never applies hardcoded halves, and the report side
+        (which has the engine) re-derives its own regional rates.
+        """
+        try:
+            from bq_assess.engine.redshift import cost_constants as k
+        except ImportError:
+            return AWSRates(source="hardcoded (engine unavailable in collector)")
+
+        nodes = k.V6_RA3_NODE_TYPES
+        rg = k.V7_RG_NODE_TYPES
+        return AWSRates(
+            rpu_hour_usd=k.V1_RPU_HOUR_USD,
+            managed_storage_usd_per_gb=k.V6_MANAGED_STORAGE_USD_PER_GB_MONTH,
+            ra3_xlplus_ondemand=nodes["ra3.xlplus"]["ondemand_usd_per_node_hour"],
+            ra3_xlplus_1yr=nodes["ra3.xlplus"]["ri_1yr_usd_per_node_hour"],
+            ra3_xlplus_3yr=nodes["ra3.xlplus"]["ri_3yr_usd_per_node_hour"],
+            ra3_4xl_ondemand=nodes["ra3.4xlarge"]["ondemand_usd_per_node_hour"],
+            ra3_4xl_1yr=nodes["ra3.4xlarge"]["ri_1yr_usd_per_node_hour"],
+            ra3_4xl_3yr=nodes["ra3.4xlarge"]["ri_3yr_usd_per_node_hour"],
+            ra3_16xl_ondemand=nodes["ra3.16xlarge"]["ondemand_usd_per_node_hour"],
+            ra3_16xl_1yr=nodes["ra3.16xlarge"]["ri_1yr_usd_per_node_hour"],
+            ra3_16xl_3yr=nodes["ra3.16xlarge"]["ri_3yr_usd_per_node_hour"],
+            rg_xl_ondemand=rg["rg.xlarge"]["ondemand_usd_per_node_hour"],
+            rg_xl_1yr=rg["rg.xlarge"]["ri_1yr_usd_per_node_hour"],
+            rg_xl_3yr=rg["rg.xlarge"]["ri_3yr_usd_per_node_hour"],
+            rg_4xl_ondemand=rg["rg.4xlarge"]["ondemand_usd_per_node_hour"],
+            rg_4xl_1yr=rg["rg.4xlarge"]["ri_1yr_usd_per_node_hour"],
+            rg_4xl_3yr=rg["rg.4xlarge"]["ri_3yr_usd_per_node_hour"],
+            rg_16xl_ondemand=rg["rg.16xlarge"]["ondemand_usd_per_node_hour"],
+            rg_16xl_1yr=rg["rg.16xlarge"]["ri_1yr_usd_per_node_hour"],
+            rg_16xl_3yr=rg["rg.16xlarge"]["ri_3yr_usd_per_node_hour"],
+            s3_tables_tier1=k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1,
+            s3_tables_tier2=k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER2,
+            s3_tables_tier3=k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER3,
+            fetched_at=k.AWS_CONFIRMED_DATE,
+            source=f"hardcoded (verified {k.AWS_CONFIRMED_DATE})",
+        )
+
+    def _hardcoded_gcp(self) -> GCPRates:
+        """Return hardcoded GCP rates from pricing_constants.py."""
+        from bq_assess.core import pricing_constants as v4
+
+        return GCPRates(
+            ondemand_usd_per_tib=v4.V4_ONDEMAND_USD_PER_TIB,
+            storage_active_logical_usd_per_gib=v4.V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH,
+            storage_longterm_logical_usd_per_gib=v4.V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH,
+            fetched_at=v4.V4_CONFIRMED_DATE,
+            source=f"hardcoded (verified {v4.V4_CONFIRMED_DATE})",
+        )
+
+    def _staleness_note(self, provider: str, date_str: str) -> str:
+        """Generate a staleness warning if rates are old."""
+        if not date_str:
+            return f"{provider} pricing could not be fetched — using hardcoded rates (date unknown)"
+        try:
+            fetched = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            age_days = (datetime.now(timezone.utc) - fetched).days
+            if age_days > 90:
+                return (
+                    f"{provider} pricing is {age_days} days old (verified {date_str}). "
+                    f"Run with internet access to refresh from the {provider} Price List API."
+                )
+        except ValueError:
+            pass
+        return ""
+
+    # ================================================================ Cache
+
+    def _cache_key(self) -> str:
+        """Rates are region-specific — one cache entry per (aws_region, bq_location)."""
+        return f"{self._aws_region}|{self._bq_location}"
+
+    def _read_cache(self) -> PricingRates | None:
+        """Read cached rates for this region pair if within TTL."""
+        if not _CACHE_FILE.exists():
+            return None
+        try:
+            cache = json.loads(_CACHE_FILE.read_text(encoding="utf-8"))
+            data = cache.get(self._cache_key())
+            if not data:
+                return None
+            cached_at = data.get("cached_at", 0)
+            if time.time() - cached_at > _CACHE_TTL_SECONDS:
+                return None
+            return self._deserialize_rates(data)
+        except (json.JSONDecodeError, KeyError, OSError, AttributeError):
+            return None
+
+    def _write_cache(self, rates: PricingRates) -> None:
+        """Write rates for this region pair into the cache file (merging other entries)."""
+        try:
+            _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            cache: dict = {}
+            if _CACHE_FILE.exists():
+                try:
+                    existing = json.loads(_CACHE_FILE.read_text(encoding="utf-8"))
+                    # Pre-2026-07 cache files were a flat single-region dict — discard them.
+                    if isinstance(existing, dict) and "aws" not in existing:
+                        cache = existing
+                except (json.JSONDecodeError, OSError):
+                    pass
+            data = self._serialize_rates(rates)
+            data["cached_at"] = time.time()
+            cache[self._cache_key()] = data
+            _CACHE_FILE.write_text(json.dumps(cache, indent=2), encoding="utf-8")
+        except OSError as exc:
+            logger.debug("Could not write pricing cache: %s", exc)
+
+    def _serialize_rates(self, rates: PricingRates) -> dict:
+        """Serialize PricingRates to a JSON-safe dict (all dataclass fields, RG included)."""
+        return rates_to_dict(rates)
+
+    def _deserialize_rates(self, data: dict) -> PricingRates:
+        """Deserialize a cached dict back to PricingRates."""
+        return rates_from_dict(
+            data, default_aws_region=self._aws_region, default_bq_location=self._bq_location
+        )
+
+
+def rates_to_dict(rates: PricingRates) -> dict:
+    """Serialize PricingRates to a JSON-safe dict (pricing cache + bundle rates.json)."""
+    return {
+        "aws": {f: getattr(rates.aws, f) for f in AWSRates.__dataclass_fields__},
+        "gcp": {f: getattr(rates.gcp, f) for f in GCPRates.__dataclass_fields__},
+        "is_live": rates.is_live,
+        "staleness_warning": rates.staleness_warning,
+        "aws_region": rates.aws_region,
+        "bq_location": rates.bq_location,
+    }
+
+
+def rates_from_dict(
+    data: dict,
+    *,
+    default_aws_region: str = "us-east-1",
+    default_bq_location: str = "us",
+) -> PricingRates:
+    """Deserialize a rates dict (pricing cache entry or bundle rates.json)."""
+    aws_data = data.get("aws", {})
+    gcp_data = data.get("gcp", {})
+    return PricingRates(
+        aws=AWSRates(**{k: v for k, v in aws_data.items() if k in AWSRates.__dataclass_fields__}),
+        gcp=GCPRates(**{k: v for k, v in gcp_data.items() if k in GCPRates.__dataclass_fields__}),
+        is_live=data.get("is_live", False),
+        staleness_warning=data.get("staleness_warning", ""),
+        aws_region=data.get("aws_region", default_aws_region),
+        bq_location=data.get("bq_location", default_bq_location),
+    )
+
+
+class PricingTimeout(Exception):
+    """Raised when a live pricing lookup exceeds its aggregate wall-clock budget."""
+
+
+def fetch_live_rates_with_timeout(
+    lookup: PriceLookup,
+    gcp_client=None,
+    budget_seconds: float = _LIVE_FETCH_BUDGET_SECONDS,
+) -> PricingRates:
+    """Run ``lookup.fetch()`` under an aggregate wall-clock budget.
+
+    The underlying HTTP calls are synchronous ``urllib`` requests that cannot be cancelled
+    mid-flight, so we run the fetch on a worker thread and stop WAITING for it once the
+    budget expires — raising :class:`PricingTimeout`. The orphaned thread finishes (or
+    times out on its own 30s socket timeout) in the background and is harmless: it only
+    ever reads public pricing data and writes the local cache. Callers fall back to the
+    region-cascaded hardcoded rates already loaded into the constant modules.
+    """
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+
+    # daemon threads so a hung request never blocks interpreter exit
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pricing-fetch")
+    future = executor.submit(lookup.fetch, gcp_client)
+    try:
+        return future.result(timeout=budget_seconds)
+    except FutureTimeout:
+        raise PricingTimeout(
+            f"live pricing lookup exceeded {budget_seconds:.0f}s budget"
+        ) from None
+    finally:
+        # Don't block on the worker if it's still running — let it finish detached.
+        executor.shutdown(wait=False)
+
+
+def is_live_half(half) -> bool:
+    """True when a rates half (AWSRates/GCPRates) carries a genuine live fetch.
+
+    THE live-ness predicate — apply_live_rates gates value application on it and
+    callers derive their messaging from apply_live_rates' return value, so the
+    rule lives exactly once. Prefix-match: the fallback's source reads
+    "hardcoded (verified …)".
+    """
+    return bool(half.fetched_at) and not half.source.startswith("hardcoded")
+
+
+def apply_live_rates(rates: PricingRates) -> tuple[bool, bool]:
+    """Apply live rates to the module-level constants used by CostEstimator.
+
+    This overwrites the constants in pricing_constants.py and cost_constants.py at runtime
+    so that CostEstimator (which reads them at call time) picks up the live values.
+    The overridable-via-module-assignment design (R18.7) was built for exactly this.
+
+    Returns ``(aws_applied, gcp_applied)`` — which halves were genuinely live and
+    had their values applied. Callers MUST derive user-facing messaging from this
+    instead of re-deriving live-ness (message/application drift was a review find).
+    """
+    from bq_assess.core import pricing_constants as v4
+    from bq_assess.engine.redshift import cost_constants as k
+
+    aws = rates.aws
+    gcp = rates.gcp
+
+    # Per-half live gate: a hardcoded-fallback half must NOT have its values applied.
+    # Fallback halves are captured from whatever the module constants held at fetch
+    # time — in the collector distribution that is the un-cascaded us-east-1/US
+    # defaults, so applying them here would clobber the region-correct rates
+    # apply_bq_region/apply_aws_region installed (the Sydney-priced-as-US class).
+    aws_is_live = is_live_half(aws)
+    gcp_is_live = is_live_half(gcp)
+
+    # AWS Serverless
+    if aws_is_live and aws.rpu_hour_usd > 0:
+        k.V1_RPU_HOUR_USD = aws.rpu_hour_usd
+        # Recalculate derived reservation rates and breakeven thresholds
+        k.V1_SERVERLESS_1YR_RPU_HOUR_USD = round(
+            k.V1_RPU_HOUR_USD * (1 - k.V1_SERVERLESS_RESERVATION_1YR_DISCOUNT), 4
+        )
+        k.V1_SERVERLESS_3YR_RPU_HOUR_USD = round(
+            k.V1_RPU_HOUR_USD * (1 - k.V1_SERVERLESS_RESERVATION_3YR_DISCOUNT), 4
+        )
+
+    # AWS S3 Tables storage
+    if aws_is_live and aws.s3_tables_tier1 > 0:
+        k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1 = aws.s3_tables_tier1
+    if aws_is_live and aws.s3_tables_tier2 > 0:
+        k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER2 = aws.s3_tables_tier2
+    if aws_is_live and aws.s3_tables_tier3 > 0:
+        k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER3 = aws.s3_tables_tier3
+
+    # AWS Provisioned RA3
+    if aws_is_live and aws.managed_storage_usd_per_gb > 0:
+        k.V6_MANAGED_STORAGE_USD_PER_GB_MONTH = aws.managed_storage_usd_per_gb
+
+    node_updates = {
+        "ra3.xlplus": {
+            "ondemand_usd_per_node_hour": aws.ra3_xlplus_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.ra3_xlplus_1yr,
+            "ri_3yr_usd_per_node_hour": aws.ra3_xlplus_3yr,
+        },
+        "ra3.4xlarge": {
+            "ondemand_usd_per_node_hour": aws.ra3_4xl_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.ra3_4xl_1yr,
+            "ri_3yr_usd_per_node_hour": aws.ra3_4xl_3yr,
+        },
+        "ra3.16xlarge": {
+            "ondemand_usd_per_node_hour": aws.ra3_16xl_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.ra3_16xl_1yr,
+            "ri_3yr_usd_per_node_hour": aws.ra3_16xl_3yr,
+        },
+    }
+    for node_type, updates in node_updates.items():
+        for rate_key, value in updates.items():
+            if aws_is_live and value > 0:
+                k.V6_RA3_NODE_TYPES[node_type][rate_key] = value
+
+    # RG Graviton4 instances (used by the provisioned scenarios)
+    rg_updates = {
+        "rg.xlarge": {
+            "ondemand_usd_per_node_hour": aws.rg_xl_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.rg_xl_1yr,
+            "ri_3yr_usd_per_node_hour": aws.rg_xl_3yr,
+        },
+        "rg.4xlarge": {
+            "ondemand_usd_per_node_hour": aws.rg_4xl_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.rg_4xl_1yr,
+            "ri_3yr_usd_per_node_hour": aws.rg_4xl_3yr,
+        },
+        "rg.16xlarge": {
+            "ondemand_usd_per_node_hour": aws.rg_16xl_ondemand,
+            "ri_1yr_usd_per_node_hour": aws.rg_16xl_1yr,
+            "ri_3yr_usd_per_node_hour": aws.rg_16xl_3yr,
+        },
+    }
+    for node_type, updates in rg_updates.items():
+        for rate_key, value in updates.items():
+            if aws_is_live and value > 0:
+                k.V7_RG_NODE_TYPES[node_type][rate_key] = value
+
+    # GCP BigQuery
+    if gcp_is_live and gcp.ondemand_usd_per_tib > 0:
+        v4.V4_ONDEMAND_USD_PER_TIB = gcp.ondemand_usd_per_tib
+    if gcp_is_live and gcp.storage_active_logical_usd_per_gib > 0:
+        v4.V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH = gcp.storage_active_logical_usd_per_gib
+    if gcp_is_live and gcp.storage_longterm_logical_usd_per_gib > 0:
+        v4.V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH = gcp.storage_longterm_logical_usd_per_gib
+
+    # Update confirmed dates + region tags — same per-half live gate. Stamping the
+    # region tags here keeps the "tag == region the constants reflect" invariant true
+    # across ALL writers — the estimate() skip-guard and the unknown-region reset both
+    # key on these tags.
+    if aws_is_live:
+        k.AWS_CONFIRMED_DATE = aws.fetched_at
+        k.AWS_PROVISIONED_CONFIRMED_DATE = aws.fetched_at
+        k.AWS_PRICING_REGION = rates.aws_region
+        k.AWS_REGION_SCOPE = (
+            f"{k.AWS_REGIONAL_RATES[rates.aws_region]['label']} / {rates.aws_region}"
+            if rates.aws_region in k.AWS_REGIONAL_RATES else rates.aws_region
+        )
+    if gcp_is_live:
+        v4.V4_CONFIRMED_DATE = gcp.fetched_at
+        v4.V4_PRICING_REGION = rates.bq_location
+        v4.V4_REGION_SCOPE = f"BigQuery region {rates.bq_location}"
+
+    return aws_is_live, gcp_is_live

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/pricing.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/pricing.py
@@ -1,0 +1,168 @@
+"""BigQuery pricing-model detection — on-demand vs capacity / Editions (R16, V4/V5).
+
+``PricingDetector.detect()`` classifies how a Source is billed so the Cost Comparison (R18)
+prices the BigQuery side against the *real* model, never an assumed one (R16.4). It resolves
+to exactly four outcomes:
+
+  1. ``--reservation-config`` supplied        → CAPACITY + figures, HIGH confidence (R16.2)
+  2. JOBS carry a non-null ``reservation_id``  → CAPACITY + edition, MEDIUM (figures unknown)
+  3. JOBS all-NULL ``reservation_id``          → ON_DEMAND, MEDIUM (lookback-window caveat)
+  4. no usable signal (empty / all-SCRIPT /    → ON_DEMAND, LOW, prompt for --reservation-config
+     missing ``jobs.listAll``)                   (R16.3 / P20: never silently guess capacity)
+
+The primary signal is ``INFORMATION_SCHEMA.JOBS.reservation_id`` (NULL ⇒ on-demand, non-null ⇒
+capacity) — verified V5, simpler than reading the reservation views and needing no perms beyond
+``jobs.listAll``. SCRIPT *parent* jobs report NULL ``reservation_id`` even under capacity, so
+they are excluded before classification (V5 caveat).
+
+The detector never returns ``model == UNKNOWN`` and never raises: an undeterminable verdict
+collapses to ON_DEMAND at LOW confidence with a prompting ``source_note`` (R16.3). Verified
+constants live in ``core/pricing_constants.py`` (dated, overridable; read at call time).
+
+⚠️ Scope (issue 5.1): the model is classified from JOBS; capacity slot *figures* come only from
+``--reservation-config``. Auto-reading baseline/max/commitment out of the reservation views is
+deferred (their column schema is unverified — see SCRUM_NOTES § Detector scope 2026-06-15), so
+auto-detected CAPACITY is reported at MEDIUM with a prompt for ``--reservation-config``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from bq_assess.core import jobs_query
+from bq_assess.core import pricing_constants as k
+from bq_assess.models import BQPricingModel, ConfidenceLevel, PricingDetection
+
+logger = logging.getLogger(__name__)
+
+
+class PricingDetector:
+    """Detect the BigQuery billing model for a Source (R16)."""
+
+    def detect(
+        self,
+        client,
+        project_id: str,
+        reservation_config: dict | None,
+        location: str = "US",
+    ) -> PricingDetection:
+        """Classify the Source's pricing model. See module docstring for the four outcomes.
+
+        ``location`` region-qualifies the JOBS query (``\\`region-<location>\\```); it defaults
+        to ``"US"`` to match the US-only pricing constants (V4). Never raises (R16.3/P20).
+        """
+        # 1. A supplied --reservation-config is a confidence rung above auto-detection (R16.2):
+        #    it forces CAPACITY and carries the figures the Cost Estimator prices from. Read with
+        #    .get() so a partial/malformed dict degrades to None rather than raising (P20).
+        if reservation_config:
+            edition = reservation_config.get("edition")
+            commitment_slots = reservation_config.get("commitment_slots")
+            note = (
+                f"Capacity model from supplied --reservation-config (manual_input); "
+                f"V4/V5 {k.V5_CONFIRMED_DATE}."
+            )
+            # STANDARD edition has no true capacity/slot commitments (V4). Surface — don't
+            # silently price — a config that claims STANDARD with a commitment.
+            if (
+                edition is not None
+                and edition not in k.V4_EDITIONS_WITH_CAPACITY_COMMITMENTS
+                and commitment_slots
+            ):
+                note += (
+                    f" ⚠️ Edition {edition} has no true capacity/slot commitments — the supplied "
+                    f"commitment_slots={commitment_slots} is unexpected (V4); verify the figures."
+                )
+            return PricingDetection(
+                model=BQPricingModel.CAPACITY,
+                confidence=ConfidenceLevel.HIGH,
+                edition=edition,
+                baseline_slots=reservation_config.get("baseline_slots"),
+                max_slots=reservation_config.get("max_slots"),
+                commitment_slots=commitment_slots,
+                commitment_plan=reservation_config.get("commitment_plan"),
+                source_note=note,
+            )
+
+        rows = self._read_jobs(client, project_id, location)
+        # Rows are GROUPED (reservation_id, edition, job_count) — see _read_jobs. Each group
+        # summarizes job_count jobs; legacy per-job shaped rows (tests, file import) count
+        # as 1 each via the job_count default.
+        # Defense-in-depth: SCRIPT parents are excluded at the SQL level (jobs_query shared
+        # WHERE) AND here. The SQL filter is the primary guard; this Python filter ensures
+        # correctness if rows arrive via a non-SQL path (tests, file import) or if the
+        # constant is overridden at runtime (R18.7). Grouped rows carry no statement_type,
+        # so the filter only bites on per-job shaped input.
+        leaf_rows = [
+            r for r in rows
+            if r.get(k.V5_JOBS_STATEMENT_TYPE_COLUMN) != k.V5_JOBS_SCRIPT_STATEMENT_TYPE
+        ]
+        capacity_rows = [
+            r for r in leaf_rows if r.get(k.V5_JOBS_RESERVATION_ID_COLUMN) is not None
+        ]
+        n = sum(_group_count(r) for r in leaf_rows)
+
+        if capacity_rows:
+            # Any capacity job ⇒ the project is (at least partly) capacity-billed. Classify it
+            # so the cost step never under-prices a reserved Source (R16.4). Edition comes from
+            # the JOBS edition column; slot figures are not auto-enriched in 5.1 (MEDIUM).
+            n_capacity = sum(_group_count(r) for r in capacity_rows)
+            edition = next(
+                (r.get(k.V5_JOBS_EDITION_COLUMN) for r in capacity_rows
+                 if r.get(k.V5_JOBS_EDITION_COLUMN)),
+                None,
+            )
+            return PricingDetection(
+                model=BQPricingModel.CAPACITY,
+                confidence=ConfidenceLevel.MEDIUM,
+                edition=edition,
+                source_note=(
+                    f"Capacity model detected from INFORMATION_SCHEMA.JOBS."
+                    f"{k.V5_JOBS_RESERVATION_ID_COLUMN} (non-null on {n_capacity} of {n} "
+                    f"leaf jobs; edition={edition}). Slot figures not auto-detected — supply "
+                    f"--reservation-config for baseline/max/commitment. V5 {k.V5_CONFIRMED_DATE}."
+                ),
+            )
+
+        if not leaf_rows:
+            # No usable leaf signal (empty job list, all-SCRIPT parents, or JOBS unreadable).
+            # Undeterminable ⇒ default ON_DEMAND, mark LOW, prompt for --reservation-config.
+            # Never return UNKNOWN and never raise (R16.3 / P20: don't silently guess capacity).
+            return PricingDetection(
+                model=BQPricingModel.ON_DEMAND,
+                confidence=ConfidenceLevel.LOW,
+                source_note=(
+                    "Could not determine pricing model (no readable, non-SCRIPT job data); "
+                    "defaulting to on-demand at LOW confidence — supply --reservation-config to "
+                    f"classify a capacity Source. V5 {k.V5_CONFIRMED_DATE}."
+                ),
+            )
+
+        return PricingDetection(
+            model=BQPricingModel.ON_DEMAND,
+            confidence=ConfidenceLevel.MEDIUM,
+            source_note=(
+                f"On-demand model detected from INFORMATION_SCHEMA.JOBS."
+                f"{k.V5_JOBS_RESERVATION_ID_COLUMN} (NULL on all {n} leaf jobs); reflects the "
+                f"query-log lookback window only. V5 {k.V5_CONFIRMED_DATE}."
+            ),
+        )
+
+    def _read_jobs(self, client, project_id: str, location: str) -> list:
+        """Read GROUPED (reservation_id, edition, job_count) rows from project job history.
+
+        Delegates to ``core.jobs_query.read_reservation_groups`` (JOBS_BY_PROJECT,
+        completed-query lookback, project/region-qualified, GROUP BY reservation/edition) —
+        a handful of rows regardless of the Source's query volume (2026-07-08 storm audit:
+        the per-job read was a multi-GB row stream on busy projects). Returns ``[]`` if the
+        query cannot be run (e.g. missing ``jobs.listAll``) — the caller treats no-signal
+        as undeterminable (R16.3), never an error.
+        """
+        return jobs_query.read_reservation_groups(client, project_id, location=location)
+
+
+def _group_count(row) -> int:
+    """Jobs summarized by a grouped row; per-job shaped rows (no job_count) count as 1."""
+    try:
+        return max(int(row.get("job_count", 1) or 1), 1)
+    except (ValueError, TypeError):
+        return 1

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/pricing_constants.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/pricing_constants.py
@@ -1,0 +1,260 @@
+"""Verified BigQuery pricing + reservation-detection constants (V4, V5).
+
+Confirmed against live cloud.google.com pages on 2026-06-11 via an adversarial
+web-verification pass (50 facts cross-checked + a focused second-pass re-fetch of the four
+dollar figures the cost comparison hinges on). Values are overridable via module-level
+assignment for testing or future updates — never hardcode a guess elsewhere (R18.7).
+
+⚠️ The module-level V4_* constants default to US MULTI-REGION (region token "us") in USD.
+Other regions differ and are generally HIGHER (e.g. australia-southeast1 on-demand is
+$8.125/TiB vs $6.25). Call ``apply_bq_region(location)`` with the Source's detected dataset
+location to re-point the constants at that region's verified rates (V4_REGIONAL_RATES below)
+— the CLI does this automatically from the scanned datasets. A live Cloud Billing Catalog
+lookup (``core/price_lookup.py``, region-filtered) can then override with current rates.
+
+⚠️ The BigQuery pricing page publishes no machine-readable last-updated date; freshness here
+is a live 2026-06-11 fetch corroborated by a 2026-06-07 Wayback capture. The
+INFORMATION_SCHEMA doc pages ARE dated (reservation views 2026-06-09, JOBS 2026-06-10 UTC).
+
+References:
+- V4 pricing:  https://cloud.google.com/bigquery/pricing
+- V5 JOBS:     https://docs.cloud.google.com/bigquery/docs/information-schema-jobs
+- V5 reserv.:  https://docs.cloud.google.com/bigquery/docs/information-schema-reservations
+               https://docs.cloud.google.com/bigquery/docs/information-schema-capacity-commitments
+               https://docs.cloud.google.com/bigquery/docs/information-schema-assignments
+"""
+
+from __future__ import annotations
+
+V4_CONFIRMED_DATE: str = "2026-07-02"
+V5_CONFIRMED_DATE: str = "2026-06-24"
+V4_PRICING_SOURCE_URL: str = "https://cloud.google.com/bigquery/pricing"
+V4_REGION_SCOPE: str = "US multi-region (us)"
+# The BigQuery dataset location the module-level V4_* constants currently reflect
+# (lowercase location token; set by apply_bq_region).
+V4_PRICING_REGION: str = "us"
+
+# =============================================================================
+# V4 — On-demand (analysis) pricing
+# =============================================================================
+
+# Query/analysis: price per TiB of data scanned. Billed per TiB = 2^40 bytes.
+V4_ONDEMAND_USD_PER_TIB: float = 6.25
+# First N TiB of query data processed per month is free, per billing account.
+V4_ONDEMAND_FREE_TIB_PER_MONTH: float = 1.0
+
+# =============================================================================
+# V4 — Storage pricing ($/GiB-month; billed in GiB = 2^30 bytes, binary)
+# Page quotes per-GiB-hour rates; monthly = hourly x 730.
+# =============================================================================
+
+V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH: float = 0.02
+V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH: float = 0.01
+V4_STORAGE_ACTIVE_PHYSICAL_USD_PER_GIB_MONTH: float = 0.04
+V4_STORAGE_LONGTERM_PHYSICAL_USD_PER_GIB_MONTH: float = 0.02
+# First N GiB of storage per month is free.
+V4_STORAGE_FREE_GIB_PER_MONTH: float = 10.0
+# A table/partition not modified for 90 consecutive days drops to the long-term rate
+# (~50% lower; no performance/durability/availability difference).
+V4_LONGTERM_THRESHOLD_DAYS: int = 90
+
+# =============================================================================
+# V4 — Editions (capacity) compute pricing, USD per slot-hour
+# Keyed by the `edition` value as it appears in INFORMATION_SCHEMA.JOBS.
+# `commit_1yr` / `commit_3yr` are the Billing Catalog's per-edition "1 Year"/"3 Years"
+# commitment SKUs — consistently payg×0.8 / payg×0.6 in EVERY region including US
+# (catalog-verified 2026-07-03: US ENTERPRISE 1yr $0.048, 3yr $0.036). These defaults
+# MUST match what apply_bq_region derives, or the location=None path prices commitments
+# ~12% higher than a cascaded run. (The pricing PAGE's ×0.9/×0.8 "consumption CUD"
+# figures have no catalog SKU and are not modeled.) STANDARD has NO true capacity/slot
+# commitments — its 1yr/3yr figures are consumption-model CUDs, not slot commitments.
+# =============================================================================
+
+V4_EDITION_SLOT_HOUR_USD: dict[str, dict[str, float | None]] = {
+    "STANDARD": {"payg": 0.04, "commit_1yr": 0.032, "commit_3yr": 0.024},
+    "ENTERPRISE": {"payg": 0.06, "commit_1yr": 0.048, "commit_3yr": 0.036},
+    "ENTERPRISE_PLUS": {"payg": 0.10, "commit_1yr": 0.08, "commit_3yr": 0.06},
+}
+
+# Cheaper "Resource CUD" family for the editions that support true slot commitments.
+V4_EDITION_RESOURCE_CUD_SLOT_HOUR_USD: dict[str, dict[str, float]] = {
+    "ENTERPRISE": {"commit_1yr": 0.048, "commit_3yr": 0.036},
+    "ENTERPRISE_PLUS": {"commit_1yr": 0.08, "commit_3yr": 0.06},
+}
+
+# Editions that can purchase true capacity (slot) commitments (Standard cannot).
+V4_EDITIONS_WITH_CAPACITY_COMMITMENTS: tuple[str, ...] = ("ENTERPRISE", "ENTERPRISE_PLUS")
+
+# =============================================================================
+# V4 — Per-region rate table + region resolver
+# Verified 2026-07-02 against the GCP Cloud Billing Catalog API (services/24E6-581D-38E5
+# BigQuery + services/16B8-3DDA-9F10 BigQuery Reservation API), region-filtered on
+# serviceRegions. Cross-checked against a real australia-southeast1 bill (Analysis
+# 860.98 TiB → $6,991.12 = $8.125/TiB exactly).
+# Keys are lowercase BigQuery dataset-location tokens as returned by datasets.get
+# (multi-regions "us"/"eu"; regions like "australia-southeast1").
+# The catalog labels the EU multi-region "europe" (analysis SKUs) / "eu" (edition SKUs);
+# we key it "eu" to match dataset.location.
+# =============================================================================
+
+V4_REGIONAL_RATES: dict[str, dict[str, float]] = {
+    #                          $/TiB    active   longterm  active    longterm
+    #                          scanned  logical  logical   physical  physical
+    "us":                      {"ondemand_per_tib": 6.25,   "active_logical": 0.02,  "longterm_logical": 0.01,  "active_physical": 0.04,  "longterm_physical": 0.02},
+    "eu":                      {"ondemand_per_tib": 6.25,   "active_logical": 0.02,  "longterm_logical": 0.01,  "active_physical": 0.044, "longterm_physical": 0.022},
+    "us-central1":             {"ondemand_per_tib": 6.25,   "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.04,  "longterm_physical": 0.02},
+    "us-east1":                {"ondemand_per_tib": 6.25,   "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.044, "longterm_physical": 0.022},
+    "us-west1":                {"ondemand_per_tib": 6.25,   "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.04,  "longterm_physical": 0.02},
+    "europe-west4":            {"ondemand_per_tib": 7.5,    "active_logical": 0.02,  "longterm_logical": 0.01,  "active_physical": 0.044, "longterm_physical": 0.022},
+    "australia-southeast1":    {"ondemand_per_tib": 8.125,  "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "australia-southeast2":    {"ondemand_per_tib": 8.125,  "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "europe-west1":            {"ondemand_per_tib": 7.5,    "active_logical": 0.02,  "longterm_logical": 0.01,  "active_physical": 0.044, "longterm_physical": 0.022},
+    "europe-west2":            {"ondemand_per_tib": 7.8125, "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "europe-west3":            {"ondemand_per_tib": 8.125,  "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "asia-southeast1":         {"ondemand_per_tib": 8.4375, "active_logical": 0.02,  "longterm_logical": 0.01,  "active_physical": 0.046, "longterm_physical": 0.023},
+    "asia-northeast1":         {"ondemand_per_tib": 7.5,    "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "asia-south1":             {"ondemand_per_tib": 7.5,    "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.052, "longterm_physical": 0.026},
+    "us-east4":                {"ondemand_per_tib": 6.25,   "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.05,  "longterm_physical": 0.025},
+    "us-west2":                {"ondemand_per_tib": 8.4375, "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.05,  "longterm_physical": 0.025},
+    "northamerica-northeast1": {"ondemand_per_tib": 6.5625, "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.05,  "longterm_physical": 0.025},
+    "southamerica-east1":      {"ondemand_per_tib": 11.25,  "active_logical": 0.023, "longterm_logical": 0.016, "active_physical": 0.07,  "longterm_physical": 0.035},
+}
+
+# Editions PAYG $/slot-hr by region (Billing Catalog, 2026-07-02). The catalog's per-region
+# "1 Year"/"3 Years" SKUs — the ONLY published per-region commitment rates, verified for every
+# region below including US (e.g. US ENTERPRISE 1yr $0.048 = payg×0.8, 3yr $0.036 = payg×0.6;
+# Sydney 1yr $0.0648 = 0.081×0.8) — follow payg×0.8/×0.6. apply_bq_region prices commitments
+# from those factors. The pricing page's ×0.9/×0.8 "consumption CUD" figures are US-only and
+# have no per-region catalog SKU, so they are NOT fabricated for other regions.
+V4_REGIONAL_EDITION_PAYG: dict[str, dict[str, float]] = {
+    "us":                      {"STANDARD": 0.04,  "ENTERPRISE": 0.06,   "ENTERPRISE_PLUS": 0.10},
+    "eu":                      {"STANDARD": 0.044, "ENTERPRISE": 0.066,  "ENTERPRISE_PLUS": 0.11},
+    "us-central1":             {"STANDARD": 0.04,  "ENTERPRISE": 0.06,   "ENTERPRISE_PLUS": 0.10},
+    "us-east1":                {"STANDARD": 0.04,  "ENTERPRISE": 0.06,   "ENTERPRISE_PLUS": 0.10},
+    "us-west1":                {"STANDARD": 0.04,  "ENTERPRISE": 0.06,   "ENTERPRISE_PLUS": 0.10},
+    "europe-west4":            {"STANDARD": 0.044, "ENTERPRISE": 0.066,  "ENTERPRISE_PLUS": 0.11},
+    "australia-southeast1":    {"STANDARD": 0.054, "ENTERPRISE": 0.081,  "ENTERPRISE_PLUS": 0.135},
+    "australia-southeast2":    {"STANDARD": 0.054, "ENTERPRISE": 0.081,  "ENTERPRISE_PLUS": 0.135},
+    "europe-west1":            {"STANDARD": 0.044, "ENTERPRISE": 0.066,  "ENTERPRISE_PLUS": 0.11},
+    "europe-west2":            {"STANDARD": 0.052, "ENTERPRISE": 0.078,  "ENTERPRISE_PLUS": 0.13},
+    "europe-west3":            {"STANDARD": 0.052, "ENTERPRISE": 0.078,  "ENTERPRISE_PLUS": 0.13},
+    "asia-southeast1":         {"STANDARD": 0.049, "ENTERPRISE": 0.0735, "ENTERPRISE_PLUS": 0.1225},
+    "asia-northeast1":         {"STANDARD": 0.051, "ENTERPRISE": 0.0765, "ENTERPRISE_PLUS": 0.1275},
+    "asia-south1":             {"STANDARD": 0.046, "ENTERPRISE": 0.069,  "ENTERPRISE_PLUS": 0.115},
+    "us-east4":                {"STANDARD": 0.04,  "ENTERPRISE": 0.06,   "ENTERPRISE_PLUS": 0.10},
+    "us-west2":                {"STANDARD": 0.05,  "ENTERPRISE": 0.075,  "ENTERPRISE_PLUS": 0.125},
+    "northamerica-northeast1": {"STANDARD": 0.046, "ENTERPRISE": 0.069,  "ENTERPRISE_PLUS": 0.115},
+    "southamerica-east1":      {"STANDARD": 0.062, "ENTERPRISE": 0.093,  "ENTERPRISE_PLUS": 0.155},
+}
+
+# Commitment factors from the catalog "1 Year"/"3 Years" SKUs (the true slot-commitment /
+# Resource-CUD family). Consistently payg×0.8 (1yr) / payg×0.6 (3yr) across every region
+# checked, US included.
+V4_RESOURCE_CUD_1YR_FACTOR: float = 0.8
+V4_RESOURCE_CUD_3YR_FACTOR: float = 0.6
+
+
+def normalize_bq_location(location: str | None) -> str:
+    """Lowercase a BigQuery dataset location token ("US" → "us")."""
+    return (location or "").strip().lower()
+
+
+def apply_bq_region(location: str | None) -> bool:
+    """Re-point the module-level V4_* rate constants at ``location``'s verified rates.
+
+    Returns True when the location is in the verified table (constants updated), False when
+    it is unknown (constants left as-is — US multi-region — so callers can attach a caveat).
+    Overridable-via-module-assignment design (R18.7): CostEstimator reads these at call time.
+    """
+    global V4_ONDEMAND_USD_PER_TIB
+    global V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH
+    global V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH
+    global V4_STORAGE_ACTIVE_PHYSICAL_USD_PER_GIB_MONTH
+    global V4_STORAGE_LONGTERM_PHYSICAL_USD_PER_GIB_MONTH
+    global V4_EDITION_SLOT_HOUR_USD, V4_EDITION_RESOURCE_CUD_SLOT_HOUR_USD
+    global V4_PRICING_REGION, V4_REGION_SCOPE
+
+    loc = normalize_bq_location(location)
+    rates = V4_REGIONAL_RATES.get(loc)
+    if rates is None:
+        return False
+
+    V4_ONDEMAND_USD_PER_TIB = rates["ondemand_per_tib"]
+    V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH = rates["active_logical"]
+    V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH = rates["longterm_logical"]
+    V4_STORAGE_ACTIVE_PHYSICAL_USD_PER_GIB_MONTH = rates["active_physical"]
+    V4_STORAGE_LONGTERM_PHYSICAL_USD_PER_GIB_MONTH = rates["longterm_physical"]
+
+    payg = V4_REGIONAL_EDITION_PAYG.get(loc)
+    if payg is not None:
+        # Commitments priced from the catalog-verified per-region factors (×0.8/×0.6 —
+        # the only commitment SKUs the catalog publishes; see table comment above).
+        V4_EDITION_SLOT_HOUR_USD = {
+            edition: {
+                "payg": rate,
+                "commit_1yr": round(rate * V4_RESOURCE_CUD_1YR_FACTOR, 6),
+                "commit_3yr": round(rate * V4_RESOURCE_CUD_3YR_FACTOR, 6),
+            }
+            for edition, rate in payg.items()
+        }
+        V4_EDITION_RESOURCE_CUD_SLOT_HOUR_USD = {
+            edition: {
+                "commit_1yr": round(payg[edition] * V4_RESOURCE_CUD_1YR_FACTOR, 6),
+                "commit_3yr": round(payg[edition] * V4_RESOURCE_CUD_3YR_FACTOR, 6),
+            }
+            for edition in V4_EDITIONS_WITH_CAPACITY_COMMITMENTS
+            if edition in payg
+        }
+
+    V4_PRICING_REGION = loc
+    V4_REGION_SCOPE = f"BigQuery region {loc}"
+    return True
+
+
+# =============================================================================
+# V5 — Reservation/commitment INFORMATION_SCHEMA views
+# Region-qualified; the project prefix is optional, the `_BY_PROJECT` suffix is a synonym.
+# Syntax:  [PROJECT_ID.]`region-REGION`.INFORMATION_SCHEMA.<VIEW>
+# Example: FROM `region-us`.INFORMATION_SCHEMA.CAPACITY_COMMITMENTS WHERE state = 'ACTIVE'
+# =============================================================================
+
+V5_REGION_QUALIFIER_EXAMPLE: str = "`region-us`"
+V5_RESERVATION_VIEWS: tuple[str, ...] = (
+    "RESERVATIONS",
+    "RESERVATIONS_TIMELINE",
+    "RESERVATION_CHANGES",
+    "CAPACITY_COMMITMENTS",
+    "CAPACITY_COMMITMENT_CHANGES",
+    "ASSIGNMENTS",
+    "ASSIGNMENT_CHANGES",
+)
+# IAM permissions to read the reservation views (one *.list per view family).
+V5_RESERVATION_LIST_PERMISSIONS: tuple[str, ...] = (
+    "bigquery.reservations.list",
+    "bigquery.capacityCommitments.list",
+    "bigquery.reservationAssignments.list",
+)
+# Lowest-privilege predefined role covering all three reservation *.list perms AND
+# bigquery.jobs.listAll. ⚠️ Reading reservation views is NOT a higher tier than jobs.listAll.
+V5_READONLY_ROLE: str = "roles/bigquery.resourceViewer"
+
+# =============================================================================
+# V5 — Primary on-demand-vs-capacity signal in INFORMATION_SCHEMA.JOBS
+# Simpler and lower-privilege than reading the reservation views: needs only the JOBS perms.
+# =============================================================================
+
+# The column whose NULL-ness distinguishes the billing model.
+V5_JOBS_RESERVATION_ID_COLUMN: str = "reservation_id"
+# reservation_id IS NULL  => on-demand (PAYG)
+# reservation_id non-null => capacity (Editions); value is the primary reservation path
+#                            "RESERVATION_ADMIN_PROJECT:RESERVATION_LOCATION.RESERVATION_NAME"
+# ⚠️ The on-demand sentinel is NULL — NOT the string "default". Do not test == "default".
+V5_JOBS_ONDEMAND_RESERVATION_ID_IS_NULL: bool = True
+# Secondary confirmation: names the edition of the assigned reservation.
+V5_JOBS_EDITION_COLUMN: str = "edition"
+# ⚠️ statement_type='SCRIPT' parent jobs have reservation_id=NULL by design even under
+# capacity billing — classify on leaf jobs / exclude SCRIPT parents, and aggregate across
+# jobs for a whole-project verdict.
+V5_JOBS_SCRIPT_PARENT_RESERVATION_ID_IS_NULL: bool = True
+V5_JOBS_STATEMENT_TYPE_COLUMN: str = "statement_type"
+V5_JOBS_SCRIPT_STATEMENT_TYPE: str = "SCRIPT"

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/region_mapping.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/region_mapping.py
@@ -1,0 +1,30 @@
+"""BQ location → AWS region mapping (shared by collector and full tool)."""
+
+from __future__ import annotations
+
+BQ_LOCATION_TO_AWS_REGION: dict[str, str] = {
+    "us": "us-east-1",
+    "eu": "eu-west-1",
+    "us-central1": "us-east-1",
+    "us-east1": "us-east-1",
+    "us-east4": "us-east-1",
+    "us-west1": "us-west-2",
+    "us-west2": "us-west-2",
+    "northamerica-northeast1": "ca-central-1",
+    "southamerica-east1": "sa-east-1",
+    "europe-west1": "eu-west-1",
+    "europe-west2": "eu-west-2",
+    "europe-west3": "eu-central-1",
+    "europe-west4": "eu-central-1",
+    "australia-southeast1": "ap-southeast-2",
+    "australia-southeast2": "ap-southeast-2",
+    "asia-southeast1": "ap-southeast-1",
+    "asia-northeast1": "ap-northeast-1",
+    "asia-south1": "ap-south-1",
+}
+
+
+def bq_location_to_aws_region(location: str | None) -> str:
+    """Map a BigQuery dataset location to the nearest AWS region (us-east-1 if unknown)."""
+    loc = (location or "").strip().lower()
+    return BQ_LOCATION_TO_AWS_REGION.get(loc, "us-east-1")

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/relationships.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/relationships.py
@@ -1,0 +1,243 @@
+"""Relationship inference for BigQuery table migration assessment.
+
+Detects table relationships from naming conventions, view SQL definitions,
+clustering keys, and optional query logs. Per R15.5, this informs Iceberg
+sort-order hints (R7) and Query Complexity blast-radius (R11) — it does NOT
+emit DISTKEY/SORTKEY recommendations (the Query Engine is Redshift Serverless
+over Iceberg; there are no distribution keys).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+
+from bq_assess.core.analyzer import QueryAnalysis
+from bq_assess.models import ConfidenceLevel, EntityMetadata
+
+
+@dataclass
+class InferredRelationship:
+    """A relationship inferred between two tables."""
+
+    source_table: str
+    target_table: str
+    join_column: str
+    confidence: ConfidenceLevel
+    source: str  # "naming_convention", "view_definition", "query_logs"
+
+
+@dataclass
+class RelationshipResult:
+    """Aggregated relationship inference results."""
+
+    relationships: list[InferredRelationship]
+    likely_join_keys: list[str]
+    sort_order_hints: dict[str, list[str]]  # table -> Iceberg sort-order hint columns (R7/R15.5)
+    confidence: ConfidenceLevel
+
+# Match patterns like: JOIN dataset.table ON ... or JOIN table ON ...
+JOIN_PATTERN = re.compile(
+    r"JOIN\s+(\w+(?:\.\w+)?)\s+",
+    re.IGNORECASE,
+)
+
+# Match ON clause: ... ON a.col = b.col
+ON_CLAUSE_PATTERN = re.compile(
+    r"ON\s+(\w+(?:\.\w+)?)\.(\w+)\s*=\s*(\w+(?:\.\w+)?)\.(\w+)",
+    re.IGNORECASE,
+)
+
+
+class RelationshipInferrer:
+    """Infer table relationships from metadata and optional query logs."""
+
+    def infer(
+        self,
+        tables: list[EntityMetadata],
+        query_analysis: QueryAnalysis | None = None,
+        view_definitions: dict[str, str] | None = None,
+    ) -> RelationshipResult:
+        """Infer table relationships from metadata and optional query logs.
+
+        Args:
+            tables: List of entity metadata (TABLE population).
+            query_analysis: Optional query log analysis results.
+            view_definitions: Optional mapping of table_name to view SQL.
+
+        Returns:
+            RelationshipResult with inferred relationships, join keys,
+            Iceberg sort-order hints, and overall confidence level.
+        """
+        relationships: list[InferredRelationship] = []
+        likely_join_keys: list[str] = []
+        sort_order_hints: dict[str, list[str]] = {}
+
+        # 1. Column naming heuristic: _id suffix columns in >3 tables
+        naming_rels, naming_keys = self._infer_from_naming(tables)
+        relationships.extend(naming_rels)
+        likely_join_keys.extend(naming_keys)
+
+        # 2. View SQL parsing: extract JOIN clauses
+        if view_definitions:
+            view_rels = self._infer_from_views(view_definitions)
+            relationships.extend(view_rels)
+
+        # 3. Clustering keys → Iceberg sort-order hints (R7; NOT Redshift SORTKEYs — R15.5)
+        for table in tables:
+            if table.clustering_fields:
+                sort_order_hints[table.full_name] = list(table.clustering_fields)
+
+        # 4. Query log integration
+        if query_analysis is not None:
+            log_rels = self._infer_from_query_logs(query_analysis)
+            relationships.extend(log_rels)
+
+        # 5. Determine overall confidence
+        confidence = self._determine_confidence(
+            query_analysis, view_definitions, naming_keys
+        )
+
+        # Deduplicate join keys
+        likely_join_keys = sorted(set(likely_join_keys))
+
+        return RelationshipResult(
+            relationships=relationships,
+            likely_join_keys=likely_join_keys,
+            sort_order_hints=sort_order_hints,
+            confidence=confidence,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _infer_from_naming(
+        tables: list[EntityMetadata],
+    ) -> tuple[list[InferredRelationship], list[str]]:
+        """Detect relationships from _id suffix column naming conventions.
+
+        Columns ending in ``_id`` that appear in more than 3 tables are
+        considered likely join keys.  For each pair of tables sharing such
+        a column, an InferredRelationship is created.
+        """
+        # Map column_name -> set of table full_names that contain it
+        id_column_tables: dict[str, set[str]] = defaultdict(set)
+
+        for table in tables:
+            for col in table.columns:
+                if col.name.endswith("_id"):
+                    id_column_tables[col.name].add(table.full_name)
+
+        relationships: list[InferredRelationship] = []
+        likely_join_keys: list[str] = []
+
+        MAX_TOTAL_RELS = 100_000
+        for col_name, table_names in id_column_tables.items():
+            if len(table_names) > 3:
+                likely_join_keys.append(col_name)
+                sorted_names = sorted(table_names)[:10]
+                for src, tgt in combinations(sorted_names, 2):
+                    relationships.append(
+                        InferredRelationship(
+                            source_table=src,
+                            target_table=tgt,
+                            join_column=col_name,
+                            confidence=ConfidenceLevel.MEDIUM,
+                            source="naming_convention",
+                        )
+                    )
+                    if len(relationships) >= MAX_TOTAL_RELS:
+                        return relationships, likely_join_keys
+
+        return relationships, likely_join_keys
+
+    @staticmethod
+    def _infer_from_views(
+        view_definitions: dict[str, str],
+    ) -> list[InferredRelationship]:
+        """Parse JOIN clauses from view SQL definitions.
+
+        Extracts table relationships from SQL JOIN patterns found in view
+        definitions.
+        """
+        relationships: list[InferredRelationship] = []
+
+        for view_name, sql in view_definitions.items():
+            # Try to extract ON clause details first
+            for match in ON_CLAUSE_PATTERN.finditer(sql):
+                left_ref = match.group(1)
+                left_col = match.group(2)
+                right_ref = match.group(3)
+                # right_col = match.group(4) — same join column typically
+
+                # Use the join column name from the ON clause
+                join_col = left_col
+
+                relationships.append(
+                    InferredRelationship(
+                        source_table=left_ref,
+                        target_table=right_ref,
+                        join_column=join_col,
+                        confidence=ConfidenceLevel.MEDIUM,
+                        source="view_definition",
+                    )
+                )
+
+            # If no ON clause matches, fall back to just detecting JOINed tables
+            if not any(ON_CLAUSE_PATTERN.finditer(sql)):
+                joined_tables = JOIN_PATTERN.findall(sql)
+                for joined_table in joined_tables:
+                    relationships.append(
+                        InferredRelationship(
+                            source_table=view_name,
+                            target_table=joined_table,
+                            join_column="unknown",
+                            confidence=ConfidenceLevel.MEDIUM,
+                            source="view_definition",
+                        )
+                    )
+
+        return relationships
+
+    @staticmethod
+    def _infer_from_query_logs(
+        query_analysis: QueryAnalysis,
+    ) -> list[InferredRelationship]:
+        """Extract relationships from query log join patterns."""
+        relationships: list[InferredRelationship] = []
+
+        for _table, patterns in query_analysis.join_patterns.items():
+            for jp in patterns:
+                relationships.append(
+                    InferredRelationship(
+                        source_table=jp.left_table,
+                        target_table=jp.right_table,
+                        join_column=jp.join_column,
+                        confidence=ConfidenceLevel.HIGH,
+                        source="query_logs",
+                    )
+                )
+
+        return relationships
+
+    @staticmethod
+    def _determine_confidence(
+        query_analysis: QueryAnalysis | None,
+        view_definitions: dict[str, str] | None,
+        naming_keys: list[str],
+    ) -> ConfidenceLevel:
+        """Determine overall confidence based on available data sources.
+
+        HIGH  — query logs provided
+        MEDIUM — view definitions found or naming heuristics produced results
+        LOW   — schema-only analysis
+        """
+        if query_analysis is not None:
+            return ConfidenceLevel.HIGH
+        if (view_definitions and len(view_definitions) > 0) or len(naming_keys) > 0:
+            return ConfidenceLevel.MEDIUM
+        return ConfidenceLevel.LOW

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/scanner.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/scanner.py
@@ -1,0 +1,475 @@
+"""BigQuery metadata scanner — yields normative EntityMetadata (R2, R3, R4, R23.1-.2).
+
+Read-only: captures table/view/mview/routine *metadata and definitions* only; never
+executes SELECT against data rows (R22.2). Resilient: transient API errors (429/500/503)
+retried with exponential backoff (R23.1); per-entity failures recorded and skipped (R23.2).
+
+Implements the design.md § Component Interfaces ``BigQueryScanner`` contract — the frozen
+seam other modules build on is ``scan() -> Iterator[EntityMetadata]`` and
+``self.failures: list[FailureRecord]``. (Issue #6 / 1.1.)
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import re
+import time
+from collections.abc import Iterator
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import bigquery
+from google.oauth2 import service_account
+
+from bq_assess.core.classifier import classify_population
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    FailureRecord,
+    RangePartitionConfig,
+    RoutineMetadata,
+    TimePartitionConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Retry configuration for transient BigQuery API errors (R23.1)
+RETRY_CONFIG = {
+    "max_retries": 3,
+    "initial_delay_seconds": 1.0,
+    "backoff_multiplier": 2.0,  # 1s, 2s, 4s
+    "retryable_status_codes": [429, 500, 503],
+}
+
+# BigQuery table_type string -> EntityType (R4.1). Unknown types fall back to TABLE.
+_TABLE_TYPE_MAP: dict[str, EntityType] = {
+    "TABLE": EntityType.TABLE,
+    "EXTERNAL": EntityType.EXTERNAL,
+    "VIEW": EntityType.VIEW,
+    "MATERIALIZED_VIEW": EntityType.MATERIALIZED_VIEW,
+}
+
+
+class ScannerError(Exception):
+    """Raised when the scanner encounters a fatal error (auth, project-not-found)."""
+
+
+def population_for(entity_type: EntityType) -> EntityPopulation:
+    """Deprecated shim — delegates to the canonical classifier (issue #7).
+
+    Kept as a thin alias so any external caller of the old name still works; new code
+    should import ``classify_population`` from ``core/classifier`` directly. (The #6 seam
+    note is resolved: the classifier is now the single source of truth.)
+    """
+    return classify_population(entity_type)
+
+
+class BigQueryScanner:
+    """Scans BigQuery project metadata with retry logic and per-entity resilience.
+
+    Supports service-account JSON credentials or Application Default Credentials.
+    Accesses metadata and object definitions only — never reads data rows (R22.2).
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        credentials_path: str | None = None,
+        use_adc: bool = False,
+        max_concurrent_requests: int = 16,
+    ) -> None:
+        self._project_id = project_id
+        self._credentials_path = credentials_path
+        self._use_adc = use_adc
+        self._max_concurrent = max_concurrent_requests
+        self._client: bigquery.Client | None = None
+        self.failures: list[FailureRecord] = []
+
+    # ------------------------------------------------------------------
+    # Client initialisation
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> bigquery.Client:
+        """Lazily create and return the BigQuery client (read-only scope)."""
+        if self._client is not None:
+            return self._client
+
+        if self._credentials_path:
+            credentials = service_account.Credentials.from_service_account_file(
+                self._credentials_path,
+                scopes=["https://www.googleapis.com/auth/bigquery.readonly"],
+            )
+            self._client = bigquery.Client(
+                project=self._project_id, credentials=credentials
+            )
+        elif self._use_adc:
+            self._client = bigquery.Client(project=self._project_id)
+        else:
+            raise ScannerError(
+                "No credentials provided. Supply a service account JSON path "
+                "or enable Application Default Credentials (--use-adc)."
+            )
+
+        self._expand_connection_pool(self._client)
+        return self._client
+
+    def _expand_connection_pool(self, client: bigquery.Client) -> None:
+        """Resize the HTTP connection pool to match concurrency, preventing pool-full warnings."""
+        from requests.adapters import HTTPAdapter
+
+        pool_size = self._max_concurrent + 10
+        adapter = HTTPAdapter(pool_connections=pool_size, pool_maxsize=pool_size)
+        client._http.mount("https://", adapter)
+        client._http.mount("http://", adapter)
+
+    # ------------------------------------------------------------------
+    # Credential validation (R2)
+    # ------------------------------------------------------------------
+
+    def validate_credentials(self) -> bool:
+        """Run a lightweight metadata-only call to verify read access (R2.1).
+
+        Returns ``True`` on success; raises :class:`ScannerError` with a descriptive
+        message distinguishing invalid-credentials / insufficient-permissions /
+        project-not-found on failure (R2.2).
+        """
+        try:
+            client = self._get_client()
+            _ = list(client.list_datasets(max_results=1))
+            return True
+        except ScannerError:
+            raise
+        except Exception as exc:
+            raise ScannerError(_describe_auth_error(exc)) from exc
+
+    # ------------------------------------------------------------------
+    # Scanning (R3, R4, R23)
+    # ------------------------------------------------------------------
+
+    def scan(
+        self, dataset_filter: list[str] | None = None
+    ) -> Iterator[EntityMetadata]:
+        """Yield :class:`EntityMetadata` for every entity in the project.
+
+        Scans, per dataset: tables/views/materialized-views/external (via ``list_tables``
+        + ``get_table``) and persistent routines (via ``list_routines``). When
+        ``dataset_filter`` is provided, only those datasets are scanned; otherwise all
+        datasets in the project (R3.4).
+
+        Transient API errors are retried (R23.1). Per-entity errors are recorded in
+        ``self.failures`` and skipped so one bad entity never aborts the scan (R23.2).
+        """
+        client = self._get_client()
+        self.failures = []
+
+        datasets = self._list_datasets_with_retry(client)
+        if dataset_filter:
+            filter_set = set(dataset_filter)
+            datasets = [ds for ds in datasets if ds.dataset_id in filter_set]
+
+        for dataset_ref in datasets:
+            dataset_id = dataset_ref.dataset_id
+            yield from self._scan_tables(client, dataset_id)
+            yield from self._scan_routines(client, dataset_id)
+
+    def _scan_tables(
+        self, client: bigquery.Client, dataset_id: str
+    ) -> Iterator[EntityMetadata]:
+        """Yield EntityMetadata for tables/views/mviews/external in a dataset.
+
+        Uses a thread pool to parallelize get_table calls (I/O-bound). On early exit
+        (KeyboardInterrupt, GeneratorExit) pending futures are cancelled immediately.
+        """
+        try:
+            table_items = self._list_tables_with_retry(client, dataset_id)
+        except Exception as exc:  # dataset-level failure → record + continue (R23.2)
+            logger.error("Failed to list tables in %s: %s", dataset_id, exc)
+            self.failures.append(
+                FailureRecord(entity_name=dataset_id, stage="scan", error=str(exc))
+            )
+            return
+
+        yield from self._parallel_fetch(
+            table_items,
+            lambda item: self._get_table_with_retry(client, item.reference),
+            lambda item: f"{item.dataset_id}.{item.table_id}",
+            _to_entity_metadata,
+        )
+
+    def _scan_routines(
+        self, client: bigquery.Client, dataset_id: str
+    ) -> Iterator[EntityMetadata]:
+        """Yield EntityMetadata for persistent routines (UDFs / procedures) — R3.3."""
+        try:
+            routines = self._list_routines_with_retry(client, dataset_id)
+        except Exception as exc:
+            logger.error("Failed to list routines in %s: %s", dataset_id, exc)
+            self.failures.append(
+                FailureRecord(
+                    entity_name=f"{dataset_id} (routines)",
+                    stage="scan",
+                    error=str(exc),
+                )
+            )
+            return
+
+        yield from self._parallel_fetch(
+            routines,
+            lambda r: _retry(lambda: client.get_routine(r.reference)),
+            lambda r: f"{dataset_id}.{r.routine_id}",
+            lambda full_routine: _routine_to_entity(full_routine, dataset_id),
+        )
+
+    # ------------------------------------------------------------------
+    # Parallel fetch helper
+    # ------------------------------------------------------------------
+
+    def _parallel_fetch(self, items, fetch_fn, name_fn, transform_fn) -> Iterator[EntityMetadata]:
+        """Submit fetch_fn for each item via thread pool; yield transform_fn(result).
+
+        On early exit (KeyboardInterrupt, GeneratorExit) pending futures are cancelled
+        immediately — the process never blocks waiting for in-flight work to drain.
+        """
+        pool = ThreadPoolExecutor(max_workers=self._max_concurrent)
+        futures: dict[Future, str] = {}
+        try:
+            for item in items:
+                futures[pool.submit(fetch_fn, item)] = name_fn(item)
+            for future in as_completed(futures):
+                full_name = futures[future]
+                try:
+                    yield transform_fn(future.result())
+                except Exception as exc:
+                    logger.error("Failed to scan entity %s: %s", full_name, exc)
+                    self.failures.append(
+                        FailureRecord(entity_name=full_name, stage="scan", error=str(exc))
+                    )
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
+
+    # ------------------------------------------------------------------
+    # Retry wrappers
+    # ------------------------------------------------------------------
+
+    def _list_datasets_with_retry(self, client: bigquery.Client) -> list:
+        return _retry(lambda: list(client.list_datasets()))
+
+    def _list_tables_with_retry(self, client: bigquery.Client, dataset_id: str) -> list:
+        return _retry(lambda: list(client.list_tables(dataset_id)))
+
+    def _list_routines_with_retry(
+        self, client: bigquery.Client, dataset_id: str
+    ) -> list:
+        return _retry(lambda: list(client.list_routines(dataset_id)))
+
+    def _get_table_with_retry(
+        self, client: bigquery.Client, table_ref: bigquery.TableReference
+    ) -> bigquery.Table:
+        return _retry(lambda: client.get_table(table_ref))
+
+
+# ======================================================================
+# Module-level helpers
+# ======================================================================
+
+
+def _retry(fn, config: dict | None = None):
+    """Execute *fn* with exponential-backoff retries on transient errors (R23.1)."""
+    cfg = config or RETRY_CONFIG
+    max_retries: int = cfg["max_retries"]
+    delay: float = cfg["initial_delay_seconds"]
+    multiplier: float = cfg["backoff_multiplier"]
+    retryable: set[int] = set(cfg["retryable_status_codes"])
+
+    last_exc: Exception | None = None
+    for attempt in range(max_retries + 1):  # 0 = first try, 1..3 = retries
+        try:
+            return fn()
+        except GoogleAPICallError as exc:
+            last_exc = exc
+            if exc.code not in retryable or attempt == max_retries:
+                raise
+            jittered = delay * (0.5 + random.random())  # nosec B311 - retry jitter, not cryptographic
+            logger.warning(
+                "Transient error (code=%s), retrying in %.1fs (attempt %d/%d)",
+                exc.code,
+                jittered,
+                attempt + 1,
+                max_retries,
+            )
+            time.sleep(jittered)
+            delay *= multiplier
+        except Exception:
+            raise
+
+    raise last_exc  # type: ignore[misc]  # unreachable; satisfies type checkers
+
+
+def _describe_auth_error(exc: Exception) -> str:
+    """Return a user-friendly description for auth/permission errors (R2.2)."""
+    msg = str(exc).lower()
+    if "403" in msg or "permission" in msg:
+        return (
+            f"Insufficient permissions for project: {exc}. "
+            "Ensure the principal has the bigquery.metadataViewer (or dataViewer) role."
+        )
+    if "404" in msg or "not found" in msg:
+        return f"Project not found or inaccessible: {exc}"
+    if "invalid" in msg or "credential" in msg or "401" in msg:
+        return f"Invalid credentials: {exc}"
+    return f"Credential validation failed: {exc}"
+
+
+def _entity_type_for(table: bigquery.Table) -> EntityType:
+    """Map a BigQuery table_type to EntityType (R4.1); unknown → TABLE."""
+    return _TABLE_TYPE_MAP.get((table.table_type or "TABLE").upper(), EntityType.TABLE)
+
+
+def _to_entity_metadata(table: bigquery.Table) -> EntityMetadata:
+    """Convert a ``bigquery.Table`` to :class:`EntityMetadata` (tables/views/mviews)."""
+    entity_type = _entity_type_for(table)
+    population = classify_population(entity_type)
+
+    columns = [_to_column_schema(f) for f in table.schema] if table.schema else []
+
+    time_part = _to_time_partition(table)
+    range_part = _to_range_partition(table)  # R3.8 — captured distinctly
+    clustering = list(table.clustering_fields) if table.clustering_fields else None
+
+    view_query = getattr(table, "view_query", None)
+    mview_query = getattr(table, "mview_query", None)
+
+    depends_on = _extract_dependencies(view_query or mview_query)
+
+    return EntityMetadata(
+        entity_id=table.table_id,
+        dataset_id=table.dataset_id,
+        full_name=f"{table.dataset_id}.{table.table_id}",
+        entity_type=entity_type,
+        population=population,
+        num_rows=table.num_rows or 0,
+        num_bytes=table.num_bytes or 0,
+        columns=columns,
+        time_partitioning=time_part,
+        range_partitioning=range_part,
+        clustering_fields=clustering,
+        view_query=view_query,
+        mview_query=mview_query,
+        routine=None,
+        depends_on=depends_on,
+        last_modified=_normalize_modified(table.modified),
+    )
+
+
+def _routine_to_entity(routine, dataset_id: str) -> EntityMetadata:
+    """Convert a fully-fetched routine to a ROUTINE :class:`EntityMetadata` (R3.3)."""
+
+    arguments = [
+        arg.name or f"arg{i}"
+        for i, arg in enumerate(routine.arguments or [])
+    ]
+    routine_meta = RoutineMetadata(
+        name=routine.routine_id,
+        language=routine.language or "SQL",
+        arguments=arguments,
+        body=routine.body or "",
+        routine_type=str(routine.type_ or "SCALAR_FUNCTION"),
+    )
+
+    depends_on = _extract_dependencies(routine.body)
+
+    return EntityMetadata(
+        entity_id=routine.routine_id,
+        dataset_id=dataset_id,
+        full_name=f"{dataset_id}.{routine.routine_id}",
+        entity_type=EntityType.ROUTINE,
+        population=EntityPopulation.REBUILT,
+        num_rows=0,
+        num_bytes=0,
+        columns=[],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=routine_meta,
+        depends_on=depends_on,
+        last_modified=_normalize_modified(getattr(routine, "modified", None)),
+    )
+
+
+def _to_time_partition(table: bigquery.Table) -> TimePartitionConfig | None:
+    """Capture time partitioning; field=None models ingestion-time (_PARTITIONTIME)."""
+    tp = table.time_partitioning
+    if tp is None:
+        return None
+    return TimePartitionConfig(type=tp.type_ or "DAY", field=tp.field)
+
+
+def _to_range_partition(table: bigquery.Table) -> RangePartitionConfig | None:
+    """Capture range partitioning distinctly from time partitioning (R3.8)."""
+    rp = getattr(table, "range_partitioning", None)
+    if rp is None:
+        return None
+    rng = getattr(rp, "range_", None)
+    return RangePartitionConfig(
+        field=rp.field,
+        start=int(getattr(rng, "start", 0) or 0),
+        end=int(getattr(rng, "end", 0) or 0),
+        interval=int(getattr(rng, "interval", 1) or 1),
+    )
+
+
+def _to_column_schema(field: bigquery.SchemaField) -> ColumnSchema:
+    """Recursively convert a BigQuery ``SchemaField`` to :class:`ColumnSchema`.
+
+    Nesting is preserved (no flattening) — STRUCT/RECORD children recurse (R6.2).
+    """
+    nested = [_to_column_schema(f) for f in field.fields] if field.fields else []
+    return ColumnSchema(
+        name=field.name,
+        field_type=field.field_type,
+        mode=field.mode or "NULLABLE",
+        fields=nested,
+    )
+
+
+# Matches `project.dataset.table` or `dataset.table` references inside FROM/JOIN clauses,
+# optionally backtick-quoted. Best-effort dependency extraction (R4.5); refined in 4.x.
+_DEP_RE = re.compile(
+    r"(?:FROM|JOIN)\s+`?([A-Za-z0-9_.\-]+)`?",
+    re.IGNORECASE,
+)
+
+
+def _extract_dependencies(sql: str | None) -> list[str]:
+    """Best-effort parse of referenced tables from view/mview/routine SQL (R4.5).
+
+    Returns ``dataset.table`` FQNs (project prefix stripped), de-duplicated, order-stable.
+    Deliberately conservative — relationship inference (issue 4.1) refines this later.
+    """
+    if not sql:
+        return []
+    seen: dict[str, None] = {}
+    for raw in _DEP_RE.findall(sql):
+        ref = raw.strip("`").strip()
+        if not ref or "." not in ref:
+            continue
+        parts = ref.split(".")
+        # Normalize project.dataset.table -> dataset.table
+        fqn = ".".join(parts[-2:]) if len(parts) >= 2 else ref
+        seen.setdefault(fqn, None)
+    return list(seen.keys())
+
+
+def _normalize_modified(modified: datetime | None) -> datetime:
+    """Return a tz-aware UTC datetime for the entity's last-modified time."""
+    if modified is None:
+        return datetime.now(timezone.utc)
+    if modified.tzinfo is None:
+        return modified.replace(tzinfo=timezone.utc)
+    return modified

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/sql_surface.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/sql_surface.py
@@ -1,0 +1,222 @@
+"""SQL Surface assembly + BigQuery construct detection + anonymization (R10, R22.4).
+
+The SQL Surface is every piece of Source SQL the Query Complexity axis scores: view SQL,
+materialized-view SQL, and persistent UDF/procedure bodies (auto-captured), plus inline
+``CREATE TEMP FUNCTION`` and ad-hoc query text when query logs are provided (R10.1, R10.2).
+
+``detect()`` scans a SQL string for BigQuery-specific constructs in five classes
+(R10.3); ``anonymize()`` strips string and numeric literals before anything is stored or
+reported (R10.4 / R22.4); ``assemble()`` builds the per-entity surface keyed by full_name
+and attributes each construct to its entity (R10.5).
+
+Issue #19 / 3.1.
+
+⚠️ SEAM (see SCRUM_NOTES § construct_class vocabulary): ``DetectedConstruct.construct_class``
+is a plain ``str``. The five canonical values below are the contract the Query Complexity
+scorer (``scoring/complexity.py``, Ryan / #21) keys on. They match design.md and issue #21's
+description. Hardening this to an Enum on ``models.py`` is an open option pending Ryan — do
+NOT diverge from these strings without updating both sides.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from bq_assess.models import DetectedConstruct, EntityMetadata
+
+# ---- Canonical construct classes (the frozen seam with scoring/complexity) ----
+
+UNNEST = "UNNEST"
+FUNCTION_DRIFT = "FUNCTION_DRIFT"
+ARRAY_FN = "ARRAY_FN"
+STRUCT_NAV = "STRUCT_NAV"
+JS_UDF = "JS_UDF"
+
+CONSTRUCT_CLASSES = (UNNEST, FUNCTION_DRIFT, ARRAY_FN, STRUCT_NAV, JS_UDF)
+
+
+# ---------------------------------------------------------------------------
+# Anonymization (R10.4 / R22.4) — salvaged from core/analyzer.py
+# ---------------------------------------------------------------------------
+
+# Single-quoted string literals (handles empty strings; greedy within quotes).
+_STRING_LITERAL_RE = re.compile(r"'[^']*'")
+
+# Numeric literals following an operator/keyword/punctuation, so digits inside
+# identifiers (e.g. col1, table2) are preserved.
+_NUMERIC_LITERAL_RE = re.compile(r"(?<=[\s=><!(,+\-*/])\d+\.?\d*(?=[\s,);]|$)")
+
+
+# ---------------------------------------------------------------------------
+# Construct detection patterns (R10.3)
+# ---------------------------------------------------------------------------
+
+# UNNEST(...) array-unnesting.
+_UNNEST_RE = re.compile(r"\bUNNEST\s*\(", re.IGNORECASE)
+
+# ARRAY_* scalar/aggregate functions (ARRAY_AGG, ARRAY_LENGTH, ARRAY_TO_STRING, ...)
+# and ARRAY[...] / ARRAY<...>(...) constructors.
+_ARRAY_FN_RE = re.compile(r"\bARRAY_[A-Z_]+\s*\(|\bARRAY\s*[<\[]", re.IGNORECASE)
+
+# Function-name / semantic drift: BigQuery functions whose Redshift equivalent differs in
+# name or argument order. Conservative, high-signal set (R10.3 names DATE_DIFF, ARRAY_LENGTH).
+_FUNCTION_DRIFT_NAMES = (
+    "DATE_DIFF",
+    "DATETIME_DIFF",
+    "TIMESTAMP_DIFF",
+    "ARRAY_LENGTH",
+    "SAFE_CAST",
+    "FORMAT_DATE",
+    "PARSE_DATE",
+    "GENERATE_ARRAY",
+    "GENERATE_DATE_ARRAY",
+    "APPROX_QUANTILES",
+)
+_FUNCTION_DRIFT_RE = re.compile(
+    r"\b(" + "|".join(_FUNCTION_DRIFT_NAMES) + r")\s*\(", re.IGNORECASE
+)
+
+# Nested STRUCT path navigation: dotted access two or more levels deep
+# (e.g. payload.user.id). Avoids matching simple alias.col by requiring >=2 dots.
+_STRUCT_NAV_RE = re.compile(r"\b\w+\.\w+\.\w+\b")
+
+# JavaScript UDF: LANGUAGE js (in a CREATE FUNCTION / TEMP FUNCTION body).
+_JS_UDF_RE = re.compile(r"\bLANGUAGE\s+js\b", re.IGNORECASE)
+
+# Inline temp function marker (R10.2) — used by assemble() when scanning ad-hoc query text.
+_TEMP_FUNCTION_RE = re.compile(r"\bCREATE\s+(?:TEMP|TEMPORARY)\s+FUNCTION\b", re.IGNORECASE)
+
+
+_DETECTORS: list[tuple[str, re.Pattern, str]] = [
+    (JS_UDF, _JS_UDF_RE, "JavaScript UDF — no Query Engine equivalent; rewrite to Python/Lambda UDF."),
+    (UNNEST, _UNNEST_RE, "UNNEST over nested/array data — rewrite array-unnesting for the Query Engine."),
+    (ARRAY_FN, _ARRAY_FN_RE, "ARRAY_* function or ARRAY constructor — dialect adaptation required."),
+    (FUNCTION_DRIFT, _FUNCTION_DRIFT_RE, "BigQuery function with name/argument-order drift — adapt to the Query Engine dialect."),
+    (STRUCT_NAV, _STRUCT_NAV_RE, "Nested STRUCT path navigation — verify struct access on the Query Engine."),
+]
+
+
+class SQLSurfaceAnalyzer:
+    """Assembles the SQL Surface and detects BigQuery-specific constructs (R10)."""
+
+    # ------------------------------------------------------------------
+    # Anonymization (R10.4 / R22.4)
+    # ------------------------------------------------------------------
+
+    def anonymize(self, sql: str) -> str:
+        """Replace string and numeric literals with ``?`` placeholders.
+
+        String literals → ``'?'``; numeric literals after operators/keywords → ``?``.
+        Identifiers containing digits (``col1``, ``table2``) are preserved. After this,
+        no original literal value remains (P17).
+        """
+        if not sql:
+            return sql
+        result = _STRING_LITERAL_RE.sub("'?'", sql)
+        result = _NUMERIC_LITERAL_RE.sub("?", result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Construct detection (R10.3)
+    # ------------------------------------------------------------------
+
+    def detect(self, sql: str) -> list[DetectedConstruct]:
+        """Detect BigQuery-specific constructs in a single SQL string.
+
+        Returns one :class:`DetectedConstruct` per construct *class* present (deduped by
+        class), each carrying an anonymized snippet (R10.4) and a human-readable description.
+        Order is stable and deterministic (the detector order above).
+        """
+        if not sql:
+            return []
+
+        constructs: list[DetectedConstruct] = []
+        for construct_class, pattern, description in _DETECTORS:
+            match = pattern.search(sql)
+            if match is None:
+                continue
+            constructs.append(
+                DetectedConstruct(
+                    construct_class=construct_class,
+                    snippet=self._snippet(sql, match),
+                    description=description,
+                )
+            )
+        return constructs
+
+    # ------------------------------------------------------------------
+    # Surface assembly (R10.1, R10.2, R10.5)
+    # ------------------------------------------------------------------
+
+    def assemble(
+        self,
+        entities: Iterable[EntityMetadata],
+        query_log_text: list[str] | None = None,
+    ) -> dict[str, list[str]]:
+        """Build the SQL Surface: a map of entity full_name → list of SQL strings.
+
+        Auto-captured surface (always available, R10.1):
+          - views → ``view_query``
+          - materialized views → ``mview_query``
+          - routines → ``routine.body``
+        Log-only surface (only when ``query_log_text`` is provided, R10.2):
+          - each ad-hoc query / inline ``CREATE TEMP FUNCTION`` body, keyed under
+            ``"__ad_hoc__"`` since it is not owned by a defined entity.
+
+        All SQL is anonymized before being placed in the surface (R10.4 / R22.4).
+        """
+        surface: dict[str, list[str]] = {}
+
+        for entity in entities:
+            sqls: list[str] = []
+            if entity.view_query:
+                sqls.append(entity.view_query)
+            if entity.mview_query:
+                sqls.append(entity.mview_query)
+            if entity.routine is not None and entity.routine.body:
+                sqls.append(entity.routine.body)
+            if sqls:
+                surface[entity.full_name] = [self.anonymize(s) for s in sqls]
+
+        if query_log_text:
+            ad_hoc = [self.anonymize(q) for q in query_log_text if q]
+            if ad_hoc:
+                surface["__ad_hoc__"] = ad_hoc
+
+        return surface
+
+    def detect_for_entities(
+        self,
+        entities: Iterable[EntityMetadata],
+        query_log_text: list[str] | None = None,
+    ) -> dict[str, list[DetectedConstruct]]:
+        """Attribute detected constructs to each entity (R10.5).
+
+        Convenience over ``assemble`` + ``detect``: returns full_name → constructs, including
+        the ``"__ad_hoc__"`` bucket for log-sourced SQL. Entities with no detected construct
+        are omitted (callers treat absence as "no constructs", not failure).
+        """
+        result: dict[str, list[DetectedConstruct]] = {}
+        for full_name, sqls in self.assemble(entities, query_log_text).items():
+            found: list[DetectedConstruct] = []
+            seen: set[str] = set()
+            for sql in sqls:
+                for c in self.detect(sql):
+                    if c.construct_class not in seen:
+                        seen.add(c.construct_class)
+                        found.append(c)
+            if found:
+                result[full_name] = found
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _snippet(self, sql: str, match: re.Match, width: int = 40) -> str:
+        """Return an anonymized window around *match* for human context (R10.4)."""
+        start = max(0, match.start() - width // 2)
+        end = min(len(sql), match.end() + width // 2)
+        window = sql[start:end].replace("\n", " ").strip()
+        return self.anonymize(window)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/storage_stats.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/storage_stats.py
@@ -1,0 +1,115 @@
+"""Physical-bytes resolution from INFORMATION_SCHEMA.TABLE_STORAGE.
+
+Queries `current_physical_bytes` per table (compressed Parquet footprint, excluding
+time-travel and fail-safe). Falls back to ASSUMED_PHYSICAL_RATIO × logical when
+the view is unreadable or rows are missing.
+
+The TABLE_STORAGE query filters to only the datasets that contain sized entities
+(num_bytes > 0), reducing query cost and improving performance on large projects.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from bq_assess.core.jobs_query import _retry_query
+
+logger = logging.getLogger(__name__)
+
+# Assumed physical/logical ratio when TABLE_STORAGE is unreadable — deliberately
+# conservative (typical Parquet compression is 2-5×). Lives here (not the cost engine)
+# because physical-bytes resolution is a collection-time concern; the engine re-exports
+# it for its storage-cost notes.
+ASSUMED_PHYSICAL_RATIO: float = 0.75
+
+
+@dataclass
+class StorageStats:
+    physical_map: dict[str, int]   # full_name → physical bytes
+    measured_count: int            # sized entities with a TABLE_STORAGE row
+    assumed_count: int             # sized entities that got the ratio fallback
+    source_note: str
+
+    @property
+    def basis(self) -> str:
+        if self.measured_count and not self.assumed_count:
+            return "measured"
+        if self.measured_count:
+            return "mixed"
+        return "assumed"
+
+
+def resolve_physical_bytes(client, project_id: str, location: str, entities) -> StorageStats:
+    """Resolve physical bytes for all entities; measured when possible, ratio fallback otherwise."""
+    measured_map: dict[str, int] = {}
+    try:
+        measured_map = _query_table_storage(client, project_id, location, entities)
+    except Exception as exc:
+        logger.warning("Could not read INFORMATION_SCHEMA.TABLE_STORAGE: %s", exc)
+
+    physical_map: dict[str, int] = {}
+    measured_count = 0
+    assumed_count = 0
+
+    for entity in entities:
+        if entity.num_bytes == 0:
+            physical_map[entity.full_name] = 0
+        elif entity.full_name in measured_map:
+            physical_map[entity.full_name] = measured_map[entity.full_name]
+            measured_count += 1
+        else:
+            physical_map[entity.full_name] = round(entity.num_bytes * ASSUMED_PHYSICAL_RATIO)
+            assumed_count += 1
+
+    if measured_count and assumed_count:
+        source_note = (
+            f"{measured_count} tables measured from TABLE_STORAGE; "
+            f"{assumed_count} sized at {ASSUMED_PHYSICAL_RATIO}× logical fallback."
+        )
+    elif measured_count:
+        source_note = f"Physical bytes measured from TABLE_STORAGE ({measured_count} tables)."
+    else:
+        source_note = (
+            f"TABLE_STORAGE unavailable — all entities sized at "
+            f"{ASSUMED_PHYSICAL_RATIO}× logical (conservative; typical compression is 2–5×)."
+        )
+
+    return StorageStats(
+        physical_map=physical_map,
+        measured_count=measured_count,
+        assumed_count=assumed_count,
+        source_note=source_note,
+    )
+
+
+def _query_table_storage(client, project_id: str, location: str, entities) -> dict[str, int]:
+    """Query TABLE_STORAGE and return {full_name: current_physical_bytes}.
+
+    Filters to datasets containing sized entities (num_bytes > 0) to reduce query cost.
+    """
+    # Derive the set of datasets with sized entities
+    dataset_ids = sorted({e.dataset_id for e in entities if e.num_bytes > 0})
+
+    sql = (
+        f"SELECT table_schema, table_name, current_physical_bytes "
+        f"FROM `{project_id}`.`region-{location.lower()}`.INFORMATION_SCHEMA.TABLE_STORAGE"
+    )
+
+    # Add WHERE clause if we have datasets to filter
+    if dataset_ids:
+        quoted_datasets = ", ".join(f"'{ds}'" for ds in dataset_ids)
+        sql += f" WHERE table_schema IN ({quoted_datasets})"
+
+    rows = _retry_query(lambda: client.query(sql).result())
+    result: dict[str, int] = {}
+    for row in rows:
+        full_name = f"{row.table_schema}.{row.table_name}"
+        result[full_name] = int(row.current_physical_bytes or 0)
+    return result
+
+
+def effective_physical_bytes(num_bytes: int, physical_bytes: int | None) -> int:
+    """Physical bytes if resolved; else the conservative ASSUMED_PHYSICAL_RATIO fallback."""
+    if physical_bytes is not None:
+        return int(physical_bytes)
+    return round(num_bytes * ASSUMED_PHYSICAL_RATIO)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/core/workload.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/core/workload.py
@@ -1,0 +1,513 @@
+"""Slot-time and workload analysis — the BigQuery compute-consumption curve (R17).
+
+``WorkloadAnalyzer`` reads the workload from ``INFORMATION_SCHEMA.JOBS`` (live,
+``analyze_from_api``) or an exported query-log JSON file (``analyze_from_file``) over a
+lookback window, and derives a Slot Time utilization curve: average / P50 / P99 / peak
+concurrent slots plus an active-hour fraction (idle vs busy). The result grounds the AWS
+compute estimate (R18) in real utilization.
+
+Scale note (2026-07-08, storm audit): the live path reads HOURLY aggregates
+(``jobs_query.read_jobs_hourly`` — ≤ 24×days rows) rather than per-job rows. Every curve
+metric was already derived from hourly buckets or grand sums, so aggregating server-side
+removes the multi-GB row stream a busy Source produced (the 10 PB-scale OOM risk). The
+file path accepts BOTH formats: legacy per-job entries (``creation_time`` key) are
+bucketed client-side; hourly-aggregate entries (parseable ``hour_bucket`` value, as
+written by the metadata exporter) pass straight through.
+
+Billed-basis policy (single rule, every input shape): a bucket is billed-carrying iff
+every job it summarizes carried a non-NULL ``total_bytes_billed`` — tracked as
+``missing_billed_jobs`` on each bucket (NULL column value live; absent key in a file
+entry). Any missing job degrades the window to the processed-bytes fallback (a labelled
+overestimate, never a silent underestimate). Intentional behavior change from the
+per-job era, which counted NULL billed as $0 on the billed basis: under capacity
+(reservation) pricing GCP documents total_bytes_billed as "informational only" — the
+value is untrustworthy regardless of whether it arrives as NULL, 0, or a non-billable
+number — so such a Source now degrades honestly instead of reporting a genuine-looking
+$0 scan volume.
+
+Returns ``SlotUtilization | None``: ``None`` (never a zeroed struct, never raised) when there
+is no usable workload — empty job set, missing ``bigquery.jobs.listAll`` (api), or a
+missing/empty/malformed file. That ``None`` is what trips the LOW-confidence cost *range*
+downstream (R18.4 / P22); a zero-struct would silently defeat it.
+
+Metric definitions (deterministic; SCRUM_NOTES § Issue 5.2):
+- ``days_sampled`` = distinct UTC dates carrying a slot-bearing job.
+- ``avg_slots`` = ``total_slot_ms / (days_sampled * 86_400_000)`` — mean concurrency over the
+  active-day window.
+- per-hour slot series over ``[first, last]`` active hour with idle hours zero-filled; ``p50``
+  / ``p99`` are percentiles of that series, ``peak`` its max. Bursty load ⇒ low P50, high peak.
+- ``active_hour_fraction`` = ``busy_hours / (days_sampled * 24)`` clamped to ``[0, 1]``
+  (busy = hour buckets with slot_ms > 0) — the over-provisioning signal R18 reads.
+
+Slot *concurrency* is a per-hour bucket average (``slot_ms / 3.6M``): JOBS carries no per-job
+duration, so instantaneous concurrency is not recoverable — documented approximation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from bq_assess.core import jobs_query
+from bq_assess.core.analyzer import QueryAnalyzer
+from bq_assess.models import SlotUtilization
+
+logger = logging.getLogger(__name__)
+
+_HOUR_MS = 3_600_000
+_DAY_MS = 86_400_000
+
+# Sanity cap on how far a bucket may sit from the workload's median hour. The lookback
+# is ≤ 1 year, so a bucket > ~3 years out is corrupt-by-construction (e.g. a year-9999
+# timestamp) — and one such bucket would make the zero-filled hourly series span
+# millions of hours, resurrecting the OOM the hourly aggregation removed.
+_MAX_SPAN_HOURS = 3 * 366 * 24
+
+
+def parse_json_or_jsonl(text: str) -> list[dict] | None:
+    """Parse text as a JSON array/object, falling back to JSONL (one object per line).
+
+    The single parser for query-log files: WorkloadAnalyzer.analyze_from_file and the
+    collector's statement extraction MUST accept the same formats — the old exporter
+    wrote JSONL, and one stage silently reading [] where the other succeeded was a
+    real bug (2026-07-08 review).
+    """
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            # A single-line JSONL file (e.g. a one-bucket export) parses as a bare
+            # object — treat it as a one-entry log, not an invalid format.
+            return [data]
+        # Valid JSON but not an array/object — reject (not a valid query-log format)
+        return None
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Try JSONL: one JSON object per line
+    lines = [line.strip() for line in text.strip().split("\n") if line.strip()]
+    if not lines:
+        return None
+    entries = []
+    skipped = 0
+    for line in lines:
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                entries.append(obj)
+            else:
+                skipped += 1
+        except (json.JSONDecodeError, ValueError):
+            skipped += 1
+    if skipped:
+        logger.warning("Skipped %d unparseable lines in JSONL query-log file", skipped)
+    return entries if entries else None
+
+
+class WorkloadAnalyzer:
+    """Compute the slot-utilization curve for a Source (R17)."""
+
+    def analyze_from_api(self, client, project_id: str, days: int = 30, location: str = "US"):
+        """Read HOURLY workload aggregates over the lookback and compute the curve.
+
+        Returns (SlotUtilization | None, hourly_buckets: list[dict]). hourly_buckets is the
+        normalized bucket list for metadata export (≤ 24×days entries — bounded regardless
+        of the Source's query volume). Returns (None, []) when no usable workload is
+        readable (R17.3 graceful degradation; never raises).
+        """
+        rows = self._read_jobs(client, project_id, days, location)
+        buckets = self._normalize_hourly_rows(rows)
+        if not buckets:
+            return None, []
+        return self._compute(buckets), buckets
+
+    def analyze_from_file(self, path):
+        """Compute the curve from an exported query-log JSON file (R1.3 ``--query-logs``).
+
+        Accepts BOTH formats, per entry:
+        - **hourly aggregate** (parseable ``hour_bucket`` value) — as written by the
+          metadata exporter's ``jobs_hourly.jsonl``; passes through as a bucket.
+        - **per-job** (``creation_time`` value) — old ``jobs.jsonl`` exports and
+          hand-built logs; bucketed client-side.
+        An entry with a null/unparseable ``hour_bucket`` falls through to the
+        ``creation_time`` branch rather than being dropped.
+
+        Returns (SlotUtilization | None, hourly_buckets: list[dict]). Returns (None, [])
+        when the file is missing/unreadable/malformed or yields no usable entries.
+
+        R17.4 note: the slot-utilization path consumes only slot/byte totals + timestamps
+        and never reads, stores, or reports query text, so there is no query text to anonymize
+        here. Query-text anonymization (R17.4 / R22.4) lives on the separate query-analysis path
+        (``QueryAnalyzer.anonymize_query``); ``WorkloadAnalyzer.anonymize_query`` delegates to it
+        for any caller that does handle query text, but this method does not.
+        """
+        p = Path(path)
+        if not p.exists():
+            return None, []
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning("Could not read query-log file %s: %s", p, exc)
+            return None, []
+        data = self._parse_json_or_jsonl(text)
+        if data is None:
+            return None, []
+
+        buckets = _normalize_entries(data)
+        if not buckets:
+            return None, []
+        return self._compute(buckets), buckets
+
+    def _parse_json_or_jsonl(self, text: str) -> list[dict] | None:
+        """Parse text as JSON array, falling back to JSONL (one JSON object per line)."""
+        return parse_json_or_jsonl(text)
+
+    def anonymize_query(self, query_text: str) -> str:
+        """Strip literal values from query text (R17.4 / R22.4).
+
+        Delegates to ``QueryAnalyzer.anonymize_query`` — single source of truth for the
+        anonymization regex; the Workload Analyzer does not re-implement it.
+        """
+        return QueryAnalyzer().anonymize_query(query_text)
+
+    def _read_jobs(self, client, project_id: str, days: int, location: str) -> list:
+        """Read hourly workload aggregates from project-wide job history over the lookback.
+
+        Delegates to ``core.jobs_query.read_jobs_hourly`` (JOBS_BY_PROJECT, completed-query
+        lookback, project/region-qualified, GROUP BY hour) — ≤ 24×days rows regardless of
+        the Source's query volume. Returns ``[]`` if the query cannot be run (e.g. missing
+        ``jobs.listAll``) — the caller treats no-signal as no-workload (returns None),
+        never an error (R17.3).
+        """
+        return jobs_query.read_jobs_hourly(
+            client, project_id, days=days, location=location,
+        )
+
+    def _normalize_hourly_rows(self, rows) -> list[dict]:
+        """Map raw rows (dict or BigQuery Row) to hourly bucket dicts; drop unusable ones.
+
+        Delegates to the module-level ``_normalize_entries`` — the single dual-format
+        normalizer shared with ``analyze_from_file``, so the live and file paths cannot
+        drift apart on shape or billed-basis rules.
+        """
+        return _normalize_entries(rows)
+
+    def _compute(self, buckets: list[dict]) -> SlotUtilization:
+        """Derive the SlotUtilization curve from hourly buckets (>= 1; see metric defs above)."""
+        total_slot_ms = 0
+        total_bytes_processed = 0
+        total_bytes_billed = 0
+        total_queries = 0
+        # The window counts as billed-carrying only if EVERY bucket carries billed bytes
+        # for every job in it. OR-folding would let one new-format bucket in a mixed
+        # export flip the whole window to a billed total that covers only the carrying
+        # jobs — silently dropping every legacy job's scan volume. All-or-nothing degrades
+        # safely: mixed windows fall back to processed bytes (a labelled overestimate
+        # rather than a silent underestimate).
+        has_billed_bytes = True
+        hour_slot_ms: dict[datetime, int] = defaultdict(int)
+        slot_dates: set = set()
+        all_dates: set = set()
+        for b in buckets:
+            ms = b["total_slot_ms"]
+            total_slot_ms += ms
+            total_bytes_processed += b.get("total_bytes_processed", 0)
+            total_bytes_billed += b.get("total_bytes_billed", 0)
+            total_queries += b.get("job_count", 1)
+            has_billed_bytes = has_billed_bytes and b.get("has_billed_bytes", False)
+            hour = b["hour_bucket"]
+            hour_slot_ms[hour] += ms
+            all_dates.add(hour.date())
+            if ms > 0:
+                slot_dates.add(hour.date())
+
+        # days_sampled = distinct UTC dates with a slot-bearing job (>=1 so denominators hold).
+        days_sampled = max(len(slot_dates), 1)
+
+        # lookback_days = calendar span from first to last job date (for QPD denominator).
+        if all_dates:
+            lookback_days = max((max(all_dates) - min(all_dates)).days + 1, 1)
+        else:
+            lookback_days = days_sampled
+
+        # Per-hour concurrency series over [first, last] active hour, idle hours zero-filled.
+        # Sort once; derive peak/p50/p99 from the single ordered series.
+        ordered = sorted(_hourly_series(hour_slot_ms))
+        peak_slots = ordered[-1] if ordered else 0.0
+        p50_slots = _percentile(ordered, 50)
+        p99_slots = _percentile(ordered, 99)
+
+        avg_slots = total_slot_ms / (days_sampled * _DAY_MS)
+
+        busy_hours = sum(1 for ms in hour_slot_ms.values() if ms > 0)
+        active_hour_fraction = min(1.0, max(0.0, busy_hours / (days_sampled * 24)))
+
+        return SlotUtilization(
+            avg_slots=avg_slots,
+            p50_slots=p50_slots,
+            p99_slots=p99_slots,
+            peak_slots=peak_slots,
+            active_hour_fraction=active_hour_fraction,
+            total_slot_ms=total_slot_ms,
+            days_sampled=days_sampled,
+            total_bytes_processed=total_bytes_processed,
+            total_bytes_billed=total_bytes_billed,
+            has_billed_bytes=has_billed_bytes,
+            total_queries=total_queries,
+            lookback_days=lookback_days,
+        )
+
+
+def _normalize_entries(rows) -> list[dict]:
+    """Normalize dual-format rows (dict or BigQuery Row) into merged hourly buckets.
+
+    The single normalizer behind BOTH input paths (live API rows, file entries), so the
+    format dispatch and the billed-basis rule exist exactly once:
+    - a parseable ``hour_bucket`` value (datetime live, ISO string in a file) → hourly
+      bucket; a null/unparseable ``hour_bucket`` falls through to ``creation_time``
+      rather than dropping the entry.
+    - a parseable ``creation_time`` → single-job bucket, merged client-side.
+
+    ``missing_billed_jobs`` = jobs in the bucket with no billed data: the explicit count
+    on hourly rows, and 1 per per-job row whose billed value is NULL/absent — NULL from a
+    live Row and an absent key in a file entry both mean "billed unavailable", never a
+    genuine zero. A billed column absent from an hourly entry means no job in it carries
+    billed data. The count rides on the bucket so the exporter can round-trip partial
+    billed sums without laundering them into genuine zeros.
+    """
+    buckets: list[dict] = []
+    for row in rows:
+        hour_ts = _coerce_ts(_row_get(row, "hour_bucket", None))
+        if hour_ts is not None:
+            job_count = max(_safe_int(_row_get(row, "job_count", 1)), 1)
+            billed_raw = _row_get(row, "total_bytes_billed", None)
+            if billed_raw is None:
+                missing = job_count
+            else:
+                missing = _missing_count(
+                    _row_get(row, "missing_billed_jobs", 0), job_count
+                )
+            buckets.append({
+                "hour_bucket": _hour_floor(hour_ts),
+                "total_slot_ms": _safe_int(_row_get(row, "total_slot_ms", 0)),
+                "job_count": job_count,
+                "total_bytes_processed": _safe_int(_row_get(row, "total_bytes_processed", 0)),
+                "total_bytes_billed": _safe_int(billed_raw),
+                "missing_billed_jobs": missing,
+                "has_billed_bytes": missing == 0,
+            })
+            continue
+        fields = _per_job_fields(row)
+        if fields is None:
+            continue  # no usable timestamp in either format → unusable entry
+        missing = 0 if fields["has_billed_bytes"] else 1
+        buckets.append({
+            "hour_bucket": _hour_floor(fields["creation_time"]),
+            "total_slot_ms": fields["total_slot_ms"],
+            "job_count": 1,
+            "total_bytes_processed": fields["total_bytes_processed"],
+            "total_bytes_billed": fields["total_bytes_billed"],
+            "missing_billed_jobs": missing,
+            "has_billed_bytes": missing == 0,
+        })
+    return _merge_buckets(_drop_outlier_buckets(buckets))
+
+
+def _drop_outlier_buckets(buckets: list[dict]) -> list[dict]:
+    """Drop buckets implausibly far (> ``_MAX_SPAN_HOURS``) from the median bucket hour.
+
+    A parseable-but-corrupt timestamp (year 9999, epoch-zero) would otherwise stretch the
+    zero-filled ``_hourly_series`` across millions of idle hours — an unbounded allocation
+    from a single bad file entry. Anchoring on the median keeps the real workload and
+    sheds the outlier regardless of which side it lands on. Dropping (vs clamping) keeps
+    the corrupt entry's stats out of the curve entirely; the warning names the count.
+    """
+    if len(buckets) <= 1:
+        return buckets
+    hours = sorted(b["hour_bucket"] for b in buckets)
+    median = hours[len(hours) // 2]
+    kept = [
+        b for b in buckets
+        if abs((b["hour_bucket"] - median).total_seconds()) / 3600 <= _MAX_SPAN_HOURS
+    ]
+    if len(kept) < len(buckets):
+        logger.warning(
+            "Dropped %d workload entr%s with timestamps > %d hours from the median "
+            "bucket (corrupt timestamps would unboundedly inflate the hourly series)",
+            len(buckets) - len(kept), "y" if len(buckets) - len(kept) == 1 else "ies",
+            _MAX_SPAN_HOURS,
+        )
+    return kept
+
+
+def _per_job_fields(row) -> dict | None:
+    """Coerce one per-job row (dict or BigQuery Row) to normalized fields; None if it
+    has no usable ``creation_time``. The single place the per-job billed rule lives:
+    a NULL/absent billed value means "billed unavailable", never a genuine zero."""
+    creation = _coerce_ts(_row_get(row, "creation_time", None))
+    if creation is None:
+        return None
+    billed_raw = _row_get(row, "total_bytes_billed", None)
+    return {
+        "total_slot_ms": _safe_int(_row_get(row, "total_slot_ms", 0)),
+        "creation_time": creation,
+        "total_bytes_processed": _safe_int(_row_get(row, "total_bytes_processed", 0)),
+        "total_bytes_billed": _safe_int(billed_raw),
+        "has_billed_bytes": billed_raw is not None,
+    }
+
+
+def _missing_count(raw, job_count: int) -> int:
+    """Coerce a ``missing_billed_jobs`` value, degrading on garbage.
+
+    A negative or non-numeric count is a corrupt signal about missing billed data — fail
+    toward the processed-bytes fallback (all jobs missing), never toward asserting a
+    billed-carrying basis (the silent-underestimate direction the policy forbids).
+    Clamped to [0, job_count].
+    """
+    try:
+        n = int(raw)
+    except (ValueError, TypeError):
+        return job_count
+    if n < 0:
+        return job_count
+    return min(n, job_count)
+
+
+def _bucket_missing(b: dict) -> int:
+    """A bucket's missing-billed count, deriving from ``has_billed_bytes`` when the
+    count is absent (pre-2026-07-08 bucket shape) — a legacy degraded bucket must not
+    default to 0 and silently un-degrade on merge."""
+    missing = b.get("missing_billed_jobs")
+    if missing is not None:
+        return missing
+    return 0 if b.get("has_billed_bytes", False) else b.get("job_count", 1)
+
+
+def _merge_buckets(buckets: list[dict]) -> list[dict]:
+    """Merge bucket entries sharing an hour — the single accumulator for bucket fields.
+
+    ``missing_billed_jobs`` sums across merged entries and ``has_billed_bytes`` is derived
+    from it, so a merged bucket is billed-carrying iff every summarized job carried billed
+    data (same rule as ``_normalize_entries``). Buckets lacking the count (legacy shape)
+    derive it from their ``has_billed_bytes`` flag via ``_bucket_missing``.
+    """
+    if not buckets:
+        return []
+    by_hour: dict[datetime, dict] = {}
+    for b in buckets:
+        hour = b["hour_bucket"]
+        m = by_hour.get(hour)
+        if m is None:
+            m = by_hour[hour] = dict(b)
+            m["missing_billed_jobs"] = _bucket_missing(b)
+            m["has_billed_bytes"] = m["missing_billed_jobs"] == 0
+            continue
+        m["total_slot_ms"] += b["total_slot_ms"]
+        m["job_count"] += b.get("job_count", 1)
+        m["total_bytes_processed"] += b.get("total_bytes_processed", 0)
+        m["total_bytes_billed"] += b.get("total_bytes_billed", 0)
+        m["missing_billed_jobs"] += _bucket_missing(b)
+        m["has_billed_bytes"] = m["missing_billed_jobs"] == 0
+    return list(by_hour.values())
+
+
+def _coerce_ts(value):
+    """Coerce a timestamp value (datetime from a live Row, ISO string from a file, or
+    None) to a datetime; None if absent/unparseable."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return _parse_iso8601(value)
+
+
+def _hour_floor(dt: datetime) -> datetime:
+    """Truncate a datetime to its UTC hour — the bucket key."""
+    return _to_utc(dt).replace(minute=0, second=0, microsecond=0)
+
+
+def _to_utc(dt):
+    """Normalize a datetime to UTC; treat naive datetimes as already-UTC (Decision D3)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_iso8601(value):
+    """Parse an ISO-8601 timestamp, tolerating a trailing ``Z``; return None if unparseable.
+
+    ``datetime.fromisoformat`` only accepts the ``Z`` (Zulu) suffix on Python 3.11+, but the
+    project supports 3.9+ and BigQuery exports stamp ``creation_time`` with ``Z`` — so normalize
+    ``Z`` → ``+00:00`` first. Never raises (R17.3): a bad value yields None and is skipped.
+    """
+    s = str(value).strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_int(value) -> int:
+    """Coerce a value to a non-negative int; 0 on None/garbage/negative. Never raises (R17.3).
+
+    Accepts float-formatted numeric strings ("3600000.0", "1e6") — third-party query-log
+    exports (spreadsheet/CSV-mediated) stringify numbers that way, and zeroing them would
+    silently erase compute from the curve (the underestimate direction the module forbids).
+    """
+    try:
+        n = int(value)
+    except (ValueError, TypeError, OverflowError):
+        # OverflowError: json.loads accepts the bare Infinity literal → float('inf').
+        try:
+            n = int(float(value))
+        except (ValueError, TypeError, OverflowError):
+            return 0
+    return n if n > 0 else 0
+
+
+def _hourly_series(hour_slot_ms: dict) -> list[float]:
+    """Concurrency per hour over [first, last] active hour, idle hours zero-filled.
+
+    Concurrency in a bucket = slot_ms / 3.6M (a per-hour average, not instantaneous — JOBS
+    carries no per-job duration). Bursty load ⇒ many zero hours ⇒ low P50, high peak.
+    """
+    if not hour_slot_ms:
+        return []
+    hours = sorted(hour_slot_ms)
+    first, last = hours[0], hours[-1]
+    span_hours = int((last - first).total_seconds() // 3600) + 1
+    series = []
+    for i in range(span_hours):
+        bucket = first + timedelta(hours=i)
+        series.append(hour_slot_ms.get(bucket, 0) / _HOUR_MS)
+    return series
+
+
+def _percentile(ordered: list[float], pct: int) -> float:
+    """Percentile of a PRE-SORTED value series via linear interpolation (deterministic).
+
+    Caller sorts once and passes the ordered series (peak/p50/p99 share one sort). Single-element
+    (or empty) series return that value (or 0.0) — guards the n==1 case so the P21 test is stable.
+    """
+    if not ordered:
+        return 0.0
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def _row_get(row, key, default):
+    """Read a column from either a dict or a BigQuery Row (attribute access)."""
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Query Engine layer: cost estimation, query-rewrite guidance, placement (Redshift Serverless)."""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/__init__.py
@@ -1,0 +1,6 @@
+"""Redshift Serverless Query Engine: Serverless RPU + S3 storage cost, rewrite guidance, placement.
+
+The Query Engine is Redshift Serverless over the Iceberg Storage Target (ADR-0001): no node
+sizing, no DISTKEY/SORTKEY, no provisioned-vs-serverless advisor. See
+``.kiro/specs/phase1-assessment-tool/SCRUM_NOTES.md`` for the #2 restructure decision.
+"""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/cost.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/cost.py
@@ -1,0 +1,1008 @@
+"""Cost comparison — BigQuery vs the AWS lakehouse (R18).
+
+``CostEstimator.estimate()`` produces the honest run-rate comparison that is the business-case
+headline of the tool. The AWS side evaluates **multiple deployment scenarios** — Serverless,
+Provisioned On-Demand, Provisioned 1yr RI, Provisioned 3yr RI — selects the best-fit option
+based on the customer's actual workload profile, and provides a justified recommendation.
+
+Storage is always **decoupled** — S3 Tables (V2) for serverless, Managed Storage (V6) for
+provisioned — independent of compute choice.
+
+The recommendation engine uses customer-specific workload metrics (queries/day, bytes scanned,
+concurrent query load, active hours) to size provisioned clusters and compare against serverless.
+Justification text references the customer's actual numbers, never generic assumptions.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from bq_assess.core import pricing_constants as v4
+from bq_assess.engine.redshift import cost_constants as k
+from bq_assess.models import (
+    AWSRecommendation,
+    AWSScenario,
+    BQPricingModel,
+    ConfidenceLevel,
+    CostComparison,
+    CostLine,
+    PricingDetection,
+    SlotUtilization,
+    WorkloadProfile,
+)
+
+_log = logging.getLogger(__name__)
+
+_MS_PER_HOUR = 3_600_000
+_DAYS_HIGH_CONF = 7
+
+
+class CostEstimator:
+    """Compute the BigQuery-vs-AWS cost comparison (R18)."""
+
+    def __init__(self, *, skip_live_pricing: bool = False):
+        # Refresh once per (bq_location, aws_region) pair — a reused estimator pricing
+        # a second Source in a different geography needs its own live lookup (a plain
+        # once-per-instance flag silently skipped it and left the snapshot rates).
+        self._refreshed_pairs: set[tuple[str, str]] = set()
+        self._skip_live_pricing = skip_live_pricing
+
+    def _refresh_pricing(self, bq_location: str, aws_region: str) -> None:
+        """Attempt live pricing lookup; updates module constants and confirmed dates."""
+        if self._skip_live_pricing or (bq_location, aws_region) in self._refreshed_pairs:
+            return
+        self._refreshed_pairs.add((bq_location, aws_region))
+        try:
+            from bq_assess.core.price_lookup import PriceLookup, apply_live_rates
+            rates = PriceLookup(aws_region=aws_region, bq_location=bq_location).fetch()
+            apply_live_rates(rates)
+        except Exception as exc:
+            _log.warning("Live pricing refresh failed, using hardcoded rates: %s", exc)
+
+    def estimate(
+        self,
+        entities,
+        pricing: PricingDetection,
+        slots: SlotUtilization | None,
+        bq_monthly_override: float | None,
+        effort_total,
+        *,
+        location: str | None = None,
+        storage_basis: str = "assumed",
+    ) -> CostComparison:
+        # ---- Region cascade: price BOTH clouds in the Source's geography (2026-07-02) ----
+        # BigQuery rates re-resolve to the detected dataset location; AWS rates re-resolve
+        # to the nearest AWS region so the comparison is like-for-like. A live pricing
+        # refresh then overrides with current catalog rates for the same regions.
+        # Ordering rules (review fixes 2026-07-03/04):
+        # - The region tags (V4_PRICING_REGION / AWS_PRICING_REGION) are stamped by BOTH
+        #   writers — apply_*_region AND apply_live_rates — so "tag == requested region"
+        #   reliably means the constants already reflect that geography (hardcoded or
+        #   live). When it holds, do NOT re-apply: re-applying would clobber live rates
+        #   back to the hardcoded snapshot. This also protects locations OUTSIDE the
+        #   hardcoded table whose rates came solely from the live Billing Catalog lookup
+        #   (the CLI applies live rates in Stage 9b before calling estimate()).
+        # - If the location is unknown to the table AND no live rates were applied for
+        #   it, RESET to US multi-region rather than silently keeping whatever region a
+        #   previous estimate left in the module constants.
+        # - location=None preserves the module constants as-is (R18.7 override contract);
+        #   bq_pricing_region on the result reports whatever region they reflect.
+        region_known = True
+        if location is not None:
+            bq_location = v4.normalize_bq_location(location) or "us"
+            if v4.V4_PRICING_REGION != bq_location:
+                region_known = v4.apply_bq_region(bq_location)
+                if not region_known:
+                    v4.apply_bq_region("us")   # reset — never inherit a previous region
+                    _log.warning(
+                        "No verified rate table for BigQuery location %r — pricing at US "
+                        "multi-region rates unless a live catalog lookup resolves it",
+                        bq_location,
+                    )
+            aws_region = k.bq_location_to_aws_region(bq_location)
+            if k.AWS_PRICING_REGION != aws_region:
+                k.apply_aws_region(aws_region)
+        else:
+            bq_location = v4.V4_PRICING_REGION
+
+        self._refresh_pricing(bq_location, k.AWS_PRICING_REGION)
+        # Post-refresh reconcile: a live Billing Catalog lookup covers ~49 regions vs the
+        # hardcoded table's subset — if it just resolved this location (stamping the tag),
+        # the "priced at US rates" caveat would be false. Trust the tag.
+        if not region_known and v4.V4_PRICING_REGION == bq_location:
+            region_known = True
+        total_bytes = sum(_entity_bytes(e) for e in entities)
+        total_physical_bytes = sum(_entity_physical_bytes(e) for e in entities)
+
+        # ---- BigQuery side: per detected model, override wins (R18.2) ----
+        bigquery_monthly, bq_breakdown = self._bigquery_runrate(
+            total_bytes, pricing, slots, bq_monthly_override
+        )
+
+        # ---- AWS side: evaluate all scenarios ----
+        profile = self._build_workload_profile(slots, total_bytes)
+        scenarios = self._evaluate_all_scenarios(
+            total_bytes, total_physical_bytes, storage_basis, slots, profile
+        )
+
+        # ---- Select best-fit and generate recommendation ----
+        recommendation = self._generate_recommendation(
+            scenarios, profile, bigquery_monthly
+        )
+
+        # Mark the recommended scenario
+        for s in scenarios:
+            s.is_recommended = (s.label == recommendation.recommended_scenario)
+
+        # Use the recommended scenario for headline numbers
+        best = next((s for s in scenarios if s.is_recommended), scenarios[0])
+        aws_monthly_low = sum(_line_low(ln) for ln in best.lines)
+        aws_monthly_high = sum(_line_high(ln) for ln in best.lines)
+
+        # ---- deltas / annual / break-even ----
+        monthly_delta_low = bigquery_monthly - aws_monthly_high
+        monthly_delta_high = bigquery_monthly - aws_monthly_low
+        annual_savings_low = monthly_delta_low * 12
+        annual_savings_high = monthly_delta_high * 12
+
+        migration_onetime = _safe_num(effort_total) * k.MIGRATION_USD_PER_EFFORT_POINT
+        breakeven_low = _breakeven(migration_onetime, monthly_delta_low)
+        breakeven_high = _breakeven(migration_onetime, monthly_delta_high)
+
+        return CostComparison(
+            bq_pricing_model=pricing.model,
+            bigquery_monthly=bigquery_monthly,
+            bigquery_breakdown=bq_breakdown,
+            aws_lines=best.lines,
+            aws_monthly_low=aws_monthly_low,
+            aws_monthly_high=aws_monthly_high,
+            monthly_delta_low=monthly_delta_low,
+            monthly_delta_high=monthly_delta_high,
+            annual_savings_low=annual_savings_low,
+            annual_savings_high=annual_savings_high,
+            migration_onetime=migration_onetime,
+            breakeven_months_low=breakeven_low,
+            breakeven_months_high=breakeven_high,
+            compute_confidence=best.confidence,
+            aws_scenarios=scenarios,
+            recommendation=recommendation,
+            bq_pricing_region=v4.V4_PRICING_REGION,
+            aws_pricing_region=k.AWS_PRICING_REGION,
+            scope_notes=self._scope_notes(bq_location, region_known),
+        )
+
+    def _scope_notes(self, bq_location: str, region_known: bool) -> list[str]:
+        """What the BigQuery estimate covers/omits — rendered verbatim in reports.
+
+        A customer comparing the estimate against the GCP billing console must know that
+        only analysis (scan) + storage SKUs are modeled; ingestion/egress SKUs
+        (streaming inserts, Storage Read/Write API, BI Engine, Data Transfer Service)
+        appear on the same BigQuery bill but are NOT in this figure.
+        """
+        notes = [
+            "BigQuery estimate covers on-demand analysis (bytes billed) and active logical "
+            "storage only. NOT modeled: streaming inserts, Storage Read/Write API, "
+            "BI Engine, Data Transfer Service — these appear on the BigQuery bill and can "
+            "be significant for ingestion- or extract-heavy projects.",
+            "Monthly projection normalizes to a 30-day month; calendar months of 31 days "
+            "bill ~3% higher.",
+            "On-demand free tier (1 TiB scan + 10 GiB storage/month) and negotiated "
+            "discounts are not modeled.",
+        ]
+        if not region_known and bq_location != "us":
+            notes.insert(0, (
+                f"⚠️ No verified rate table for BigQuery location '{bq_location}' — priced "
+                f"at US multi-region rates, which likely UNDERstates the true cost."
+            ))
+        return notes
+
+    # ================================================================== AWS Scenarios
+
+    def _evaluate_all_scenarios(
+        self, total_bytes: int, total_physical_bytes: int, storage_basis: str,
+        slots: SlotUtilization | None, profile: WorkloadProfile
+    ) -> list[AWSScenario]:
+        """Evaluate Serverless (OD + reservations) + Provisioned RG options."""
+        scenarios = []
+
+        # Scenario 1: Serverless On-Demand (always evaluated)
+        scenarios.append(self._serverless_scenario(
+            total_bytes, total_physical_bytes, storage_basis, slots
+        ))
+
+        # Scenarios 2-3: Serverless Reservations (1yr, 3yr) — only with workload data
+        if slots is not None and slots.total_slot_ms > 0:
+            scenarios.append(self._serverless_reservation_scenario(
+                total_bytes, total_physical_bytes, storage_basis, slots, profile, "1yr"
+            ))
+            scenarios.append(self._serverless_reservation_scenario(
+                total_bytes, total_physical_bytes, storage_basis, slots, profile, "3yr"
+            ))
+
+        # Scenarios 4-6: Provisioned RG (only when we have workload data to size a cluster)
+        if slots is not None and slots.total_slot_ms > 0:
+            node_type, node_count = self._size_cluster(profile)
+            for category, rate_key, label_suffix in [
+                ("PROVISIONED_ONDEMAND", "ondemand_usd_per_node_hour", "On-Demand"),
+                ("PROVISIONED_1YR", "ri_1yr_usd_per_node_hour", "1yr Reserved"),
+                ("PROVISIONED_3YR", "ri_3yr_usd_per_node_hour", "3yr Reserved"),
+            ]:
+                scenarios.append(self._provisioned_scenario(
+                    total_bytes, total_physical_bytes, storage_basis,
+                    profile, node_type, node_count, category, rate_key, label_suffix,
+                ))
+
+        return scenarios
+
+    def _serverless_scenario(
+        self, total_bytes: int, total_physical_bytes: int, storage_basis: str,
+        slots: SlotUtilization | None
+    ) -> AWSScenario:
+        """Redshift Serverless scenario."""
+        storage_line = self._aws_s3_storage_line(total_physical_bytes, storage_basis)
+        compute_line, compute_conf = self._serverless_compute_line(slots)
+        lines = [storage_line, compute_line]
+        total = round(_line_value(storage_line) + _line_value(compute_line), 4)
+
+        if slots is not None and slots.total_slot_ms > 0:
+            qpd = (slots.total_queries / slots.days_sampled) if slots.days_sampled > 0 else 0
+            justification = (
+                f"Serverless at ${k.V1_RPU_HOUR_USD}/RPU-hr ({k.AWS_PRICING_REGION}) with "
+                f"{k.V3_SLOT_TO_RPU_RATIO} slot-to-RPU ratio. "
+                f"Your workload runs {qpd:,.0f} queries/day — pay-per-second only when queries "
+                f"are active, scaling to zero during idle. Consider Serverless Reservations "
+                f"(24–45% discount) if utilization is sustained."
+            )
+        else:
+            justification = (
+                "Serverless estimated with a conservative range (no workload data). "
+                "Suitable for unpredictable or low-volume workloads."
+            )
+
+        return AWSScenario(
+            label="Redshift Serverless",
+            category="SERVERLESS",
+            lines=lines,
+            monthly_total=total,
+            confidence=compute_conf,
+            justification=justification,
+            workload_fit_notes=_serverless_fit_notes(slots),
+        )
+
+    def _serverless_reservation_scenario(
+        self, total_bytes: int, total_physical_bytes: int, storage_basis: str,
+        slots: SlotUtilization, profile: WorkloadProfile, term: str
+    ) -> AWSScenario:
+        """Serverless Reservation (1yr or 3yr) — billed 24/7 for committed RPUs."""
+        if term == "1yr":
+            rpu_rate = k.V1_SERVERLESS_1YR_RPU_HOUR_USD
+            discount_pct = k.V1_SERVERLESS_RESERVATION_1YR_DISCOUNT
+            category = "SERVERLESS_1YR"
+            label = "Serverless Reserved (1yr, All Upfront)"
+            confirmed = k.AWS_SERVERLESS_RESERVATIONS_CONFIRMED_DATE
+        else:
+            rpu_rate = k.V1_SERVERLESS_3YR_RPU_HOUR_USD
+            discount_pct = k.V1_SERVERLESS_RESERVATION_3YR_DISCOUNT
+            category = "SERVERLESS_3YR"
+            label = "Serverless Reserved (3yr, No Upfront)"
+            confirmed = k.AWS_SERVERLESS_RESERVATIONS_CONFIRMED_DATE
+
+        # Reservations bill 24/7 for committed RPUs. Size the commitment from the workload:
+        # use avg_slots × V3 ratio as the base RPU to commit (rounded up to nearest 8).
+        avg_rpus = slots.avg_slots * k.V3_SLOT_TO_RPU_RATIO
+        committed_rpus = max(8, math.ceil(avg_rpus / 8) * 8)
+
+        # 24/7 cost for the committed RPUs
+        compute_monthly = committed_rpus * rpu_rate * k.HOURS_PER_MONTH
+
+        # Overflow: peak usage above committed RPUs billed at on-demand rate,
+        # but peaks are transient — only occur during V1_OVERFLOW_BURST_FRACTION of active hours
+        peak_rpus = slots.peak_slots * k.V3_SLOT_TO_RPU_RATIO
+        overflow_rpus = max(0, peak_rpus - committed_rpus)
+        active_hours = slots.active_hour_fraction * k.HOURS_PER_MONTH
+        overflow_monthly = (
+            overflow_rpus * k.V1_RPU_HOUR_USD * active_hours * k.V1_OVERFLOW_BURST_FRACTION
+        )
+
+        storage_line = self._aws_s3_storage_line(total_physical_bytes, storage_basis)
+        compute_line = CostLine(
+            label=f"Serverless compute ({label})",
+            monthly=round(compute_monthly + overflow_monthly, 4),
+            monthly_low=None, monthly_high=None,
+            confidence=ConfidenceLevel.MEDIUM,
+            source_note=(
+                f"{committed_rpus} RPUs committed @ ${rpu_rate}/RPU-hr 24/7 "
+                f"({discount_pct:.0%} off on-demand). Billed whether active or idle "
+                f"(verified {confirmed})"
+            ),
+        )
+        lines = [storage_line, compute_line]
+        total = round(_line_value(storage_line) + _line_value(compute_line), 4)
+
+        active_frac = profile.active_hour_fraction or 0.5
+        breakeven_util = 1 - discount_pct  # reserved_rate / ondemand_rate
+        justification = (
+            f"Serverless Reservation commits {committed_rpus} RPUs for {term} at "
+            f"${rpu_rate}/RPU-hr ({discount_pct:.0%} discount). Unlike on-demand, reservations "
+            f"bill 24/7 — cost-effective when utilization exceeds ~{breakeven_util:.0%} of hours. "
+            f"Your workload is active {active_frac:.0%} of hours"
+        )
+        if active_frac > breakeven_util:
+            justification += " — the reservation pays for itself."
+        else:
+            justification += (
+                " — below the break-even threshold; on-demand or provisioned may be cheaper."
+            )
+
+        return AWSScenario(
+            label=label,
+            category=category,
+            lines=lines,
+            monthly_total=total,
+            confidence=ConfidenceLevel.MEDIUM,
+            justification=justification,
+            workload_fit_notes=[
+                f"Committed {committed_rpus} RPUs (sized from avg {avg_rpus:.1f} RPU workload)",
+                f"Reservation bills 24/7 — break-even at ~{breakeven_util:.0%} utilization",
+                f"Your active fraction: {active_frac:.0%}",
+            ],
+        )
+
+    def _provisioned_scenario(
+        self, total_bytes: int, total_physical_bytes: int, storage_basis: str,
+        profile: WorkloadProfile, node_type: str, node_count: int,
+        category: str, rate_key: str, label_suffix: str,
+    ) -> AWSScenario:
+        """Redshift Provisioned scenario at a specific commitment level (RG Graviton)."""
+        node_spec = k.V7_RG_NODE_TYPES[node_type]
+        rate = node_spec[rate_key]
+        config_label = f"{node_count}× {node_type}"
+
+        # Compute cost: nodes × rate × 730 hours/month (always-on)
+        compute_monthly = node_count * rate * k.HOURS_PER_MONTH
+
+        # Concurrency scaling overhead (customer-specific based on burst ratio)
+        cs_fraction = self._concurrency_scaling_fraction(profile)
+        cs_overhead = compute_monthly * cs_fraction
+        compute_with_cs = compute_monthly + cs_overhead
+
+        # Storage: data lives in S3 Tables (Iceberg) and is queried via external tables —
+        # both serverless and provisioned share the SAME decoupled-lakehouse storage basis.
+        # Provisioned does NOT load into Redshift Managed Storage (there is no native-DDL
+        # path), so billing RMS would price the wrong storage product for what the migration
+        # actually produces. Bill S3 Tables to match the real mapping.
+        storage_line = self._aws_s3_storage_line(total_physical_bytes, storage_basis)
+        storage_monthly = _line_value(storage_line)
+        compute_line = CostLine(
+            label=f"Compute ({config_label}, {label_suffix})",
+            monthly=round(compute_with_cs, 4), monthly_low=None, monthly_high=None,
+            confidence=ConfidenceLevel.HIGH,
+            source_note=(
+                f"{config_label} @ ${rate}/node-hr × {k.HOURS_PER_MONTH}h "
+                f"+ {cs_fraction:.0%} concurrency scaling "
+                f"(verified {k.AWS_PROVISIONED_CONFIRMED_DATE})"
+            ),
+        )
+
+        total = round(storage_monthly + compute_with_cs, 4)
+        justification = self._provisioned_justification(
+            profile, node_type, node_count, rate_key, label_suffix, total
+        )
+
+        return AWSScenario(
+            label=f"Provisioned {config_label} ({label_suffix})",
+            category=category,
+            lines=[storage_line, compute_line],
+            monthly_total=total,
+            confidence=ConfidenceLevel.HIGH,
+            justification=justification,
+            cluster_config=config_label,
+            workload_fit_notes=self._provisioned_fit_notes(profile, node_type, node_count),
+        )
+
+    # ================================================================== Cluster Sizing
+
+    def _build_workload_profile(self, slots: SlotUtilization | None, total_bytes: int) -> WorkloadProfile:
+        """Extract customer-specific workload metrics for sizing and justification."""
+        if slots is None or slots.total_slot_ms == 0:
+            return WorkloadProfile(has_data=False, total_stored_gb=total_bytes * k.GB_PER_BYTE)
+
+        days = max(slots.days_sampled, 1)
+        # Use the shared calendar window for QPD (not just slot-bearing days) to avoid
+        # inflation — same _window_days the cost line projects over.
+        lookback_days = _window_days(slots)
+        queries_per_day = slots.total_queries / lookback_days
+        avg_query_duration_est = k.V6_AVG_QUERY_DURATION_SECONDS
+        queries_per_second_avg = queries_per_day / 86_400
+        avg_concurrent = queries_per_second_avg * avg_query_duration_est
+        peak_concurrent = avg_concurrent * k.V6_PEAK_TO_AVG_CONCURRENCY_RATIO
+
+        # Same scan-volume basis and calendar window as the BigQuery cost line
+        # (_bq_ondemand) — the recommendation prose must quote the volume the customer
+        # is actually billed on, not a different one.
+        basis_bytes, _ = _scan_basis(slots)
+        bytes_per_query = (
+            basis_bytes / slots.total_queries if slots.total_queries > 0 else 0
+        )
+        monthly_scanned_tb = (
+            (basis_bytes / lookback_days * k.DAYS_PER_MONTH) / (1024 ** 4)
+        )
+
+        return WorkloadProfile(
+            has_data=True,
+            total_stored_gb=total_bytes * k.GB_PER_BYTE,
+            total_queries=slots.total_queries,
+            days_sampled=days,
+            lookback_days=lookback_days,
+            queries_per_day=queries_per_day,
+            queries_per_second_avg=queries_per_second_avg,
+            avg_concurrent_queries=avg_concurrent,
+            peak_concurrent_queries=peak_concurrent,
+            avg_bytes_per_query=bytes_per_query,
+            monthly_scanned_tb=monthly_scanned_tb,
+            active_hour_fraction=slots.active_hour_fraction,
+            total_slot_ms=slots.total_slot_ms,
+            avg_slots=slots.avg_slots,
+            p99_slots=slots.p99_slots,
+            peak_slots=slots.peak_slots,
+        )
+
+    def _size_cluster(self, profile: WorkloadProfile) -> tuple[str, int]:
+        """Determine the best-fit RG node type and count from workload metrics."""
+        qpd = profile.queries_per_day
+        peak_concurrent = profile.peak_concurrent_queries or 4
+
+        # Select node type based on query volume (RG Graviton instances)
+        if qpd <= k.V6_QUERIES_PER_DAY_XLPLUS_MAX:
+            node_type = "rg.xlarge"
+        elif qpd <= k.V6_QUERIES_PER_DAY_4XL_MAX:
+            node_type = "rg.4xlarge"
+        else:
+            node_type = "rg.16xlarge"
+
+        spec = k.V7_RG_NODE_TYPES[node_type]
+        vcpu_per_node = spec["vcpu"]
+
+        # Size by concurrency: enough vCPUs to handle peak concurrent queries
+        vcpu_needed = peak_concurrent * k.V6_VCPU_PER_CONCURRENT_QUERY
+        nodes_by_concurrency = math.ceil(vcpu_needed / vcpu_per_node)
+
+        # Minimum 2 nodes (requirement), max from spec
+        node_count = max(spec["min_nodes"], min(nodes_by_concurrency, spec["max_nodes"]))
+
+        return node_type, node_count
+
+    def _concurrency_scaling_fraction(self, profile: WorkloadProfile) -> float:
+        """Estimate concurrency scaling overhead from workload burstiness.
+
+        Uses actual peak_slots/avg_slots ratio from observed workload data rather than
+        the synthetic peak_concurrent_queries (which is derived from a fixed 3× multiplier).
+        """
+        if not profile.has_data:
+            return k.V6_CONCURRENCY_SCALING_OVERHEAD_FRACTION
+
+        active_fraction = profile.active_hour_fraction or 0.5
+        avg_slots = profile.avg_slots or 1
+        peak_slots = profile.peak_slots or avg_slots
+        peak_to_avg = peak_slots / max(avg_slots, 0.1)
+
+        # Bursty workloads (high peak:avg, low active hours) need more CS
+        if peak_to_avg > 5 and active_fraction < 0.3:
+            return 0.35
+        if peak_to_avg > 3:
+            return 0.25
+        if active_fraction > 0.6:
+            return 0.10  # steady workload, less burst
+        return 0.15
+
+    # ================================================================== Recommendation
+
+    def _generate_recommendation(
+        self, scenarios: list[AWSScenario], profile: WorkloadProfile, bq_monthly: float
+    ) -> AWSRecommendation:
+        """Select the best scenario and write customer-specific justification."""
+        if not profile.has_data:
+            return AWSRecommendation(
+                recommended_scenario=scenarios[0].label,
+                reasoning=(
+                    "No workload data available to size a provisioned cluster. "
+                    "Redshift Serverless is recommended as the starting point — it requires "
+                    "no capacity planning and scales automatically. Once the workload is "
+                    "running on AWS, monitor SYS_SERVERLESS_USAGE to determine if a "
+                    "provisioned cluster would be more cost-effective."
+                ),
+                workload_profile=profile,
+                alternatives_considered=[s.label for s in scenarios],
+            )
+
+        qpd = profile.queries_per_day
+        monthly_tb = profile.monthly_scanned_tb
+        active_frac = profile.active_hour_fraction
+        peak_conc = profile.peak_concurrent_queries
+
+        # Decision logic: serverless (OD + reserved) vs provisioned
+        # Serverless wins for: low/sporadic volume, unpredictable burst, <10k queries/day
+        # Provisioned wins for: sustained high volume, predictable patterns, >50k queries/day
+        serverless_od = next(s for s in scenarios if s.category == "SERVERLESS")
+        serverless_reserved = [s for s in scenarios if s.category in ("SERVERLESS_1YR", "SERVERLESS_3YR")]
+        provisioned_options = [s for s in scenarios if s.category.startswith("PROVISIONED")]
+
+        # Best serverless option (OD or reserved)
+        all_serverless = [serverless_od] + serverless_reserved
+        serverless = min(all_serverless, key=lambda s: s.monthly_total)
+
+        if not provisioned_options:
+            return AWSRecommendation(
+                recommended_scenario=serverless.label,
+                reasoning="Serverless is the only evaluated option (insufficient data for provisioned sizing).",
+                workload_profile=profile,
+                alternatives_considered=[s.label for s in scenarios],
+            )
+
+        # Find cheapest provisioned option
+        cheapest_prov = min(provisioned_options, key=lambda s: s.monthly_total)
+        cheapest_prov_ri = next(
+            (s for s in provisioned_options if s.category == "PROVISIONED_1YR"), cheapest_prov
+        )
+
+        # Decision factors
+        is_high_volume = qpd > 10_000
+        is_steady = active_frac > 0.3
+        provisioned_saves = cheapest_prov_ri.monthly_total < serverless.monthly_total * 0.85
+
+        # First check: if serverless (best of OD/reserved) beats all provisioned, recommend it
+        serverless_wins = serverless.monthly_total < cheapest_prov_ri.monthly_total
+
+        if is_high_volume and is_steady and provisioned_saves:
+            # Provisioned is clearly better than serverless on-demand
+            # Pick the best-value committed option (provisioned 1yr RI or serverless reserved)
+            recommended = cheapest_prov_ri
+            cheapest_3yr = next(
+                (s for s in provisioned_options if s.category == "PROVISIONED_3YR"), None
+            )
+            reasoning = (
+                f"Your workload runs {qpd:,.0f} queries/day ({profile.total_queries:,} total "
+                f"over {profile.lookback_days} days) scanning {monthly_tb:,.0f} TB/month. "
+                f"This is a sustained, high-volume pattern (active {active_frac:.0%} of hours) "
+                f"with ~{peak_conc:.0f} peak concurrent queries. "
+                f"Provisioned RG (Graviton4) with a 1-year RI saves "
+                f"{_fmt_usd(serverless.monthly_total - recommended.monthly_total)}/month vs Serverless On-Demand "
+                f"({_fmt_usd((serverless.monthly_total - recommended.monthly_total) * 12)}/year). "
+                f"The steady query volume makes the commitment predictable and low-risk."
+            )
+            if cheapest_3yr and cheapest_3yr.monthly_total < bq_monthly * 1.1:
+                reasoning += (
+                    f" A 3-year RI at {_fmt_usd(cheapest_3yr.monthly_total)}/month achieves near "
+                    f"cost-parity with your current BigQuery spend ({_fmt_usd(bq_monthly)}/month) "
+                    f"— consider this if the workload will remain on AWS long-term."
+                )
+            elif cheapest_3yr:
+                reasoning += (
+                    f" A 3-year RI would save an additional "
+                    f"{_fmt_usd(recommended.monthly_total - cheapest_3yr.monthly_total)}/month "
+                    f"if the workload will remain on AWS long-term."
+                )
+        elif is_high_volume and provisioned_saves:
+            recommended = cheapest_prov_ri
+            reasoning = (
+                f"Your workload runs {qpd:,.0f} queries/day scanning {monthly_tb:,.0f} TB/month. "
+                f"Despite bursty patterns (active only {active_frac:.0%} of hours), the volume "
+                f"is high enough that provisioned RG with concurrency scaling still beats serverless "
+                f"by {_fmt_usd(serverless.monthly_total - recommended.monthly_total)}/month. "
+                f"Consider starting with On-Demand provisioned to validate sizing, then "
+                f"converting to a 1-year RI once the pattern is confirmed."
+            )
+        elif serverless_wins or qpd < 5_000 or (not is_steady and serverless.monthly_total < cheapest_prov_ri.monthly_total):
+            recommended = serverless
+            reasoning = (
+                f"Your workload runs {qpd:,.0f} queries/day (active {active_frac:.0%} of hours). "
+            )
+            if serverless_wins:
+                reasoning += (
+                    f"Serverless at {_fmt_usd(serverless.monthly_total)}/month beats Provisioned 1yr RI "
+                    f"({_fmt_usd(cheapest_prov_ri.monthly_total)}/month) due to the pay-per-second "
+                    f"model and efficient RPU auto-scaling. "
+                )
+            else:
+                reasoning += (
+                    f"This is a {'sporadic' if active_frac < 0.2 else 'moderate-volume'} pattern "
+                    f"where Serverless pay-per-use is more efficient than maintaining an always-on "
+                    f"provisioned cluster. "
+                )
+            reasoning += (
+                "Serverless auto-scales to zero during idle periods and "
+                "handles burst without pre-provisioning."
+            )
+        else:
+            # Marginal case — recommend provisioned on-demand as stepping stone
+            prov_od = next(
+                (s for s in provisioned_options if s.category == "PROVISIONED_ONDEMAND"),
+                cheapest_prov_ri
+            )
+            recommended = prov_od
+            reasoning = (
+                f"Your workload ({qpd:,.0f} queries/day, {monthly_tb:,.0f} TB/month scanned, "
+                f"active {active_frac:.0%} of hours) sits between clear serverless and "
+                f"committed-provisioned territory. Recommend starting with Provisioned RG On-Demand "
+                f"to validate cluster sizing without commitment. If costs are stable after 1-2 "
+                f"months, convert to a 1-year RI to save "
+                f"~{_fmt_usd(prov_od.monthly_total - cheapest_prov_ri.monthly_total)}/month."
+            )
+
+        return AWSRecommendation(
+            recommended_scenario=recommended.label,
+            reasoning=reasoning,
+            workload_profile=profile,
+            alternatives_considered=[s.label for s in scenarios if s.label != recommended.label],
+        )
+
+    # ================================================================== Compute Lines
+
+    def _serverless_compute_line(
+        self, slots: SlotUtilization | None
+    ) -> tuple[CostLine, ConfidenceLevel]:
+        """Serverless RPU compute (V1) via the slot→RPU bridge (V3)."""
+        if slots is not None and slots.total_slot_ms > 0:
+            rpu_hours = _rpu_hours_per_month(slots)
+            usd = rpu_hours * k.V1_RPU_HOUR_USD
+            conf = (
+                ConfidenceLevel.HIGH if slots.days_sampled >= _DAYS_HIGH_CONF
+                else ConfidenceLevel.MEDIUM
+            )
+            line = CostLine(
+                label="Redshift Serverless compute",
+                monthly=round(usd, 4), monthly_low=None, monthly_high=None,
+                confidence=conf,
+                source_note=(
+                    f"Redshift Serverless @ ${k.V1_RPU_HOUR_USD}/RPU-hr, slot-to-RPU ratio "
+                    f"{k.V3_SLOT_TO_RPU_RATIO} (assumption — verify with empirical measurement) "
+                    f"(verified {k.AWS_CONFIRMED_DATE})"
+                ),
+            )
+            return line, conf
+
+        hours = k.RANGE_ACTIVE_HOURS_PER_MONTH
+        low = k.SERVERLESS_MIN_RPU_FLOOR * hours * k.V1_RPU_HOUR_USD
+        high = k.SERVERLESS_DEFAULT_BASE_RPU * hours * k.V1_RPU_HOUR_USD
+        line = CostLine(
+            label="Redshift Serverless compute",
+            monthly=None, monthly_low=round(low, 4), monthly_high=round(high, 4),
+            confidence=ConfidenceLevel.LOW,
+            source_note=(
+                f"Redshift Serverless @ ${k.V1_RPU_HOUR_USD}/RPU-hr; {k.SERVERLESS_MIN_RPU_FLOOR}–"
+                f"{k.SERVERLESS_DEFAULT_BASE_RPU} RPU range, LOW-confidence estimate — no query "
+                f"logs/slots; provide query logs to refine (verified {k.AWS_CONFIRMED_DATE})"
+            ),
+        )
+        return line, ConfidenceLevel.LOW
+
+    def _aws_s3_storage_line(self, total_physical_bytes: int, basis: str = "measured") -> CostLine:
+        """S3 Tables tiered storage (V2) — sized on physical (compressed) bytes."""
+        gb = total_physical_bytes * k.GB_PER_BYTE
+        usd = _tiered_s3_tables_usd(gb)
+
+        if basis == "measured":
+            confidence = ConfidenceLevel.HIGH
+            basis_phrase = "physical (from TABLE_STORAGE)"
+        elif basis == "mixed":
+            confidence = ConfidenceLevel.MEDIUM
+            basis_phrase = f"physical (mixed: TABLE_STORAGE + {k.ASSUMED_PHYSICAL_RATIO}× logical fallback)"
+        else:  # assumed
+            confidence = ConfidenceLevel.MEDIUM
+            basis_phrase = f"({k.ASSUMED_PHYSICAL_RATIO}× logical — TABLE_STORAGE unavailable)"
+
+        note = (
+            f"{gb:,.1f} GB {basis_phrase} × tiered from "
+            f"${k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1}/GB-mo "
+            f"{k.AWS_REGION_SCOPE} (verified {k.AWS_CONFIRMED_DATE})"
+        )
+
+        return CostLine(
+            label="S3 Tables storage",
+            monthly=round(usd, 4), monthly_low=None, monthly_high=None,
+            confidence=confidence,
+            source_note=note,
+        )
+
+    # ================================================================== BigQuery
+
+    def _bigquery_runrate(self, total_bytes, pricing, slots, override):
+        """BigQuery monthly run-rate + explaining breakdown lines (R18.2 / R16.4)."""
+        if override is not None:
+            line = CostLine(
+                label="BigQuery (operator override)", monthly=round(float(override), 4),
+                monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.HIGH,
+                source_note="operator-supplied via --bigquery-monthly-cost (no price-list date)",
+            )
+            return float(override), [line]
+
+        if pricing.model is BQPricingModel.CAPACITY:
+            return self._bq_capacity(pricing)
+        return self._bq_ondemand(total_bytes, slots)
+
+    def _bq_ondemand(self, total_bytes, slots):
+        gib = total_bytes / (1024 ** 3)
+        storage_usd = gib * v4.V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH
+        region = v4.V4_PRICING_REGION
+
+        basis_bytes, basis_label = _scan_basis(slots)
+        # A carried-but-zero billed total (all-cached / reservation-served window) is a
+        # genuine $0 scan month — don't fall through to the stored-bytes proxy branch.
+        billed_zero_window = (
+            slots is not None and slots.has_billed_bytes and slots.total_bytes_billed == 0
+        )
+
+        if slots is not None and slots.days_sampled > 0 and (basis_bytes > 0 or billed_zero_window):
+            # Project over the CALENDAR window, not just active days: dividing by
+            # days_sampled inflates sparse/batch workloads (10 TiB across 4 active days
+            # in a 30-day window is ~10 TiB/month, not 75).
+            window_days = _window_days(slots)
+            monthly_scanned_bytes = basis_bytes / window_days * k.DAYS_PER_MONTH
+            scanned_tib = monthly_scanned_bytes / (1024 ** 4)
+            scanned_usd = scanned_tib * v4.V4_ONDEMAND_USD_PER_TIB
+            scan_conf = ConfidenceLevel.HIGH
+            scan_note = (
+                f"BigQuery on-demand @ ${v4.V4_ONDEMAND_USD_PER_TIB}/TiB ({region}); "
+                f"{basis_bytes / (1024**4):,.2f} TiB {basis_label} across "
+                f"{slots.total_queries} queries over a {window_days}-day window, "
+                f"projected to monthly (verified {v4.V4_CONFIRMED_DATE})"
+            )
+        else:
+            scanned_bytes = total_bytes * k.BQ_DAILY_SCAN_FRACTION * k.DAYS_PER_MONTH
+            scanned_tib = scanned_bytes / (1024 ** 4)
+            scanned_usd = scanned_tib * v4.V4_ONDEMAND_USD_PER_TIB
+            scan_conf = ConfidenceLevel.LOW
+            scan_note = (
+                f"BigQuery on-demand @ ${v4.V4_ONDEMAND_USD_PER_TIB}/TiB ({region}); scan volume "
+                f"estimated at {k.BQ_DAILY_SCAN_FRACTION:.0%}/day of stored bytes (LOW-confidence "
+                f"proxy, no logs) (verified {v4.V4_CONFIRMED_DATE})"
+            )
+
+        lines = [
+            CostLine(
+                label="BigQuery storage", monthly=round(storage_usd, 4),
+                monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.HIGH,
+                source_note=(
+                    f"{gib:,.1f} GiB stored × ${v4.V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH}/GiB-mo "
+                    f"({region}) (verified {v4.V4_CONFIRMED_DATE})"
+                ),
+            ),
+            CostLine(
+                label="BigQuery bytes scanned", monthly=round(scanned_usd, 4),
+                monthly_low=None, monthly_high=None, confidence=scan_conf,
+                source_note=scan_note,
+            ),
+        ]
+        return round(storage_usd + scanned_usd, 4), lines
+
+    def _bq_capacity(self, pricing: PricingDetection):
+        """Price a capacity Source from its reservation figures."""
+        caveats: list[str] = []
+
+        edition = pricing.edition if pricing.edition in v4.V4_EDITION_SLOT_HOUR_USD else None
+        edition_known = edition is not None
+        if not edition_known:
+            if pricing.edition:
+                caveats.append(f"unrecognized edition {pricing.edition!r}, priced at ENTERPRISE rates")
+            edition = "ENTERPRISE"
+        edition_rates = v4.V4_EDITION_SLOT_HOUR_USD[edition]
+
+        rate_key = k.COMMITMENT_PLAN_TO_RATE_KEY.get(pricing.commitment_plan or "FLEX", "payg")
+        if edition not in v4.V4_EDITIONS_WITH_CAPACITY_COMMITMENTS and rate_key != "payg":
+            caveats.append(
+                f"{edition} has no true slot commitments — {pricing.commitment_plan} priced at PAYG"
+            )
+            rate_key = "payg"
+        slot_hour_usd = edition_rates.get(rate_key)
+        if slot_hour_usd is None:
+            slot_hour_usd = edition_rates["payg"]
+
+        slots_n, basis = _first_positive(
+            ("commitment", pricing.commitment_slots),
+            ("baseline", pricing.baseline_slots),
+            ("max", pricing.max_slots),
+        )
+        if slots_n is None:
+            slots_n, conf = 0, ConfidenceLevel.LOW
+            caveats.append("no reservation slot figures — supply --reservation-config")
+        else:
+            conf = ConfidenceLevel.HIGH if basis in ("commitment", "baseline") else ConfidenceLevel.MEDIUM
+        if not edition_known:
+            conf = ConfidenceLevel.LOW
+
+        monthly = slots_n * slot_hour_usd * k.HOURS_PER_MONTH
+        note = (
+            f"BigQuery {edition} slot-hour @ ${slot_hour_usd} ({rate_key}, "
+            f"{v4.V4_PRICING_REGION}) × {slots_n:g} slots × "
+            f"{k.HOURS_PER_MONTH:g}h (verified {v4.V4_CONFIRMED_DATE})"
+        )
+        if caveats:
+            note += " ⚠️ " + "; ".join(caveats)
+        line = CostLine(
+            label=f"BigQuery capacity ({edition})", monthly=round(monthly, 4),
+            monthly_low=None, monthly_high=None, confidence=conf, source_note=note,
+        )
+        return round(monthly, 4), [line]
+
+    # ================================================================== Justification helpers
+
+    def _provisioned_justification(
+        self, profile: WorkloadProfile, node_type: str, node_count: int,
+        rate_key: str, label_suffix: str, total: float,
+    ) -> str:
+        """Customer-specific justification for a provisioned scenario."""
+        spec = k.V7_RG_NODE_TYPES[node_type]
+        qpd = profile.queries_per_day
+        peak_conc = profile.peak_concurrent_queries
+        total_vcpu = node_count * spec["vcpu"]
+
+        return (
+            f"Sized for {qpd:,.0f} queries/day with ~{peak_conc:.0f} peak concurrent queries. "
+            f"{node_count}× {node_type} (Graviton4) provides {total_vcpu} vCPUs and "
+            f"{node_count * spec['memory_gb']} GB RAM — 30% better price/vCPU vs RA3. "
+            f"Rate: ${spec[rate_key]}/node-hr ({label_suffix})."
+        )
+
+    def _provisioned_fit_notes(
+        self, profile: WorkloadProfile, node_type: str, node_count: int
+    ) -> list[str]:
+        """Workload-fit notes for a provisioned scenario."""
+        spec = k.V7_RG_NODE_TYPES[node_type]
+        notes = []
+        total_vcpu = node_count * spec["vcpu"]
+        peak_conc = profile.peak_concurrent_queries
+
+        if total_vcpu >= peak_conc * k.V6_VCPU_PER_CONCURRENT_QUERY:
+            notes.append(f"✓ {total_vcpu} vCPUs handles {peak_conc:.0f} peak concurrent queries")
+        else:
+            notes.append(f"⚠ {total_vcpu} vCPUs may be tight for {peak_conc:.0f} peak concurrent queries — concurrency scaling will activate")
+
+        active_frac = profile.active_hour_fraction
+        if active_frac > 0.5:
+            notes.append(f"✓ High utilization ({active_frac:.0%} active hours) — provisioned is cost-effective")
+        elif active_frac < 0.2:
+            notes.append(f"⚠ Low utilization ({active_frac:.0%} active hours) — cluster idle most of the time")
+
+        return notes
+
+
+def _serverless_fit_notes(slots: SlotUtilization | None) -> list[str]:
+    """Workload-fit notes for the serverless scenario."""
+    notes = []
+    if slots is None or slots.total_slot_ms == 0:
+        notes.append("No workload data — serverless is a safe default (scales to zero)")
+        return notes
+
+    qpd = slots.total_queries / max(slots.days_sampled, 1)
+    if qpd > 50_000:
+        notes.append(f"⚠ {qpd:,.0f} queries/day is high volume — serverless per-second billing adds up quickly")
+    else:
+        notes.append(f"✓ {qpd:,.0f} queries/day — moderate volume suits serverless pay-per-use")
+
+    if slots.active_hour_fraction < 0.3:
+        notes.append(f"✓ Active only {slots.active_hour_fraction:.0%} of hours — serverless scales to zero during idle")
+    else:
+        notes.append(f"⚠ Active {slots.active_hour_fraction:.0%} of hours — always-on provisioned may be cheaper")
+
+    return notes
+
+
+# ================================================================== Module helpers
+
+
+def _window_days(slots: SlotUtilization) -> int:
+    """The calendar window (days) scan volume is projected over — ONE definition.
+
+    max(lookback_days, days_sampled, 1): lookback_days is the calendar span, but
+    hand-built SlotUtilization values may set days_sampled above the defaulted
+    lookback_days=30 — the clamp keeps the denominator ≥ the observed activity so the
+    cost line and the workload profile can never disagree on the projection window.
+    """
+    return max(getattr(slots, "lookback_days", slots.days_sampled), slots.days_sampled, 1)
+
+
+def _scan_basis(slots: SlotUtilization | None) -> tuple[int, str]:
+    """The scan-volume basis both the BQ cost line and the workload profile share.
+
+    Prefers total_bytes_billed (what on-demand billing charges — 10 MiB per-query
+    minimums included) only when EVERY job in the window carried billed data
+    (has_billed_bytes), honoring a genuine zero. A degraded window's total_bytes_billed
+    is a PARTIAL sum (NULL-billed jobs' volume excluded — workload.py's billed policy),
+    so pricing on it would be a silent underestimate; degraded windows fall back to
+    total_bytes_processed, the labelled overestimate. Returns (bytes, label);
+    (0, "") when slots is None.
+    """
+    if slots is None:
+        return 0, ""
+    if getattr(slots, "has_billed_bytes", False):
+        return slots.total_bytes_billed, "billed"
+    return slots.total_bytes_processed, "processed (billed unavailable)"
+
+
+def _first_positive(*pairs):
+    for label, value in pairs:
+        if value is not None:
+            coerced = _safe_num(value)
+            if coerced > 0:
+                return coerced, label
+    return None, None
+
+
+def _safe_num(value) -> float:
+    try:
+        n = float(value)
+    except (ValueError, TypeError):
+        return 0.0
+    return n if n >= 0 else 0.0
+
+
+def _entity_bytes(e) -> int:
+    if hasattr(e, "num_bytes"):
+        return int(e.num_bytes)
+    if hasattr(e, "size_gb"):
+        return int(e.size_gb * (1024 ** 3))
+    return 0
+
+
+def _entity_physical_bytes(e) -> int:
+    """Get physical bytes from entity (physical_bytes field, or fallback via helper)."""
+    from bq_assess.core.storage_stats import effective_physical_bytes
+    return effective_physical_bytes(_entity_bytes(e), getattr(e, "physical_bytes", None))
+
+
+def _tiered_s3_tables_usd(gb: float) -> float:
+    remaining = gb
+    usd = 0.0
+    t1 = min(remaining, k.V2_TIER1_WIDTH_GB)
+    usd += t1 * k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1
+    remaining -= t1
+    if remaining > 0:
+        t2 = min(remaining, k.V2_TIER2_WIDTH_GB)
+        usd += t2 * k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER2
+        remaining -= t2
+    if remaining > 0:
+        usd += remaining * k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER3
+    return usd
+
+
+def _rpu_hours_per_month(slots: SlotUtilization) -> float:
+    slot_hours = slots.total_slot_ms / _MS_PER_HOUR
+    return slot_hours * k.V3_SLOT_TO_RPU_RATIO
+
+
+def _line_value(line: CostLine) -> float:
+    """Get the effective monthly value from a CostLine (point or range midpoint)."""
+    if line.monthly is not None:
+        return line.monthly
+    low = line.monthly_low or 0
+    high = line.monthly_high or low
+    return (low + high) / 2
+
+
+def _line_low(line: CostLine) -> float:
+    return line.monthly if line.monthly is not None else (line.monthly_low or 0)
+
+
+def _line_high(line: CostLine) -> float:
+    return line.monthly if line.monthly is not None else (line.monthly_high or 0)
+
+
+def _breakeven(onetime: float, monthly_delta: float) -> float:
+    if monthly_delta <= 0:
+        return k.BREAKEVEN_NEVER
+    return onetime / monthly_delta
+
+
+def _fmt_usd(amount: float) -> str:
+    """Format a USD monthly figure for customer-facing prose.
+
+    Sub-dollar totals must NOT round to ``$0`` (that reads as free/broken when a tiny
+    workload genuinely costs e.g. $0.12/mo). Show two decimals under $1, comma-grouped
+    whole dollars at $1+.
+    """
+    a = abs(amount)
+    sign = "-" if amount < 0 else ""
+    if a < 1:
+        return f"{sign}${a:.2f}"
+    return f"{sign}${a:,.0f}"

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/cost_constants.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/cost_constants.py
@@ -1,0 +1,396 @@
+"""Verified AWS lakehouse pricing constants — V1 (Serverless RPU), V2 (S3 Tables) + the
+V3 slot→RPU bridge ASSUMPTION (R18.7).
+
+Confirmed 2026-06-15 against the **AWS Price List API** (machine-readable, authoritative) with a
+Wayback cross-read for the RPU-hour rate. Mirrors ``core/pricing_constants.py``: dated, sourced,
+overridable via module-level assignment — never hardcode a guess elsewhere.
+
+⚠️ The module-level constants default to US East (N. Virginia) / us-east-1, USD, on-demand.
+Other regions differ and are generally HIGHER. Call ``apply_aws_region(region)`` — normally
+with ``bq_location_to_aws_region(detected_bq_location)`` — to re-point the constants at that
+region's verified rates (AWS_REGIONAL_RATES below); the CLI/CostEstimator do this
+automatically so the AWS comparison is priced in the same geography as the BigQuery side.
+A live Price List API lookup (``core/price_lookup.py``, regional URL) can then override.
+
+References:
+- V1 Redshift Serverless: https://aws.amazon.com/redshift/pricing/
+  (Price List API SKU USE1-Redshift:ServerlessUsage = $0.375/RPU-Hr)
+- V2 S3 Tables:           https://aws.amazon.com/s3/pricing/  (S3 Tables tab; Price List API AmazonS3 us-east-1)
+"""
+
+from __future__ import annotations
+
+AWS_CONFIRMED_DATE: str = "2026-06-24"
+AWS_REGION_SCOPE: str = "US East (N. Virginia) / us-east-1"
+# The AWS region the module-level constants currently reflect (set by apply_aws_region).
+AWS_PRICING_REGION: str = "us-east-1"
+V1_SOURCE_URL: str = "https://aws.amazon.com/redshift/pricing/"
+V2_SOURCE_URL: str = "https://aws.amazon.com/s3/pricing/"
+
+# =============================================================================
+# V1 — Redshift Serverless compute, $/RPU-hour (HIGH confidence; triple-confirmed)
+# =============================================================================
+
+V1_RPU_HOUR_USD: float = 0.375
+V1_RPU_GB_MEMORY: int = 16          # 1 RPU = 16 GB memory (documentary only; NOT used to size by storage)
+HOURS_PER_MONTH: float = 730.0      # matches pricing_constants' hourly×730 convention
+
+# Serverless Reservations — commitment-based discounts (launched Apr 2025 / Feb 2026).
+# Unlike on-demand (pay-per-second when active), reservations bill 24/7 for the committed RPUs.
+# Source: https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-billing-reserved.html
+V1_SERVERLESS_RESERVATION_1YR_DISCOUNT: float = 0.24   # All Upfront, 1-year
+V1_SERVERLESS_RESERVATION_3YR_DISCOUNT: float = 0.45   # No Upfront, 3-year
+V1_SERVERLESS_1YR_RPU_HOUR_USD: float = round(V1_RPU_HOUR_USD * (1 - 0.24), 4)  # $0.285
+V1_SERVERLESS_3YR_RPU_HOUR_USD: float = round(V1_RPU_HOUR_USD * (1 - 0.45), 4)  # $0.2063
+AWS_SERVERLESS_RESERVATIONS_CONFIRMED_DATE: str = "2026-06-24"
+
+# Break-even utilization for reservations: the active-hour fraction at which the 24/7
+# reservation cost equals on-demand cost (reserved_rate / ondemand_rate).
+# At utilization ABOVE this threshold, the reservation saves money vs on-demand.
+V1_SERVERLESS_1YR_BREAKEVEN_UTIL: float = round(1 - V1_SERVERLESS_RESERVATION_1YR_DISCOUNT, 4)  # 0.76
+V1_SERVERLESS_3YR_BREAKEVEN_UTIL: float = round(1 - V1_SERVERLESS_RESERVATION_3YR_DISCOUNT, 4)  # 0.55
+
+# Overflow burst fraction: fraction of active hours during which peak usage exceeds
+# committed RPUs. Models that overflow RPUs are transient bursts, not sustained for the
+# full active period. Derived from typical query burst patterns (peak lasts ~30% of active time).
+V1_OVERFLOW_BURST_FRACTION: float = 0.30
+
+# Serverless base/step facts (HIGH; AWS mgmt docs). Used ONLY for the R18.4 no-data range floor.
+SERVERLESS_MIN_RPU_FLOOR: int = 4       # minimum base capacity for Redshift Serverless
+SERVERLESS_DEFAULT_BASE_RPU: int = 32   # moderate workload anchor (range high)
+# Hours/month the no-data range assumes the warehouse is "on". Models a typical business-day
+# usage pattern: 8 hours/day × 22 working days ≈ 176 hours/month.
+RANGE_ACTIVE_HOURS_PER_MONTH: float = 176.0
+
+# =============================================================================
+# V2 — S3 Tables Standard storage, $/GB-month, us-east-1 (HIGH confidence)
+# ⚠️ S3 TABLES, not plain S3 Standard ($0.023) — the managed Iceberg/compaction layer is ~15%
+#    dearer and adds the monitoring/compaction lines below that plain S3 lacks.
+# Marginal tiering: store tier WIDTHS, not cumulative thresholds (the audit caught a 50 TB bug).
+# Billed in GB (decimal, 10^9), per AWS convention — distinct from BigQuery's binary GiB.
+# =============================================================================
+
+V2_S3_TABLES_USD_PER_GB_MONTH_TIER1: float = 0.0265   # first 50 TB
+V2_S3_TABLES_USD_PER_GB_MONTH_TIER2: float = 0.0253   # next 450 TB (50–500 TB)
+V2_S3_TABLES_USD_PER_GB_MONTH_TIER3: float = 0.0242   # over 500 TB
+V2_TIER1_WIDTH_GB: float = 50.0 * 1000      # first 50 TB, in decimal GB
+V2_TIER2_WIDTH_GB: float = 450.0 * 1000     # next 450 TB (NOT 500 — marginal width)
+GB_PER_BYTE: float = 1e-9                    # AWS storage billing: bytes → decimal GB
+
+# Physical-bytes fallback ratio: canonical value lives in core/storage_stats.py
+# (collection-time concern — the collector distribution must not import the engine).
+# Re-exported so cost/report call sites keep their k.ASSUMED_PHYSICAL_RATIO idiom.
+from bq_assess.core.storage_stats import ASSUMED_PHYSICAL_RATIO  # noqa: E402,F401
+
+# S3-Tables-only recurring maintenance lines (plain S3 lacks these) — the "negligible
+# request/maintenance lines" R18.1 folds alongside storage.
+V2_OBJECT_MONITORING_USD_PER_1K_OBJECTS_MONTH: float = 0.025
+V2_COMPACTION_USD_PER_1K_OBJECTS: float = 0.002
+V2_COMPACTION_USD_PER_GB_PROCESSED: float = 0.005
+V2_REQUEST_TIER1_USD_PER_1K: float = 0.005      # PUT/COPY/POST/LIST
+V2_REQUEST_TIER2_USD_PER_1K: float = 0.0004     # GET/other
+
+# =============================================================================
+# V3 — slot→RPU bridge.  ⚠️⚠️ LOW-CONFIDENCE ASSUMPTION, NOT A VERIFIED FACT. ⚠️⚠️
+# There is NO published AWS/GCP slot↔RPU equivalence. Cross-referencing hardware specs
+# (1 RPU = 2 vCPU + 16 GB; 1 BQ slot ≈ 0.5 vCPU) yields ~0.25; the Fivetran 2022 benchmark
+# (300 BQ slots ≈ 18 RPU-equiv at performance parity) yields ~0.06; pure cost ratio ($0.06 vs
+# $0.375 per unit-hr) yields ~0.16. We use 0.20 — deliberately ABOVE the evidence midpoint,
+# toward the hardware-spec bound (~0.25) — so the projected Redshift compute errs on the
+# HIGH side and quoted savings err conservative (raised from 0.15 on 2026-07-05 after the
+# Montu reconciliation; understating AWS cost is the riskier direction in a customer-facing
+# business case). MUST be replaced by empirical RPU-hour measurement (SYS_SERVERLESS_USAGE)
+# on a representative migrated workload before quoting. Every emitted compute line carries a
+# visible LOW-confidence / ASSUMPTION label (R18.7).
+# =============================================================================
+
+V3_SLOT_TO_RPU_RATIO: float = 0.20
+V3_CONFIDENCE_IS_ASSUMPTION: bool = True
+V3_ASSUMPTION_NOTE: str = (
+    "slot→RPU 0.20 ASSUMPTION (evidence range: 0.06–0.25, set above midpoint so AWS "
+    "compute errs high / savings err conservative; no published equivalence; "
+    "overridable; verify with empirical RPU-hour measurement before quoting)"
+)
+
+# =============================================================================
+# Plan vocabulary bridge — PricingDetection.commitment_plan → V4_EDITION_SLOT_HOUR_USD sub-key.
+# PricingDetection emits {FLEX, MONTHLY, ANNUAL, THREE_YEAR}; the V4 rate table keys on
+# {payg, commit_1yr, commit_3yr}. FLEX/MONTHLY have no slot commitment → payg.
+# =============================================================================
+
+COMMITMENT_PLAN_TO_RATE_KEY: dict[str, str] = {
+    "FLEX": "payg",
+    "MONTHLY": "payg",
+    "ANNUAL": "commit_1yr",
+    "THREE_YEAR": "commit_3yr",
+}
+
+# =============================================================================
+# Migration one-time cost — derived from aggregate Migration Effort (R9), NOT a per-table fee
+# (R18.5). $/effort-point; calibration-tunable (R9.2 weights are "subject to calibration").
+# =============================================================================
+
+MIGRATION_USD_PER_EFFORT_POINT: float = 5.0
+
+# =============================================================================
+# BigQuery on-demand scan proxy — when no query logs/slots are available, estimate monthly
+# bytes scanned as a fraction of stored bytes per day (R18.2a). Labelled LOW-confidence estimate.
+# =============================================================================
+
+BQ_DAILY_SCAN_FRACTION: float = 0.10    # 10% of stored bytes scanned/day (legacy proxy, retained)
+DAYS_PER_MONTH: float = 30.0
+
+# Break-even sentinel: finite (JSON-safe) stand-in for "migration never recoups". 9999 months
+# (~833 years) is semantically equivalent to "never" for any business decision.
+BREAKEVEN_NEVER: float = 9999.0
+
+# =============================================================================
+# V6 — Redshift Provisioned RA3, $/node-hour, us-east-1 (HIGH confidence)
+# Confirmed 2026-06-15 against the AWS Price List API.
+# References: https://aws.amazon.com/redshift/pricing/
+# =============================================================================
+
+AWS_PROVISIONED_CONFIRMED_DATE: str = "2026-06-24"
+
+# =============================================================================
+# V7 — Redshift Graviton (RG) instances, $/node-hour, us-east-1 (HIGH confidence)
+# GA May 12, 2026. Graviton4-powered, 30% lower price/vCPU vs RA3, eliminates
+# separate Spectrum per-TB charges (built-in data lake query engine).
+# Source: https://aws.amazon.com/redshift/pricing/
+# Migration from RA3: 4:3 node mapping (4× ra3.4xl → 3× rg.4xl) for 25% infra savings.
+# =============================================================================
+
+V7_RG_NODE_TYPES: dict[str, dict] = {
+    "rg.xlarge": {
+        "vcpu": 4,
+        "memory_gb": 32,
+        "ondemand_usd_per_node_hour": 0.76,
+        "ri_1yr_usd_per_node_hour": 0.532,
+        "ri_3yr_usd_per_node_hour": 0.331,
+        "min_nodes": 2,
+        "max_nodes": 32,
+    },
+    "rg.4xlarge": {
+        "vcpu": 16,
+        "memory_gb": 128,
+        "ondemand_usd_per_node_hour": 3.043,
+        "ri_1yr_usd_per_node_hour": 2.130,
+        "ri_3yr_usd_per_node_hour": 1.324,
+        "min_nodes": 2,
+        "max_nodes": 32,
+    },
+    "rg.16xlarge": {
+        "vcpu": 64,
+        "memory_gb": 512,
+        "ondemand_usd_per_node_hour": 12.173,
+        "ri_1yr_usd_per_node_hour": 8.521,
+        "ri_3yr_usd_per_node_hour": 5.297,
+        "min_nodes": 2,
+        "max_nodes": 128,
+    },
+}
+
+# Legacy RA3 types retained for reference/fallback (regions without RG availability).
+V6_RA3_NODE_TYPES: dict[str, dict] = {
+    "ra3.xlplus": {
+        "vcpu": 4,
+        "memory_gb": 32,
+        "ondemand_usd_per_node_hour": 1.086,
+        "ri_1yr_usd_per_node_hour": 0.760,
+        "ri_3yr_usd_per_node_hour": 0.473,
+        "min_nodes": 2,
+        "max_nodes": 32,
+    },
+    "ra3.4xlarge": {
+        "vcpu": 12,
+        "memory_gb": 96,
+        "ondemand_usd_per_node_hour": 3.26,
+        "ri_1yr_usd_per_node_hour": 2.282,
+        "ri_3yr_usd_per_node_hour": 1.418,
+        "min_nodes": 2,
+        "max_nodes": 32,
+    },
+    "ra3.16xlarge": {
+        "vcpu": 48,
+        "memory_gb": 384,
+        "ondemand_usd_per_node_hour": 13.04,
+        "ri_1yr_usd_per_node_hour": 9.128,
+        "ri_3yr_usd_per_node_hour": 5.672,
+        "min_nodes": 2,
+        "max_nodes": 128,
+    },
+}
+
+# Redshift Managed Storage (RMS): applies to all RA3 node types.
+V6_MANAGED_STORAGE_USD_PER_GB_MONTH: float = 0.024
+
+# Concurrency scaling: 1 free hour/day/cluster; billed at same node-hour rate beyond that.
+V6_CONCURRENCY_SCALING_FREE_HOURS_PER_DAY: float = 1.0
+# Fraction of base cost to add for concurrency scaling burst (workload-dependent estimate).
+V6_CONCURRENCY_SCALING_OVERHEAD_FRACTION: float = 0.20
+
+# =============================================================================
+# Region cascade — BigQuery dataset location → nearest AWS region, plus verified
+# per-region AWS rates. Verified 2026-07-02 against the AWS Price List API
+# (AmazonRedshift + AmazonS3 regional offer files). The comparison must price both
+# clouds in the same geography: an australia-southeast1 Source gets its Query Engine
+# (Redshift Serverless / provisioned nodes) and storage priced in ap-southeast-2,
+# not us-east-1.
+# =============================================================================
+
+# BigQuery location token (lowercase) → AWS region: canonical mapping lives in
+# core/region_mapping.py (the collector distribution records aws_region in the bundle
+# manifest without importing the engine). Re-exported here for existing call sites.
+from bq_assess.core.region_mapping import (  # noqa: E402,F401
+    BQ_LOCATION_TO_AWS_REGION,
+    bq_location_to_aws_region,
+)
+
+# Per-AWS-region rates (Price List API, 2026-07-02). rg.16xlarge is not yet published in
+# the regional offer files — derived as 4× rg.4xlarge, which matches us-east-1 exactly
+# (12.173 ≈ 4 × 3.043).
+AWS_REGIONAL_RATES: dict[str, dict] = {
+    "us-east-1": {
+        "label": "US East (N. Virginia)",
+        "rpu_hour": 0.375, "rms": 0.024,
+        "s3_tables": (0.0265, 0.0253, 0.0242),
+        "rg.xlarge": (0.76, 0.532, 0.331), "rg.4xlarge": (3.043, 2.130, 1.324),
+        "ra3.xlplus": (1.086, 0.760, 0.473), "ra3.4xlarge": (3.26, 2.282, 1.418), "ra3.16xlarge": (13.04, 9.128, 5.672),
+    },
+    "us-west-2": {
+        "label": "US West (Oregon)",
+        "rpu_hour": 0.36, "rms": 0.024,
+        "s3_tables": (0.0265, 0.0253, 0.0242),
+        "rg.xlarge": (0.7602, 0.53214, 0.33075), "rg.4xlarge": (3.04267, 2.12987, 1.32356),
+        "ra3.xlplus": (1.086, 0.7602, 0.4725), "ra3.4xlarge": (3.26, 2.282, 1.4181), "ra3.16xlarge": (13.04, 9.128, 5.6724),
+    },
+    "ca-central-1": {
+        "label": "Canada (Central)",
+        "rpu_hour": 0.4125, "rms": 0.0261,
+        "s3_tables": (0.0288, 0.0276, 0.0265),
+        "rg.xlarge": (0.8414, 0.58898, 0.36603), "rg.4xlarge": (3.36653, 2.35723, 1.46487),
+        "ra3.xlplus": (1.202, 0.8414, 0.5229), "ra3.4xlarge": (3.607, 2.5256, 1.5695), "ra3.16xlarge": (14.43, 10.101, 6.2771),
+    },
+    "sa-east-1": {
+        "label": "South America (São Paulo)",
+        "rpu_hour": 0.5976, "rms": 0.043,
+        "s3_tables": (0.0466, 0.0449, 0.0426),
+        "rg.xlarge": (1.2117, 0.8484, 0.5271), "rg.4xlarge": (4.84867, 3.39407, 2.10924),
+        "ra3.xlplus": (1.731, 1.212, 0.753), "ra3.4xlarge": (5.195, 3.6365, 2.2599), "ra3.16xlarge": (20.78, 14.546, 9.0393),
+    },
+    "eu-west-1": {
+        "label": "Europe (Ireland)",
+        "rpu_hour": 0.387, "rms": 0.024,
+        "s3_tables": (0.0265, 0.0253, 0.0242),
+        "rg.xlarge": (0.8414, 0.58898, 0.36603), "rg.4xlarge": (3.3656, 2.35592, 1.46412),
+        "ra3.xlplus": (1.202, 0.8414, 0.5229), "ra3.4xlarge": (3.606, 2.5242, 1.5687), "ra3.16xlarge": (14.424, 10.0968, 6.2745),
+    },
+    "eu-west-2": {
+        "label": "Europe (London)",
+        "rpu_hour": 0.467, "rms": 0.025,
+        "s3_tables": (0.0276, 0.0265, 0.0253),
+        "rg.xlarge": (0.8848, 0.61936, 0.38493), "rg.4xlarge": (3.54013, 2.47809, 1.54),
+        "ra3.xlplus": (1.264, 0.8848, 0.5499), "ra3.4xlarge": (3.793, 2.6551, 1.65), "ra3.16xlarge": (15.174, 10.6218, 6.6007),
+    },
+    "eu-central-1": {
+        "label": "Europe (Frankfurt)",
+        "rpu_hour": 0.451, "rms": 0.0256,
+        "s3_tables": (0.0282, 0.027, 0.0259),
+        "rg.xlarge": (0.9086, 0.63602, 0.39529), "rg.4xlarge": (3.6344, 2.54408, 1.58097),
+        "ra3.xlplus": (1.298, 0.9086, 0.5647), "ra3.4xlarge": (3.894, 2.7258, 1.6939), "ra3.16xlarge": (15.578, 10.9046, 6.7765),
+    },
+    "ap-southeast-2": {
+        "label": "Asia Pacific (Sydney)",
+        "rpu_hour": 0.419, "rms": 0.0261,
+        "s3_tables": (0.0288, 0.0276, 0.0265),
+        "rg.xlarge": (0.9121, 0.63847, 0.39683), "rg.4xlarge": (3.6484, 2.55388, 1.58713),
+        "ra3.xlplus": (1.303, 0.9121, 0.5669), "ra3.4xlarge": (3.909, 2.7363, 1.7005), "ra3.16xlarge": (15.636, 10.9452, 6.8017),
+    },
+    "ap-southeast-1": {
+        "label": "Asia Pacific (Singapore)",
+        "rpu_hour": 0.45, "rms": 0.0261,
+        "s3_tables": (0.0288, 0.0276, 0.0265),
+        "rg.xlarge": (0.9121, 0.63847, 0.39683), "rg.4xlarge": (3.6484, 2.55388, 1.58713),
+        "ra3.xlplus": (1.303, 0.9121, 0.5669), "ra3.4xlarge": (3.909, 2.7363, 1.7005), "ra3.16xlarge": (15.636, 10.9452, 6.8017),
+    },
+    "ap-northeast-1": {
+        "label": "Asia Pacific (Tokyo)",
+        "rpu_hour": 0.494, "rms": 0.0261,
+        "s3_tables": (0.0288, 0.0276, 0.0265),
+        "rg.xlarge": (0.8946, 0.62622, 0.3892), "rg.4xlarge": (3.58027, 2.50619, 1.55745),
+        "ra3.xlplus": (1.278, 0.8946, 0.556), "ra3.4xlarge": (3.836, 2.6852, 1.6687), "ra3.16xlarge": (15.347, 10.7429, 6.676),
+    },
+    "ap-south-1": {
+        "label": "Asia Pacific (Mumbai)",
+        "rpu_hour": 0.4275, "rms": 0.0261,
+        "s3_tables": (0.0288, 0.0276, 0.0265),
+        "rg.xlarge": (0.8645, 0.60515, 0.37611), "rg.4xlarge": (3.45893, 2.42125, 1.50472),
+        "ra3.xlplus": (1.235, 0.8645, 0.5373), "ra3.4xlarge": (3.706, 2.5942, 1.6122), "ra3.16xlarge": (14.827, 10.3789, 6.4498),
+    },
+}
+
+
+def apply_aws_region(region: str) -> bool:
+    """Re-point the module-level AWS rate constants at ``region``'s verified rates.
+
+    Returns True when the region is in the verified table (constants updated), False when
+    unknown (constants left at us-east-1 so callers can attach a caveat). Same
+    overridable-module-assignment contract as apply_live_rates (R18.7).
+    """
+    global V1_RPU_HOUR_USD, V1_SERVERLESS_1YR_RPU_HOUR_USD, V1_SERVERLESS_3YR_RPU_HOUR_USD
+    global V2_S3_TABLES_USD_PER_GB_MONTH_TIER1, V2_S3_TABLES_USD_PER_GB_MONTH_TIER2
+    global V2_S3_TABLES_USD_PER_GB_MONTH_TIER3, V6_MANAGED_STORAGE_USD_PER_GB_MONTH
+    global AWS_PRICING_REGION, AWS_REGION_SCOPE
+
+    rates = AWS_REGIONAL_RATES.get(region)
+    if rates is None:
+        return False
+
+    V1_RPU_HOUR_USD = rates["rpu_hour"]
+    V1_SERVERLESS_1YR_RPU_HOUR_USD = round(
+        V1_RPU_HOUR_USD * (1 - V1_SERVERLESS_RESERVATION_1YR_DISCOUNT), 4
+    )
+    V1_SERVERLESS_3YR_RPU_HOUR_USD = round(
+        V1_RPU_HOUR_USD * (1 - V1_SERVERLESS_RESERVATION_3YR_DISCOUNT), 4
+    )
+    t1, t2, t3 = rates["s3_tables"]
+    V2_S3_TABLES_USD_PER_GB_MONTH_TIER1 = t1
+    V2_S3_TABLES_USD_PER_GB_MONTH_TIER2 = t2
+    V2_S3_TABLES_USD_PER_GB_MONTH_TIER3 = t3
+    V6_MANAGED_STORAGE_USD_PER_GB_MONTH = rates["rms"]
+
+    for node_type, table in (("rg.xlarge", V7_RG_NODE_TYPES), ("rg.4xlarge", V7_RG_NODE_TYPES),
+                             ("ra3.xlplus", V6_RA3_NODE_TYPES), ("ra3.4xlarge", V6_RA3_NODE_TYPES),
+                             ("ra3.16xlarge", V6_RA3_NODE_TYPES)):
+        od, ri1, ri3 = rates[node_type]
+        table[node_type]["ondemand_usd_per_node_hour"] = od
+        table[node_type]["ri_1yr_usd_per_node_hour"] = ri1
+        table[node_type]["ri_3yr_usd_per_node_hour"] = ri3
+    # rg.16xlarge is not in the regional Price List offers — derive as 4× rg.4xlarge
+    # (matches us-east-1's published rate).
+    od4, ri1_4, ri3_4 = rates["rg.4xlarge"]
+    V7_RG_NODE_TYPES["rg.16xlarge"]["ondemand_usd_per_node_hour"] = round(od4 * 4, 4)
+    V7_RG_NODE_TYPES["rg.16xlarge"]["ri_1yr_usd_per_node_hour"] = round(ri1_4 * 4, 4)
+    V7_RG_NODE_TYPES["rg.16xlarge"]["ri_3yr_usd_per_node_hour"] = round(ri3_4 * 4, 4)
+
+    AWS_PRICING_REGION = region
+    AWS_REGION_SCOPE = f"{rates['label']} / {region}"
+    return True
+
+
+# =============================================================================
+# V6 — Cluster sizing heuristics (from workload metrics)
+# =============================================================================
+
+# Queries/day thresholds that determine node type.
+V6_QUERIES_PER_DAY_XLPLUS_MAX: int = 50_000
+V6_QUERIES_PER_DAY_4XL_MAX: int = 500_000
+
+# vCPUs needed per concurrent query slot (heuristic; BQ on-demand typically runs
+# queries with 1-4 effective slot equivalents for small scans, more for large scans).
+V6_VCPU_PER_CONCURRENT_QUERY: float = 1.5
+
+# Assumed average query duration in seconds (for concurrency estimation from QPD).
+V6_AVG_QUERY_DURATION_SECONDS: float = 7.0
+# Peak-to-average ratio for query concurrency (business-hour burst factor).
+V6_PEAK_TO_AVG_CONCURRENCY_RATIO: float = 3.0

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/placement.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/placement.py
@@ -1,0 +1,84 @@
+"""View/MV/UDF Placement recommendation (R14).
+
+UDF → REDSHIFT always. View/MV → signal-based recommendation with no blanket default.
+MV with Iceberg placement → refresh_unverified=True (V7 unconfirmed).
+"""
+from __future__ import annotations
+
+from bq_assess.models import (
+    ConfidenceLevel,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    PlacementRecommendation,
+)
+
+
+class PlacementAdvisor:
+    """Recommend home for Views/MVs/UDFs — Redshift or Iceberg catalog (R14)."""
+
+    def recommend(
+        self,
+        entity: EntityMetadata,
+        relationships=None,
+        has_logs: bool = False,
+    ) -> PlacementRecommendation | None:
+        if entity.population is EntityPopulation.TABLE:
+            return None
+
+        if entity.entity_type == EntityType.ROUTINE:
+            return self._recommend_routine(entity)
+
+        return self._recommend_view_or_mv(entity, has_logs)
+
+    def _recommend_routine(self, entity: EntityMetadata) -> PlacementRecommendation:
+        signals = ["UDF/procedure — Iceberg has no function concept"]
+        if entity.routine and entity.routine.language and entity.routine.language.upper() == "JAVASCRIPT":
+            signals.append("JavaScript UDF — requires Python/Lambda rewrite")
+        return PlacementRecommendation(
+            home="REDSHIFT",
+            signals=signals,
+            confidence=ConfidenceLevel.HIGH,
+            refresh_unverified=False,
+        )
+
+    def _recommend_view_or_mv(self, entity: EntityMetadata, has_logs: bool) -> PlacementRecommendation:
+        is_mv = entity.entity_type == EntityType.MATERIALIZED_VIEW
+
+        # Per-entity signal (R14.2 — never a blanket default). From metadata we use
+        # cross-dataset breadth as a proxy for multi-engine/open-lakehouse consumption:
+        # a view/MV that spans more than one dataset is a candidate for the open Iceberg
+        # catalog (queryable by multiple engines); a single-dataset one is simplest kept
+        # engine-local in Redshift. Query logs (when present) raise confidence.
+        distinct_datasets = {
+            dep.split(".")[0] for dep in entity.depends_on if "." in dep
+        }
+        multi_domain = len(distinct_datasets) > 1
+
+        if multi_domain:
+            home = "ICEBERG_CATALOG"
+            signals = [
+                f"spans {len(distinct_datasets)} datasets — open multi-engine access favors "
+                "the Iceberg catalog"
+            ]
+        else:
+            home = "REDSHIFT"
+            signals = [
+                "single-dataset, engine-local consumption — simplest kept in Redshift"
+            ]
+
+        confidence = ConfidenceLevel.MEDIUM if has_logs else ConfidenceLevel.LOW
+        if has_logs:
+            signals.append("query logs available — consumption pattern observed")
+
+        refresh_unverified = False
+        if is_mv and home == "ICEBERG_CATALOG":
+            refresh_unverified = True
+            signals.append("MV on Iceberg — refresh behavior unverified (V7)")
+
+        return PlacementRecommendation(
+            home=home,
+            signals=signals,
+            confidence=confidence,
+            refresh_unverified=refresh_unverified,
+        )

--- a/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/rewrite.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/engine/redshift/rewrite.py
@@ -1,0 +1,112 @@
+"""Query-Rewrite Guidance + Best-Effort SQL Translation (R13).
+
+Per detected construct, emit a human-readable required change + effort indication.
+For entities with SQL surface, also produce a best-effort Redshift translation using
+sqlglot (illustrative only — requires validation before production use).
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import sqlglot
+
+from bq_assess.models import DetectedConstruct, EntityMetadata, TranslationResult
+
+_GUIDANCE: dict[str, str] = {
+    "JS_UDF": "JavaScript UDF has no Redshift equivalent — rewrite as Lambda UDF, Node.js recommended (high effort).",
+    "UNNEST": "UNNEST over nested arrays — replace with Redshift FROM-clause unnest pattern: FROM t, t.arr AS x (medium effort).",
+    "ARRAY_FN": "ARRAY_* function — replace with Redshift equivalent or SUPER array functions (medium effort).",
+    "STRUCT_NAV": "Struct-path navigation (dot notation) — works as-is for Iceberg tables via Spectrum (low effort).",
+    "FUNCTION_DRIFT": "Function name/semantic drift — rename or adjust argument order for Redshift dialect (low effort).",
+}
+
+_TIMESTAMPDIFF_RE = re.compile(
+    r"\bTIMESTAMPDIFF\s*\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^)]+)\s*\)",
+    re.IGNORECASE,
+)
+
+_SAFE_DIVIDE_RE = re.compile(
+    r"\bSAFE_DIVIDE\s*\(\s*([^,]+)\s*,\s*([^)]+)\s*\)",
+    re.IGNORECASE,
+)
+
+_JS_UDF_RE = re.compile(r"\bLANGUAGE\s+js\b", re.IGNORECASE)
+
+
+class RewriteGuide:
+    """Generate human-readable rewrite guidance and best-effort SQL translation."""
+
+    def guide(self, entity: EntityMetadata, constructs: list[DetectedConstruct]) -> list[str]:
+        if not constructs:
+            return []
+        result: list[str] = []
+        for c in constructs:
+            text = _GUIDANCE.get(c.construct_class)
+            if text is None:
+                text = f"{c.construct_class}: {c.description} — review and adapt for Redshift."
+            result.append(text)
+        return result
+
+    def translate(self, sql: str) -> TranslationResult:
+        """Best-effort BQ→Redshift translation using sqlglot + post-processing."""
+        if not sql or not sql.strip():
+            return TranslationResult(
+                redshift_sql="",
+                confidence="LOW",
+                warnings=["Empty SQL — nothing to translate."],
+            )
+
+        warnings: list[str] = []
+        confidence = "HIGH"
+
+        if _JS_UDF_RE.search(sql):
+            warnings.append(
+                "JavaScript UDF cannot be auto-translated — "
+                "rewrite as Lambda UDF (Node.js recommended)."
+            )
+            confidence = "LOW"
+
+        try:
+            _sqlglot_logger = logging.getLogger("sqlglot")
+            prev_level = _sqlglot_logger.level
+            _sqlglot_logger.setLevel(logging.ERROR)
+            try:
+                results = sqlglot.transpile(sql, read="bigquery", write="redshift")
+            finally:
+                _sqlglot_logger.setLevel(prev_level)
+            translated = "; ".join(results)
+        except Exception as e:
+            return TranslationResult(
+                redshift_sql=f"-- [TRANSLATION FAILED: {type(e).__name__}]\n{sql}",
+                confidence="LOW",
+                warnings=[f"sqlglot could not parse this SQL: {e}"],
+            )
+
+        translated = self._post_fix(translated, warnings)
+
+        if "BEGIN" in sql and ("DECLARE" in sql or "EXCEPTION" in sql or "FOR " in sql):
+            warnings.append("Stored procedure with scripting constructs — partial translation only.")
+            confidence = "LOW"
+
+        if warnings:
+            confidence = "LOW"
+
+        return TranslationResult(
+            redshift_sql=translated,
+            confidence=confidence,
+            warnings=warnings,
+        )
+
+    def _post_fix(self, sql: str, warnings: list[str]) -> str:
+        """Apply post-processing fixes for known sqlglot gaps."""
+        # Fix TIMESTAMPDIFF → DATEDIFF (sqlglot bug for TIMESTAMP_DIFF)
+        if _TIMESTAMPDIFF_RE.search(sql):
+            sql = _TIMESTAMPDIFF_RE.sub(r"DATEDIFF(\3, \2, \1)", sql)
+
+        # Fix SAFE_DIVIDE (sqlglot passes it through unchanged)
+        if _SAFE_DIVIDE_RE.search(sql):
+            sql = _SAFE_DIVIDE_RE.sub(r"(\1) / NULLIF((\2), 0)", sql)
+            warnings.append("SAFE_DIVIDE converted to x / NULLIF(y, 0) — verify NULL semantics.")
+
+        return sql

--- a/solution-architecture/clis/bq-assess/src/bq_assess/models.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/models.py
@@ -1,0 +1,362 @@
+"""Shared data models for bq-assess — normative dataclasses and enums.
+
+These are the NORMATIVE models for the lakehouse assessment, implemented exactly per
+``.kiro/specs/phase1-assessment-tool/design.md`` § Data Models. Canonical glossary names
+(CONTEXT.md); nested types preserved (no flattening).
+
+All legacy code has been migrated to these models as of Phase 8 (8.1). Module-local types
+(e.g., ``QueryAnalysis``, ``RelationshipResult``) were moved to their respective consumer
+modules (``core/analyzer.py``, ``core/relationships.py``) where they remain internal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+# ---- Enums -----------------------------------------------------------------
+
+
+class EntityType(Enum):
+    TABLE = "TABLE"
+    EXTERNAL = "EXTERNAL"            # treated as Table (moves)
+    VIEW = "VIEW"
+    MATERIALIZED_VIEW = "MATERIALIZED_VIEW"
+    ROUTINE = "ROUTINE"             # UDF / stored procedure
+
+
+class EntityPopulation(Enum):
+    TABLE = "TABLE"                 # scored on both axes
+    REBUILT = "REBUILT"             # view/mv/udf — Query Complexity only, Effort = 0
+
+
+class EffortCategory(Enum):         # Migration Effort axis (R9)
+    AUTO = "AUTO"
+    ASSISTED = "ASSISTED"
+    MANUAL = "MANUAL"
+
+
+class ComplexityCategory(Enum):     # Query Complexity axis (R11)
+    PORTABLE = "PORTABLE"
+    ADAPT = "ADAPT"
+    REWRITE = "REWRITE"
+
+
+class ConfidenceLevel(Enum):
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+
+
+class ConfidenceSource(Enum):
+    QUERY_LOGS = "query_logs"
+    VIEW_DEFINITION = "view_definition"
+    NAMING_HEURISTIC = "naming_heuristic"
+    SCHEMA_ONLY = "schema_only"
+    MANUAL_INPUT = "manual_input"
+    SAFE_DEFAULT = "safe_default"
+
+
+class BQPricingModel(Enum):
+    ON_DEMAND = "ON_DEMAND"         # bytes scanned
+    CAPACITY = "CAPACITY"           # slot reservations / Editions
+    UNKNOWN = "UNKNOWN"             # → default on-demand, LOW confidence (R16.3)
+
+
+# ---- Scanned metadata ------------------------------------------------------
+
+
+@dataclass
+class ColumnSchema:
+    name: str
+    field_type: str                 # BigQuery type name
+    mode: str                       # NULLABLE | REQUIRED | REPEATED
+    fields: list["ColumnSchema"] = field(default_factory=list)  # nested STRUCT/RECORD
+
+
+@dataclass
+class TimePartitionConfig:
+    type: str                       # DAY | HOUR | MONTH | YEAR
+    field: str | None               # None => ingestion-time (_PARTITIONTIME) => non-clean (R7.3)
+
+
+@dataclass
+class RangePartitionConfig:         # R3.8 — previously uncaptured
+    field: str
+    start: int
+    end: int
+    interval: int
+
+
+@dataclass
+class RoutineMetadata:              # R3.3 — UDFs / stored procedures
+    name: str
+    language: str                   # SQL | JAVASCRIPT | ...
+    arguments: list[str]
+    body: str
+    routine_type: str               # SCALAR_FUNCTION | PROCEDURE | ...
+
+
+@dataclass
+class EntityMetadata:
+    entity_id: str
+    dataset_id: str
+    full_name: str                  # "dataset.entity" (the shared cross-file key, R19.5)
+    entity_type: EntityType
+    population: EntityPopulation
+    num_rows: int                   # 0 for views/mviews/routines
+    num_bytes: int
+    columns: list[ColumnSchema]
+    time_partitioning: TimePartitionConfig | None
+    range_partitioning: RangePartitionConfig | None
+    clustering_fields: list[str] | None
+    view_query: str | None          # views (R3.2)
+    mview_query: str | None         # materialized views (R3.2)
+    routine: RoutineMetadata | None  # routines (R3.3)
+    depends_on: list[str]           # FQNs of Tables this entity references (R4.5)
+    last_modified: datetime
+    physical_bytes: int | None = None  # populated by storage_stats; None = not yet resolved
+
+
+# ---- Conversion / scoring results -----------------------------------------
+
+
+@dataclass
+class PartitionMapping:             # R7
+    iceberg_transforms: list[str]   # e.g. ["day(event_date)"]
+    sort_order: list[str]
+    auto_derived: bool              # True = clean annotation; False = flagged decision
+    decision_flags: list[str]       # partition_decision_required / sort_decision_required
+
+
+@dataclass
+class LossyCast:                    # R8
+    column: str
+    source_type: str
+    iceberg_type: str
+    loss_description: str
+
+
+@dataclass
+class ConversionResult:
+    ddl: str                        # "" for non-Tables
+    partition_mapping: PartitionMapping | None
+    lossy_casts: list[LossyCast]
+    warnings: list[str]
+    success: bool
+
+
+@dataclass
+class EffortResult:                 # R9 — Tables only
+    category: EffortCategory
+    score: int
+    flags: list[str]
+    reasoning: str
+    confidence: ConfidenceLevel
+
+
+@dataclass
+class DetectedConstruct:            # R10.3
+    construct_class: str            # UNNEST | FUNCTION_DRIFT | ARRAY_FN | STRUCT_NAV | JS_UDF | ...
+    snippet: str                    # anonymized (R10.4 / R22.4)
+    description: str
+
+
+@dataclass
+class ComplexityResult:             # R11
+    category: ComplexityCategory
+    score: int
+    constructs: list[DetectedConstruct]
+    flags: list[str]
+    reasoning: str
+    confidence: ConfidenceLevel
+    confidence_source: ConfidenceSource
+
+
+@dataclass
+class TranslationResult:            # Best-effort BQ→Redshift SQL translation
+    redshift_sql: str               # translated SQL (or original + comment if failed)
+    confidence: str                 # "HIGH" | "LOW"
+    warnings: list[str]             # e.g. ["JavaScript UDF requires manual rewrite"]
+
+
+@dataclass
+class PlacementRecommendation:      # R14
+    home: str                       # "REDSHIFT" | "ICEBERG_CATALOG"
+    signals: list[str]
+    confidence: ConfidenceLevel
+    refresh_unverified: bool        # True for Iceberg-MV until V7 confirmed
+
+
+# ---- Cost ------------------------------------------------------------------
+
+
+@dataclass
+class PricingDetection:             # R16 — what PricingDetector.detect() returns
+    # The bare BQPricingModel enum cannot carry the figures R16.2 and the confidence
+    # R16.3/P20 require, so detect() returns this. `model` is the classification; the
+    # capacity_* fields are populated only when model is CAPACITY (R16.2).
+    model: BQPricingModel
+    confidence: ConfidenceLevel
+    source_note: str                # how the model was determined + date (R16.3, P20; V4/V5)
+    edition: str | None = None              # "STANDARD" | "ENTERPRISE" | "ENTERPRISE_PLUS"
+    baseline_slots: int | None = None
+    max_slots: int | None = None
+    commitment_slots: int | None = None
+    commitment_plan: str | None = None      # "FLEX" | "MONTHLY" | "ANNUAL" | "THREE_YEAR"
+
+
+@dataclass
+class SlotUtilization:              # R17
+    avg_slots: float
+    p50_slots: float
+    p99_slots: float
+    peak_slots: float
+    active_hour_fraction: float
+    total_slot_ms: int
+    days_sampled: int               # distinct UTC dates with slot-bearing activity
+    total_bytes_processed: int = 0
+    # Bytes actually billed (10 MiB per-query minimum, rounded up to the nearest MiB) —
+    # what on-demand billing charges. Zero is a legitimate value (all-cached or
+    # reservation-served windows); has_billed_bytes below says whether the source
+    # carried the column at all.
+    total_bytes_billed: int = 0
+    # True when the job source exposed total_bytes_billed (JOBS_BY_PROJECT always does;
+    # old query-log exports may not). Distinguishes "billed 0" from "column unavailable"
+    # so the cost model doesn't fall back to processed bytes on genuinely-zero windows.
+    has_billed_bytes: bool = False
+    total_queries: int = 0
+    lookback_days: int = 30         # calendar days in the observation window
+
+
+@dataclass
+class CostLine:
+    label: str
+    monthly: float | None           # None when expressed as a range
+    monthly_low: float | None
+    monthly_high: float | None
+    confidence: ConfidenceLevel
+    source_note: str                # pricing-constant provenance + date (R18.7; V1–V4)
+
+
+@dataclass
+class WorkloadProfile:
+    """Customer-specific workload metrics used for AWS cluster sizing and justification."""
+    has_data: bool = False
+    total_stored_gb: float = 0.0
+    total_queries: int = 0
+    days_sampled: int = 0
+    lookback_days: int = 30
+    queries_per_day: float = 0.0
+    queries_per_second_avg: float = 0.0
+    avg_concurrent_queries: float = 0.0
+    peak_concurrent_queries: float = 0.0
+    avg_bytes_per_query: float = 0.0
+    monthly_scanned_tb: float = 0.0
+    active_hour_fraction: float = 0.0
+    total_slot_ms: int = 0
+    avg_slots: float = 0.0
+    p99_slots: float = 0.0
+    peak_slots: float = 0.0
+
+
+@dataclass
+class AWSScenario:
+    """One AWS deployment option with its cost lines, total, and justification."""
+    label: str                      # e.g. "Redshift Serverless", "Provisioned 3× ra3.4xl (1yr RI)"
+    category: str                   # "SERVERLESS" | "PROVISIONED_ONDEMAND" | "PROVISIONED_1YR" | "PROVISIONED_3YR"
+    lines: list[CostLine]
+    monthly_total: float
+    confidence: ConfidenceLevel
+    is_recommended: bool = False
+    justification: str = ""         # why this option is/isn't recommended for this workload
+    cluster_config: str = ""        # e.g. "3× ra3.4xlarge" (empty for serverless)
+    workload_fit_notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AWSRecommendation:
+    """The tool's best-fit recommendation with reasoning anchored to customer workload."""
+    recommended_scenario: str       # label of the recommended AWSScenario
+    reasoning: str                  # paragraph explaining why, referencing actual workload numbers
+    workload_profile: WorkloadProfile = field(default_factory=WorkloadProfile)
+    alternatives_considered: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CostComparison:               # R18
+    bq_pricing_model: BQPricingModel
+    bigquery_monthly: float
+    bigquery_breakdown: list[CostLine]
+    aws_lines: list[CostLine]       # storage (point) + compute (point or range) — best scenario
+    aws_monthly_low: float
+    aws_monthly_high: float
+    monthly_delta_low: float        # headline: bigquery_monthly - aws_monthly_high
+    monthly_delta_high: float       # bigquery_monthly - aws_monthly_low
+    annual_savings_low: float
+    annual_savings_high: float
+    migration_onetime: float        # derived from aggregate Migration Effort (R18.5)
+    breakeven_months_low: float
+    breakeven_months_high: float
+    compute_confidence: ConfidenceLevel
+    aws_scenarios: list[AWSScenario] = field(default_factory=list)
+    recommendation: AWSRecommendation | None = None
+    # Region provenance: which geography each side was priced in (2026-07-02 region cascade).
+    bq_pricing_region: str = "us"           # BigQuery dataset location the BQ rates reflect
+    aws_pricing_region: str = "us-east-1"   # AWS region the AWS rates reflect
+    # What the BigQuery estimate does NOT cover (streaming inserts, Storage R/W API, …) —
+    # rendered verbatim in reports so the estimate is never mistaken for the whole GCP bill.
+    scope_notes: list[str] = field(default_factory=list)
+
+
+# ---- Report ----------------------------------------------------------------
+
+
+@dataclass
+class FailureRecord:
+    entity_name: str
+    stage: str                      # scan | classify | convert | detect | score
+    error: str
+
+
+@dataclass
+class EntityReport:
+    full_name: str                  # shared cross-file key (R19.5)
+    entity_type: EntityType
+    population: EntityPopulation
+    rows: int
+    size_gb: float
+    depends_on: list[str]
+    # Effort axis (Tables only; None for REBUILT)
+    effort: EffortResult | None
+    conversion: ConversionResult | None
+    load_sync_dml: str | None
+    # Query axis (any entity with SQL surface / direct query target)
+    complexity: ComplexityResult | None
+    rewrite_guidance: list[str]
+    translated_sql: TranslationResult | None = None
+    placement: PlacementRecommendation | None = None
+    physical_bytes: int | None = None  # measured physical storage; None = not available/measured
+
+
+@dataclass
+class AssessmentSummary:
+    total_entities: int
+    total_tables: int
+    total_size_gb: float                # projected post-migration (physical) size
+    effort_counts: dict[str, int]       # {"AUTO": n, "ASSISTED": n, "MANUAL": n}
+    complexity_counts: dict[str, int]   # {"PORTABLE": n, "ADAPT": n, "REWRITE": n}
+    sql_surface_confidence: ConfidenceLevel
+    total_logical_size_gb: float = 0.0  # BigQuery logical size (what the customer's console shows)
+
+
+@dataclass
+class Assessment:
+    assessment_id: str                  # "assess-{date}-{hash}"
+    generated_at: datetime
+    project_id: str
+    summary: AssessmentSummary
+    cost: CostComparison
+    entities: list[EntityReport]
+    failures: list[FailureRecord]

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/__init__.py
@@ -1,0 +1,12 @@
+"""Report generation: three mirrored JSON files + three HTML interfaces (Landing/Effort/Query).
+
+No CSV output in the target design (ADR-0001 / R20.8). See
+``.kiro/specs/phase1-assessment-tool/SCRUM_NOTES.md`` for the #2 restructure decision.
+
+All legacy code migrated to the normative writers as of Phase 8 (8.1).
+"""
+
+from bq_assess.report.html_writer import HTMLWriter  # noqa: F401
+from bq_assess.report.json_writer import JSONWriter  # noqa: F401
+
+__all__ = ["HTMLWriter", "JSONWriter"]

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/_serialize.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/_serialize.py
@@ -1,0 +1,145 @@
+"""Shared serialization: Assessment dataclass → dicts for JSON/HTML consumption."""
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime
+from enum import Enum
+
+from bq_assess.models import Assessment, EntityPopulation
+from bq_assess.engine.redshift import cost_constants as k
+
+
+def _to_dict(obj):
+    """Recursively serialize a dataclass/enum/datetime tree to JSON-safe primitives.
+
+    Rules:
+    - Enum → .value
+    - datetime → .isoformat()
+    - dataclass → dict (None-valued fields omitted)
+    - list → list (recurse each element)
+    - dict → dict (recurse values, omit None values)
+    - primitives pass through
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {
+            k: v
+            for k, v in (
+                (f.name, _to_dict(getattr(obj, f.name)))
+                for f in dataclasses.fields(obj)
+            )
+            if v is not None
+        }
+    if isinstance(obj, list):
+        return [_to_dict(item) for item in obj]
+    if isinstance(obj, dict):
+        return {k: v for k, v in ((k, _to_dict(v)) for k, v in obj.items()) if v is not None}
+    return obj
+
+
+def serialize_landing(assessment: Assessment) -> dict:
+    """Build the landing JSON dict: metadata + summary + cost + failures."""
+    result = {
+        "assessment_id": assessment.assessment_id,
+        "generated_at": assessment.generated_at.isoformat(),
+        "project_id": assessment.project_id,
+        "summary": _to_dict(assessment.summary),
+        "cost": _to_dict(assessment.cost),
+        "failures": _to_dict(assessment.failures),
+    }
+    return result
+
+
+def serialize_entities(assessment: Assessment) -> tuple[list[dict], list[dict]]:
+    """Serialize all entities once; return (effort_entities, query_entities).
+
+    Avoids calling _to_dict() twice on TABLE entities (which appear in both views).
+    The result is memoized on the assessment instance: JSONWriter and HTMLWriter both
+    call this in the default ``--format json,html`` run, and the recursive walk over
+    every entity (column schemas, view SQL) is the most expensive serialization step
+    at large-warehouse scale.
+    """
+    cached = getattr(assessment, "_serialized_entities", None)
+    if cached is not None:
+        return cached
+    effort: list[dict] = []
+    query: list[dict] = []
+    for e in assessment.entities:
+        d = _to_dict(e)
+        # Add physical and logical size for display
+        d["logical_size_gb"] = e.size_gb
+        pb = e.physical_bytes
+        d["physical_size_gb"] = round(pb / (1024 ** 3), 4) if pb is not None else round(e.size_gb * k.ASSUMED_PHYSICAL_RATIO, 4)
+        query.append(d)
+        if e.population is EntityPopulation.TABLE:
+            effort.append(d)
+    assessment._serialized_entities = (effort, query)
+    return assessment._serialized_entities
+
+
+# Fields the HTML report's client-side table renderer uses. Full entity dicts carry
+# column schemas and view SQL that the report tables never show — dropping them keeps
+# the embedded JSON (and thus the report file) small at warehouse scale. The template's
+# JS renderer and these allowlists are pinned together by
+# tests/unit/test_report_serialize.py::test_report_rows_cover_template_accesses.
+_EFFORT_ROW_KEYS = (
+    "full_name", "entity_type", "population", "rows",
+    "logical_size_gb", "physical_size_gb",
+    "effort", "conversion", "load_sync_dml",
+)
+_QUERY_ROW_KEYS = (
+    "full_name", "entity_type", "population",
+    "complexity", "depends_on", "rewrite_guidance", "translated_sql", "placement",
+)
+
+# Nested fields the renderer never reads. `complexity.constructs` matters most: it
+# carries per-construct anonymized SQL snippets, which at query-log scale dominate
+# the payload (and would ship SQL text the report never displays).
+_NESTED_DROP_KEYS = {
+    "complexity": ("constructs",),
+    "placement": ("refresh_unverified",),
+    "conversion": ("success",),
+}
+
+
+def _project_row(d: dict, keys: tuple[str, ...]) -> dict:
+    """Copy the allowlisted keys, pruning nested dead fields without mutating ``d``.
+
+    ``d`` is shared with the JSON sidecar writer, so nested dicts are shallow-copied
+    rather than edited in place.
+    """
+    row = {}
+    for key in keys:
+        value = d.get(key)
+        if value is None:
+            continue
+        drop = _NESTED_DROP_KEYS.get(key)
+        if drop and isinstance(value, dict):
+            value = {k: v for k, v in value.items() if k not in drop}
+        row[key] = value
+    return row
+
+
+def build_report_rows(effort_entities: list[dict], query_entities: list[dict]) -> dict:
+    """Project serialized entity dicts down to the HTML report's table payload.
+
+    Rows without a score are dropped here, mirroring the former template-side
+    ``{% if e.effort %}`` / ``{% if e.complexity %}`` guards.
+    """
+    return {
+        "effort": [
+            _project_row(d, _EFFORT_ROW_KEYS)
+            for d in effort_entities if d.get("effort")
+        ],
+        "query": [
+            _project_row(d, _QUERY_ROW_KEYS)
+            for d in query_entities if d.get("complexity")
+        ],
+    }
+
+

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/html_writer.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/html_writer.py
@@ -1,0 +1,161 @@
+"""Single-file HTML report (Landing + Effort + Query tabs), offline-inlined — R20.
+
+Renders all three views into one self-contained HTML file with JS tab navigation,
+mobile-responsive layout. Uses the same serialization layer as JSONWriter.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import datetime
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, Undefined
+
+from bq_assess.models import Assessment
+from bq_assess.core import pricing_constants as v4
+from bq_assess.core.disclaimer import (
+    ADVISORY_GUIDANCE, AS_IS, BETA_STATUS, COST_NOT_QUOTE, DATA_HANDLING,
+)
+from bq_assess.engine.redshift import cost_constants as k
+from bq_assess.report._serialize import (
+    build_report_rows, serialize_entities, serialize_landing,
+)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _format_currency(value):
+    """Jinja2 filter: format USD with commas, rounded to integer."""
+    if value is None or isinstance(value, Undefined):
+        return "N/A"
+    return f"${value:,.0f}"
+
+
+def _format_currency_precise(value):
+    """Show up to 2 decimal places for all values."""
+    if value is None or isinstance(value, Undefined):
+        return "N/A"
+    abs_val = abs(value)
+    if abs_val < 0.005:
+        return "$0.00"
+    if abs_val < 100:
+        return f"${value:,.2f}"
+    return f"${value:,.0f}"
+
+
+def _format_timestamp(value):
+    """Render an ISO timestamp (str or datetime) in the local timezone, minute precision.
+
+    e.g. 2026-06-29 21:42 PDT — aware values are converted to the machine's
+    local timezone; naive values are displayed as-is.
+    """
+    if value is None or isinstance(value, Undefined):
+        return "N/A"
+    dt = value
+    if isinstance(dt, str):
+        try:
+            dt = datetime.fromisoformat(dt)
+        except ValueError:
+            return value
+    if dt.tzinfo is not None:
+        dt = dt.astimezone()
+    tz = dt.strftime("%Z")
+    return dt.strftime("%Y-%m-%d %H:%M") + (f" {tz}" if tz else "")
+
+
+def _format_savings(value):
+    """Render savings: positive = 'Save $X', zero = 'Comparable', negative = 'No savings'."""
+    if value is None or isinstance(value, Undefined):
+        return "N/A"
+    abs_val = abs(value)
+    if abs_val < 1.0:
+        return "Comparable"
+    if value < 0:
+        return "No savings"
+    formatted = _format_currency_precise(abs_val)
+    return f"Save {formatted}"
+
+
+class HTMLWriter:
+    """Write a single combined HTML report from an Assessment."""
+
+    def __init__(self):
+        self._env = Environment(
+            loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+            autoescape=True,
+        )
+        self._env.filters["currency"] = _format_currency
+        self._env.filters["currency_precise"] = _format_currency_precise
+        self._env.filters["savings"] = _format_savings
+        self._env.filters["timestamp"] = _format_timestamp
+
+    def write(self, assessment: Assessment, out_dir: str, storage_basis: str = "assumed") -> list[str]:
+        """Write a single combined HTML file; return list with its absolute path."""
+        landing_data = serialize_landing(assessment)
+        effort_entities, query_entities = serialize_entities(assessment)
+        report_rows = build_report_rows(effort_entities, query_entities)
+
+        rg_4xl = k.V7_RG_NODE_TYPES["rg.4xlarge"]
+        ri_1yr_discount = round(
+            (1 - rg_4xl["ri_1yr_usd_per_node_hour"] / rg_4xl["ondemand_usd_per_node_hour"]) * 100
+        )
+        ri_3yr_discount = round(
+            (1 - rg_4xl["ri_3yr_usd_per_node_hour"] / rg_4xl["ondemand_usd_per_node_hour"]) * 100
+        )
+
+        # Compute reservation rates from the (possibly live-updated) base rate
+        serverless_1yr_rate = round(
+            k.V1_RPU_HOUR_USD * (1 - k.V1_SERVERLESS_RESERVATION_1YR_DISCOUNT), 4
+        )
+        serverless_3yr_rate = round(
+            k.V1_RPU_HOUR_USD * (1 - k.V1_SERVERLESS_RESERVATION_3YR_DISCOUNT), 4
+        )
+
+        # Per-render CSP nonce: the one legitimate inline <script> carries it; any
+        # script injected via a malicious BigQuery identifier (rendered into DDL/SQL
+        # code blocks) will NOT, so a compliant browser refuses to execute it. Fresh
+        # per file so the value is never guessable/reusable.
+        script_nonce = secrets.token_urlsafe(16)
+
+        ctx = {
+            **landing_data,
+            "report_rows": report_rows,
+            "storage_basis": storage_basis,
+            "csp_nonce": script_nonce,
+            "disclaimer_paragraphs": [
+                BETA_STATUS, COST_NOT_QUOTE, ADVISORY_GUIDANCE, AS_IS, DATA_HANDLING,
+            ],
+            "pricing": {
+                "s3_tables_tier1_per_gb": k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1,
+                "rms_per_gb": k.V6_MANAGED_STORAGE_USD_PER_GB_MONTH,
+                "serverless_rpu_hr": k.V1_RPU_HOUR_USD,
+                "serverless_1yr_rpu_hr": serverless_1yr_rate,
+                "serverless_3yr_rpu_hr": serverless_3yr_rate,
+                "serverless_1yr_discount_pct": round(k.V1_SERVERLESS_RESERVATION_1YR_DISCOUNT * 100),
+                "serverless_3yr_discount_pct": round(k.V1_SERVERLESS_RESERVATION_3YR_DISCOUNT * 100),
+                "serverless_1yr_breakeven_pct": round(k.V1_SERVERLESS_1YR_BREAKEVEN_UTIL * 100),
+                "serverless_3yr_breakeven_pct": round(k.V1_SERVERLESS_3YR_BREAKEVEN_UTIL * 100),
+                "slot_to_rpu_ratio": k.V3_SLOT_TO_RPU_RATIO,
+                "rg_4xl_ondemand_hr": rg_4xl["ondemand_usd_per_node_hour"],
+                "ri_1yr_discount_pct": ri_1yr_discount,
+                "ri_3yr_discount_pct": ri_3yr_discount,
+                "hours_per_month": int(k.HOURS_PER_MONTH),
+                "region": k.AWS_REGION_SCOPE,
+                "aws_region": k.AWS_PRICING_REGION,
+                "bq_region": v4.V4_PRICING_REGION,
+                "bq_ondemand_per_tib": v4.V4_ONDEMAND_USD_PER_TIB,
+                "bq_storage_active_per_gib": v4.V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH,
+                "physical_ratio": k.ASSUMED_PHYSICAL_RATIO,
+            },
+        }
+
+        template = self._env.get_template("combined.html.j2")
+        html = template.render(**ctx)
+
+        filename = f"{assessment.project_id}-assessment.html"
+        path = os.path.join(out_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(html)
+
+        return [os.path.abspath(path)]

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/json_writer.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/json_writer.py
@@ -1,0 +1,48 @@
+"""Three mirrored JSON files (Landing / Effort / Query) — R19.
+
+Writes three JSON files cross-referenced by full_name:
+- Landing: metadata + summary + cost + failures
+- Effort: Tables/External entities only (things that physically move)
+- Query: All entities (Tables + REBUILT views/MVs/UDFs)
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from bq_assess.models import Assessment
+from bq_assess.report._serialize import serialize_entities, serialize_landing
+
+
+class JSONWriter:
+    """Write three mirrored JSON files from an Assessment."""
+
+    def write(self, assessment: Assessment, out_dir: str) -> list[str]:
+        """Write landing/effort/query JSON files; return list of absolute paths."""
+        aid = assessment.assessment_id
+        paths = []
+
+        landing = serialize_landing(assessment)
+        paths.append(self._dump(landing, out_dir, f"assessment-landing-{aid}.json"))
+
+        effort_entities, query_entities = serialize_entities(assessment)
+
+        effort = {
+            "assessment_id": aid,
+            "entities": effort_entities,
+        }
+        paths.append(self._dump(effort, out_dir, f"assessment-effort-{aid}.json"))
+
+        query = {
+            "assessment_id": aid,
+            "entities": query_entities,
+        }
+        paths.append(self._dump(query, out_dir, f"assessment-query-{aid}.json"))
+
+        return paths
+
+    def _dump(self, data: dict, out_dir: str, filename: str) -> str:
+        path = os.path.join(out_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        return os.path.abspath(path)

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_donut.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_donut.j2
@@ -1,0 +1,53 @@
+{# Donut chart macro — pure SVG, offline-safe.
+   segments: list of dicts {key, label, count, color: green|amber|red}
+   center headline = share of the first segment (the "ready" story). #}
+{% macro donut(title, segments) %}
+{% set total = segments | sum(attribute="count") %}
+{% set C = 301.59 %}{# 2 * pi * r=48 #}
+{% set nonzero = segments | selectattr("count", "gt", 0) | list %}
+{% set gap = 4 if nonzero | length > 1 else 0 %}
+<div class="donut-panel">
+  <h3 class="donut-panel__title">{{ title }}</h3>
+  <div class="donut-panel__body">
+    <div class="donut">
+      <svg viewBox="0 0 120 120" role="img" aria-label="{{ title }}: {% for s in segments %}{{ s.label }} {{ s.count }}{% if not loop.last %}, {% endif %}{% endfor %}">
+        <circle cx="60" cy="60" r="48" fill="none" class="donut__track" stroke-width="16"/>
+        {% if total > 0 %}
+        {% set ns = namespace(cum=0.0) %}
+        {% for s in segments if s.count > 0 %}
+        {% set frac = s.count / total %}
+        {% set seg_len = [frac * C - gap, 1.5] | max %}
+        <circle cx="60" cy="60" r="48" fill="none" stroke-width="16"
+                class="donut__seg donut__seg--{{ s.color }}"
+                stroke-dasharray="{{ seg_len | round(2) }} {{ (C - seg_len) | round(2) }}"
+                stroke-dashoffset="{{ (-1 * ns.cum) | round(2) }}"
+                transform="rotate(-90 60 60)">
+          <title>{{ s.label }}: {{ s.count }} ({{ (frac * 100) | round(1) }}%)</title>
+        </circle>
+        {% set ns.cum = ns.cum + frac * C %}
+        {% endfor %}
+        {% endif %}
+      </svg>
+      <div class="donut__center">
+        {% if total > 0 %}
+        <span class="donut__center-value">{{ ((segments[0].count / total) * 100) | round | int }}%</span>
+        <span class="donut__center-label">{{ segments[0].label }}</span>
+        {% else %}
+        <span class="donut__center-value">&mdash;</span>
+        <span class="donut__center-label">no data</span>
+        {% endif %}
+      </div>
+    </div>
+    <ul class="donut-legend">
+      {% for s in segments %}
+      <li class="donut-legend__item">
+        <span class="donut-legend__dot donut-legend__dot--{{ s.color }}"></span>
+        <span class="donut-legend__label">{{ s.label }}</span>
+        <span class="donut-legend__count">{{ s.count }}</span>
+        <span class="donut-legend__pct">{% if total > 0 %}{{ ((s.count / total) * 100) | round | int }}%{% else %}0%{% endif %}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endmacro %}

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_help.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_help.j2
@@ -1,0 +1,73 @@
+{# Shared help copy for the report. The dicts below are imported by
+   combined.html.j2 — partly rendered server-side (cost/sql_surface badges), partly
+   exported to the client-side row renderer via the help-data JSON block.
+   Tooltip copy is derived from the actual scorer logic (scoring/effort.py,
+   scoring/complexity.py, engine/redshift/placement.py) — keep in sync. #}
+
+{% set CONFIDENCE_HELP = {
+  "effort": {
+    "HIGH": "Table size and schema were read directly from BigQuery metadata, so the effort factors are measured, not estimated.",
+    "MEDIUM": "Some metadata was incomplete — effort factors are partly estimated.",
+    "LOW": "Table size was not available in BigQuery metadata, so volume-based effort factors could not be assessed.",
+  },
+  "complexity": {
+    "HIGH": "Based on actual query logs — the SQL your workload really runs was analyzed.",
+    "MEDIUM": "Based on the saved view/routine definition only — queries from consumers were not visible. Provide query logs for a HIGH-confidence rating.",
+    "LOW": "No SQL was visible for this entity (schema only). The rating is a default, not an analysis — provide query logs to assess it properly.",
+  },
+  "placement": {
+    "HIGH": "Only one valid home exists for this entity type — for example, UDFs and procedures must live in Redshift because Iceberg has no function concept.",
+    "MEDIUM": "Query logs were available, so the recommendation reflects how this object is actually consumed.",
+    "LOW": "No query logs were provided, so this recommendation is inferred from schema structure alone (how many datasets the object spans). Re-run with query logs or validate manually before acting on it.",
+  },
+  "cost": {
+    "HIGH": "Priced from measured usage in your project and current published rates.",
+    "MEDIUM": "Priced using research-based conversion ratios or partial usage data — validate with a pilot workload.",
+    "LOW": "Priced from rough assumptions due to missing data — treat as an order-of-magnitude estimate only.",
+  },
+  "sql_surface": {
+    "HIGH": "Query logs were provided — the tool saw the SQL your workload actually runs.",
+    "MEDIUM": "Only view and routine definitions were visible — consumer queries were not. Provide query logs to raise confidence.",
+    "LOW": "Little or no SQL was visible. Complexity ratings are defaults, not analysis — re-run with query logs.",
+  },
+} %}
+
+{% set CATEGORY_HELP = {
+  "AUTO": "Score 0 — no effort factors detected. The generated DDL and load statements can run without manual intervention.",
+  "ASSISTED": "Score 1–2 — mostly automated, with a small number of items to review first (for example a type cast or a partitioning choice).",
+  "MANUAL": "Score 3+ — needs hands-on migration design: many lossy casts, very large volume, or a failed automatic conversion.",
+  "PORTABLE": "Score 0 — no BigQuery-specific SQL detected. Should run on Redshift with little or no change.",
+  "ADAPT": "Score 1–3 — uses some BigQuery-specific constructs. Small, targeted edits are needed.",
+  "REWRITE": "Score 4+ — relies heavily on BigQuery-specific constructs (arrays, JavaScript UDFs). Plan a genuine rewrite.",
+} %}
+
+{% set FLAG_INFO = {
+  "lossy_casts": ("Lossy type casts", "Some columns lose precision or range when mapped to Iceberg types. Review the cast table and confirm each loss is acceptable for your data."),
+  "ongoing_sync": ("Ongoing sync needed", "The table carries an update-timestamp or ingestion-time signal, so it likely changes continuously. Plan a recurring MERGE/CDC sync rather than a one-time copy."),
+  "data_volume_large": ("Large table (1+ GB)", "Big enough to need a staged COPY load rather than a single INSERT…SELECT."),
+  "data_volume_huge": ("Very large table (100+ GB)", "Needs a partition-wise, parallelized load strategy and a validation plan."),
+  "partition_decision_required": ("Partitioning decision needed", "The BigQuery partition spec has no clean Iceberg equivalent — a human must choose the Iceberg partition transform."),
+  "sort_decision_required": ("Sort-order decision needed", "BigQuery clustering does not map one-to-one to an Iceberg sort order — a human must choose the sort columns."),
+  "conversion_failed": ("Conversion failed", "The automatic Iceberg DDL conversion failed for this table — the migration must be designed manually."),
+  "UNNEST": ("UNNEST array flattening", "Redshift has no direct UNNEST. Array flattening must be rewritten, e.g. with SUPER/PartiQL navigation or a join against unnested elements."),
+  "ARRAY_FN": ("Array functions", "BigQuery array functions (ARRAY_AGG options, ARRAY_LENGTH, OFFSET…) have no one-to-one Redshift equivalent and need rewriting."),
+  "JS_UDF": ("JavaScript UDF", "Redshift cannot run JavaScript UDFs. Reimplement in SQL, a Python UDF, or a Lambda UDF."),
+  "STRUCT_NAV": ("Nested STRUCT access", "Navigation into STRUCT fields must be adapted to Redshift's SUPER dot-notation, or the structure flattened."),
+  "FUNCTION_DRIFT": ("Function differences", "Uses functions whose name or behavior differs in Redshift (e.g. TIMESTAMP_DIFF, FORMAT_DATE). Each call site needs mapping to the Redshift equivalent."),
+  "hub_entity": ("Hub entity", "Three or more other entities depend on this one, so changes here ripple outward. Migrate and validate it early."),
+} %}
+
+{% set SOURCE_LABELS = {
+  "query_logs": "query logs",
+  "view_definition": "view definition",
+  "schema_only": "schema only",
+} %}
+
+{# Copy used by the client-side row renderer in combined.html.j2 — exported through
+   the help-data JSON block so it has exactly one source. #}
+{% set UI_TEXT = {
+  "score_tip": "Each detected factor adds weighted points. 0 points = fully automatic / portable; a low score = review needed; a high score = manual work or rewrite.",
+  "partition_auto": " — mapped automatically from the BigQuery partition spec; no action needed.",
+  "partition_manual": " — could not be mapped automatically; review the flagged decision before migrating.",
+  "source_tip": "What the tool analyzed to reach this rating: query logs (the SQL your workload actually runs), the saved view/routine definition, or just the table schema.",
+} %}

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_styles.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/_styles.j2
@@ -1,0 +1,705 @@
+/* Migration Assessment — Cloudscape-inspired design system */
+:root {
+  --color-bg-layout: #f2f8fd;
+  --color-bg-default: #ffffff;
+  --color-bg-alt: #f4f4f4;
+  --color-bg-header: #0f1b2a;
+  --color-bg-nav: #ffffff;
+
+  --color-text-body: #000716;
+  --color-text-heading: #0f1b2a;
+  --color-text-secondary: #5f6b7a;
+  --color-text-muted: #7d8998;
+  --color-text-inverse: #ffffff;
+  --color-text-link: #0972d3;
+
+  --color-border-divider: #e9ebed;
+  --color-border-card: #e9ebed;
+  --color-border-input: #7d8998;
+
+  --color-brand-orange: #ff9900;
+  --color-brand-navy: #232f3e;
+  --color-brand-squid: #ec7211;
+
+  --color-severity-success: #037f0c;
+  --color-severity-success-bg: #f2fcf3;
+  --color-severity-warning: #d97706;
+  --color-severity-warning-bg: #fffce9;
+  --color-severity-error: #d91515;
+  --color-severity-error-bg: #fff7f7;
+  --color-severity-info: #0972d3;
+  --color-severity-info-bg: #f0f9ff;
+  --color-severity-neutral: #414d5c;
+
+  --shadow-xs: 0 1px 2px 0 rgba(0, 7, 22, 0.05);
+  --shadow-sm: 0 2px 4px -1px rgba(0, 7, 22, 0.07), 0 1px 2px -1px rgba(0, 7, 22, 0.04);
+  --shadow-md: 0 4px 12px -2px rgba(0, 7, 22, 0.08), 0 2px 4px -2px rgba(0, 7, 22, 0.04);
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 100px;
+
+  --font-body: "Amazon Ember", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Source Code Pro", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--color-text-body);
+  background: var(--color-bg-layout);
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container { max-width: 1320px; margin: 0 auto; padding: 0 var(--space-lg); }
+h1, h2, h3 { margin-top: 0; font-weight: 700; line-height: 1.25; color: var(--color-text-heading); }
+h1 { font-size: 1.5rem; letter-spacing: -0.01em; }
+h2 { font-size: 1.125rem; margin-bottom: var(--space-lg); letter-spacing: -0.005em; }
+h3 { font-size: 0.9375rem; margin-bottom: var(--space-md); }
+p { margin-top: 0; margin-bottom: var(--space-md); }
+a { color: var(--color-text-link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Layout Grid */
+.row { display: flex; flex-wrap: wrap; gap: var(--space-md); }
+.col { flex: 1 1 0%; min-width: 0; }
+.col-3 { flex: 0 0 calc(25% - 12px); min-width: 0; }
+.col-4 { flex: 0 0 calc(33.333% - 11px); min-width: 0; }
+.col-6 { flex: 0 0 calc(50% - 8px); min-width: 0; }
+.col-12 { flex: 0 0 100%; min-width: 0; }
+
+/* ─── Header ─── */
+.header {
+  background: var(--color-bg-header);
+  border-bottom: none;
+  padding: 0;
+}
+.header-inner {
+  display: flex;
+  align-items: center;
+  padding: var(--space-md) 0;
+  min-height: 56px;
+}
+.header-logo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  color: var(--color-text-inverse);
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+.header-logo .aws-cube {
+  width: 32px; height: 32px;
+  background: var(--color-brand-orange);
+  border-radius: 6px;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 800; font-size: 11px; color: var(--color-bg-header);
+  letter-spacing: 0.5px;
+}
+.header-meta {
+  margin-left: auto;
+  color: rgba(255,255,255,0.6);
+  font-size: 0.8125rem;
+}
+.header-meta strong { color: rgba(255,255,255,0.9); }
+
+/* ─── Navigation ─── */
+.nav {
+  background: var(--color-bg-nav);
+  border-bottom: 1px solid var(--color-border-divider);
+  padding: 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow-xs);
+}
+.nav-links {
+  display: flex;
+  gap: 0;
+}
+.nav-links a {
+  position: relative;
+  padding: var(--space-md) var(--space-lg);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  border-radius: 0;
+  transition: color 0.15s;
+  letter-spacing: 0.01em;
+}
+.nav-links a:hover {
+  color: var(--color-text-body);
+  text-decoration: none;
+  background: transparent;
+}
+.nav-links a.active {
+  color: var(--color-text-link);
+  background: transparent;
+}
+.nav-links a.active::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: var(--space-lg);
+  right: var(--space-lg);
+  height: 3px;
+  background: var(--color-text-link);
+  border-radius: 3px 3px 0 0;
+}
+
+/* ─── Card System ─── */
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-md);
+  margin-bottom: 0;
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+.card-body { flex: 1 1 auto; padding: var(--space-lg); }
+.card-title {
+  margin-bottom: var(--space-xs);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+/* Stat Cards */
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-text-heading);
+  letter-spacing: -0.02em;
+}
+.stat-label {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-top: var(--space-xs);
+}
+
+/* Category indicator on cards */
+.card[data-accent="green"] { border-top: 3px solid var(--color-severity-success); }
+.card[data-accent="amber"] { border-top: 3px solid var(--color-severity-warning); }
+.card[data-accent="red"] { border-top: 3px solid var(--color-severity-error); }
+.card[data-accent="orange"] { border-top: 3px solid var(--color-brand-orange); }
+
+/* ─── Donut Charts ─── */
+.donut-row {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+.donut-panel {
+  flex: 1 1 340px;
+  min-width: 0;
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
+  padding: var(--space-lg) var(--space-xl);
+}
+.donut-panel__title {
+  margin: 0 0 var(--space-md) 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-text-heading);
+}
+.donut-panel__body {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xl);
+}
+.donut {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  flex-shrink: 0;
+}
+.donut svg { width: 100%; height: 100%; display: block; }
+.donut__track { stroke: var(--color-border-divider); }
+.donut__seg--green { stroke: var(--color-severity-success); }
+.donut__seg--amber { stroke: var(--color-severity-warning); }
+.donut__seg--red { stroke: var(--color-severity-error); }
+.donut__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.donut__center-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-text-heading);
+  letter-spacing: -0.02em;
+}
+.donut__center-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+.donut-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.donut-legend__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) 0;
+  font-size: 0.9375rem;
+  color: var(--color-text-body);
+}
+.donut-legend__item + .donut-legend__item {
+  border-top: 1px solid var(--color-border-divider);
+}
+.donut-legend__dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.donut-legend__dot--green { background: var(--color-severity-success); }
+.donut-legend__dot--amber { background: var(--color-severity-warning); }
+.donut-legend__dot--red { background: var(--color-severity-error); }
+.donut-legend__label {
+  font-weight: 600;
+  color: var(--color-text-heading);
+}
+.donut-legend__count {
+  margin-left: auto;
+  font-weight: 700;
+  color: var(--color-text-heading);
+  font-variant-numeric: tabular-nums;
+}
+.donut-legend__pct {
+  min-width: 44px;
+  text-align: right;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Tables ─── */
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-md);
+}
+thead th:first-child { border-top-left-radius: var(--radius-md); }
+thead th:last-child { border-top-right-radius: var(--radius-md); }
+tbody tr:last-child td:first-child { border-bottom-left-radius: var(--radius-md); }
+tbody tr:last-child td:last-child { border-bottom-right-radius: var(--radius-md); }
+thead th {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--color-text-muted);
+  background: var(--color-bg-alt);
+  border-bottom: 1px solid var(--color-border-divider);
+}
+td {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border-divider);
+  font-size: 0.8125rem;
+}
+tbody tr:last-child td { border-bottom: none; }
+tbody tr:hover { background: #f8fafc; }
+
+/* Expandable entity rows */
+tr.entity-row.has-detail { cursor: pointer; }
+td.expand-cell { width: 28px; padding-right: 0; }
+td.expand-cell .chevron {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  transform: rotate(-45deg);
+  transition: transform 0.2s;
+}
+tr.entity-row.expanded td.expand-cell .chevron { transform: rotate(45deg); }
+tr.entity-row.expanded td { background: #f0f6fd; border-bottom-color: transparent; }
+tr.detail-row { display: none; }
+tr.detail-row.open { display: table-row; }
+tr.detail-row > td {
+  background: #fafbfd;
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--color-border-divider);
+  box-shadow: inset 0 2px 4px -2px rgba(0, 7, 22, 0.06);
+}
+tr.detail-row:hover { background: transparent; }
+tr.detail-row > td:hover { background: #fafbfd; }
+
+/* ─── Badges ─── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  border-radius: var(--radius-pill);
+  letter-spacing: 0.3px;
+}
+.badge-auto { background: var(--color-severity-success-bg); color: var(--color-severity-success); }
+.badge-assisted { background: var(--color-severity-warning-bg); color: var(--color-severity-warning); }
+.badge-manual { background: var(--color-severity-error-bg); color: var(--color-severity-error); }
+.badge-portable { background: var(--color-severity-success-bg); color: var(--color-severity-success); }
+.badge-adapt { background: var(--color-severity-warning-bg); color: var(--color-severity-warning); }
+.badge-rewrite { background: var(--color-severity-error-bg); color: var(--color-severity-error); }
+.badge-high { background: var(--color-severity-success-bg); color: var(--color-severity-success); }
+.badge-medium { background: var(--color-severity-warning-bg); color: var(--color-severity-warning); }
+.badge-low { background: var(--color-severity-error-bg); color: var(--color-severity-error); }
+.badge-flag { background: #f0f0f5; color: var(--color-severity-neutral); font-weight: 600; }
+.tooltip-icon { display: inline-flex; cursor: help; font-size: 0.75rem; color: var(--color-text-link); margin-left: 4px; }
+
+/* ─── Tooltips (pure CSS, offline-safe) ─── */
+.tip { position: relative; cursor: help; }
+.tip::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  width: max-content;
+  max-width: 320px;
+  padding: 10px 12px;
+  background: var(--color-bg-header);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0;
+  text-transform: none;
+  text-align: left;
+  white-space: normal;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s, transform 0.15s;
+  z-index: 200;
+  pointer-events: none;
+}
+.tip::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 3px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--color-bg-header);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s;
+  z-index: 200;
+  pointer-events: none;
+}
+.tip:hover::after, .tip:focus-visible::after,
+.tip:hover::before, .tip:focus-visible::before {
+  opacity: 1;
+  visibility: visible;
+}
+.tip:hover::after, .tip:focus-visible::after { transform: translateX(-50%) translateY(0); }
+/* hover affordance: dotted underline on anything with a tooltip */
+.badge.tip, .tip.tooltip-icon {
+  text-decoration: underline dotted;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+/* keep tooltips inside the viewport near table edges */
+td:last-child .tip::after, .cost-hero .tip::after { left: auto; right: 0; transform: translateX(0) translateY(4px); }
+td:last-child .tip:hover::after, td:last-child .tip:focus-visible::after,
+.cost-hero .tip:hover::after, .cost-hero .tip:focus-visible::after { transform: translateX(0) translateY(0); }
+/* detail rows span the full table width — anchor tooltips to the trigger's left edge
+   so they never extend past the viewport (must out-rank the td:last-child rule above) */
+tr.detail-row > td .tip::after { left: 0; right: auto; transform: translateX(0) translateY(4px); }
+tr.detail-row > td .tip:hover::after, tr.detail-row > td .tip:focus-visible::after { transform: translateX(0) translateY(0); }
+tr.detail-row > td .tip::before { left: 12px; transform: translateX(0); }
+
+/* ─── Alerts ─── */
+.alert {
+  position: relative;
+  padding: var(--space-md) var(--space-lg);
+  margin-bottom: var(--space-lg);
+  border-radius: var(--radius-sm);
+  border-left: 4px solid;
+  font-size: 0.8125rem;
+}
+.alert-warning {
+  color: #92400e;
+  background: var(--color-severity-warning-bg);
+  border-left-color: var(--color-severity-warning);
+}
+
+/* ─── Accordion / Details ─── */
+details { margin-bottom: var(--space-sm); }
+details summary {
+  cursor: pointer;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--color-text-heading);
+  transition: background 0.1s, border-color 0.1s;
+  list-style: none;
+  display: flex;
+  align-items: center;
+}
+details summary::-webkit-details-marker { display: none; }
+details summary::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  transform: rotate(-45deg);
+  margin-right: var(--space-sm);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+details[open] summary::before { transform: rotate(45deg); }
+details summary:hover { background: #f8fafc; border-color: #c4cad0; }
+details[open] summary {
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  border-bottom-color: transparent;
+}
+details[open] > .card {
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+  margin-top: -1px;
+  border-top-color: var(--color-border-card);
+}
+
+/* Scenario accordion */
+details.scenario { margin-bottom: var(--space-xs); }
+details.scenario summary { font-weight: 500; }
+details.scenario.scenario-recommended summary { background: var(--color-severity-success-bg); border-color: #c6f0c8; font-weight: 600; }
+.scenario-row { display: inline-flex; align-items: center; gap: var(--space-md); flex-wrap: wrap; width: calc(100% - 1.5rem); }
+.scenario-label { min-width: 180px; }
+.scenario-cost { min-width: 70px; font-weight: 700; }
+.scenario-delta { min-width: 100px; }
+
+/* ─── Code ─── */
+pre {
+  background: #f8f9fa;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  font-size: 0.8125rem;
+  margin: var(--space-sm) 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+code { font-family: var(--font-mono); font-size: 0.8125rem; }
+
+/* ─── Sections ─── */
+.section {
+  margin-bottom: var(--space-2xl);
+}
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border-divider);
+}
+.section-header h2 { margin-bottom: 0; border-bottom: none; }
+.section-header .section-badge {
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+/* ─── Cost Hero ─── */
+.cost-hero {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-lg);
+  align-items: center;
+  padding: var(--space-xl);
+  background: var(--color-bg-default);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-lg);
+}
+.cost-hero__block { text-align: center; }
+.cost-hero__block--aws { }
+.cost-hero__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-xs);
+}
+.cost-hero__value {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text-heading);
+}
+.cost-hero__sub {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+.cost-hero__arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--color-severity-success);
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+.cost-hero__arrow svg {
+  width: 28px; height: 28px;
+  stroke: currentColor;
+  fill: none;
+}
+
+/* ─── Utility ─── */
+.text-center { text-align: center; }
+.text-muted { color: var(--color-text-muted); }
+.fw-bold { font-weight: 700; }
+.fs-3 { font-size: 1.5rem; color: var(--color-text-heading); letter-spacing: -0.02em; }
+
+/* ─── Footer ─── */
+.footer {
+  text-align: center;
+  padding: var(--space-xl) 0;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  border-top: 1px solid var(--color-border-divider);
+  margin-top: var(--space-2xl);
+}
+
+/* ─── Filter Cards ─── */
+.filter-card { cursor: pointer; transition: transform 0.1s, box-shadow 0.1s; }
+.filter-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+.filter-card.active-filter { box-shadow: 0 0 0 2px var(--color-text-link); transform: translateY(-2px); }
+.filter-reset { display: none; margin: var(--space-sm) 0; font-size: 0.8125rem; color: var(--color-text-link); cursor: pointer; }
+.filter-reset.visible { display: inline-block; }
+
+/* ─── Table search ─── */
+.table-toolbar { margin-bottom: var(--space-sm); }
+.search-input {
+  width: 100%;
+  max-width: 380px;
+  padding: 7px 12px;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  color: var(--color-text-body);
+  background: var(--color-bg-default);
+}
+.search-input:focus {
+  outline: none;
+  border-color: var(--color-text-link);
+  box-shadow: 0 0 0 2px rgba(0, 115, 187, 0.15);
+}
+
+/* ─── Pagination ─── */
+.pagination-controls { display: flex; align-items: center; gap: var(--space-sm); margin: var(--space-md) 0; font-size: 0.8125rem; }
+.pagination-controls button {
+  padding: 6px 12px;
+  border: 1px solid var(--color-border-divider);
+  background: var(--color-bg-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text-body);
+  transition: background 0.1s;
+}
+.pagination-controls button:disabled { opacity: 0.4; cursor: default; }
+.pagination-controls button:hover:not(:disabled) { background: #f0f4f8; }
+.pagination-controls .page-info { color: var(--color-text-muted); }
+
+/* ─── Responsive ─── */
+@media (max-width: 768px) {
+  .container { padding: 0 var(--space-md); }
+  .header-inner { flex-direction: column; align-items: flex-start; gap: var(--space-sm); }
+  .header-meta { margin-left: 0 !important; font-size: 0.75rem; overflow-wrap: anywhere; }
+  .nav-links { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .nav-links a { padding: var(--space-md) var(--space-md); font-size: 0.75rem; white-space: nowrap; }
+  .row { gap: var(--space-sm); }
+  .col-3 { flex: 0 0 calc(50% - 4px); }
+  .col-4, .col-6, .col-12 { flex: 0 0 100%; max-width: 100%; }
+  .stat-value { font-size: 1.5rem; }
+  .fs-3 { font-size: 1.2rem; }
+  .cost-hero { grid-template-columns: 1fr; gap: var(--space-md); padding: var(--space-lg); }
+  .cost-hero__arrow { flex-direction: row; justify-content: center; gap: var(--space-sm); }
+  .cost-hero__arrow svg { transform: rotate(90deg); }
+  table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  thead th, td { padding: var(--space-sm); white-space: nowrap; }
+  details summary { font-size: 0.75rem; padding: var(--space-sm); flex-wrap: wrap; row-gap: 4px; }
+  pre { font-size: 0.75rem; padding: var(--space-sm); }
+  .card-body { padding: var(--space-md); }
+  .donut-panel { padding: var(--space-md); }
+  .donut-panel__body { flex-direction: column; gap: var(--space-md); }
+  .donut { width: 150px; height: 150px; }
+  .donut-legend { width: 100%; }
+}
+
+@media (max-width: 480px) {
+  .header-logo h1 { font-size: 1rem !important; }
+  .nav-links a { padding: var(--space-sm) var(--space-md); }
+  .stat-value { font-size: 1.25rem; }
+  .col-3 .card-body { padding: var(--space-md) var(--space-sm); }
+  .scenario-label { min-width: 0; }
+  .scenario-cost { min-width: 0; }
+  .scenario-delta { min-width: 0; }
+}
+
+/* ─── Beta/Disclaimer Notice ─── */
+.footer .disclaimer {
+  max-width: 860px;
+  margin: var(--space-lg) auto 0;
+  padding: var(--space-md) var(--space-lg);
+  text-align: left;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-divider);
+  border-radius: 8px;
+}
+.footer .disclaimer strong { display: block; margin-bottom: var(--space-xs); }
+.footer .disclaimer p { margin: 0 0 var(--space-xs) 0; }

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/combined.html.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/combined.html.j2
@@ -1,0 +1,1035 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-{{ csp_nonce }}'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Migration Assessment — {{ project_id }}</title>
+<style>
+{% include '_styles.j2' %}
+
+/* Tab system */
+.tab-content { display: none }
+.tab-content.active { display: block }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="container">
+    <div class="header-inner">
+      <div class="header-logo">
+        <div class="aws-cube">BQ</div>
+        <div>
+          <h1 style="color:#fff;margin:0;font-size:1.125rem">Migration Assessment</h1>
+          <p style="color:rgba(255,255,255,.5);margin:2px 0 0 0;font-size:.75rem">BigQuery &rarr; Amazon Redshift (Lakehouse)</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        Project: <strong>{{ project_id }}</strong> &middot;
+        {{ generated_at|timestamp }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="nav">
+  <div class="container">
+    <div class="nav-links">
+      <a href="#" data-tab="landing" class="active">Summary</a>
+      <a href="#" data-tab="effort">Migration Effort</a>
+      <a href="#" data-tab="query">Query Complexity</a>
+    </div>
+  </div>
+</div>
+
+{% import '_help.j2' as help %}
+<div class="container" style="padding-top: var(--space-xl); padding-bottom: var(--space-xl);">
+
+<noscript>
+<div class="alert alert-warning">
+  <strong>JavaScript required</strong><br>
+  The entity tables in this report render from embedded data and need JavaScript enabled.
+  Summary and cost sections above remain readable; for a script-free view of the full entity
+  data, use the JSON files generated alongside this report.
+</div>
+</noscript>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- TAB: LANDING / SUMMARY                                                 -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<div id="tab-landing" class="tab-content active">
+
+{% if cost.compute_confidence == "LOW" %}
+<div class="alert alert-warning">
+  <strong>Low Confidence Cost Estimate</strong><br>
+  Compute cost estimates are based on incomplete data. Review the cost breakdown notes below.
+</div>
+{% endif %}
+
+<div class="section">
+  <div class="section-header">
+    <h2>Overview</h2>
+  </div>
+
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Entities</div>
+          <div class="stat-value">{{ summary.total_entities }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Tables</div>
+          <div class="stat-value">{{ summary.total_tables }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Size <span class="tip tooltip-icon" tabindex="0" data-tip="Top: BigQuery logical size — matches your BigQuery console. Below: projected S3 Iceberg footprint{% if storage_basis == 'measured' %}, measured compressed (Parquet) bytes from TABLE_STORAGE{% elif storage_basis == 'mixed' %}, measured where available, assumed {{ pricing.physical_ratio }}× logical for the rest{% else %}, estimated at {{ pricing.physical_ratio }}× logical (TABLE_STORAGE unavailable){% endif %}.">i</span></div>
+          <div class="stat-value">{{ "%.1f"|format(summary.total_logical_size_gb) }} <span style="font-size:.875rem;font-weight:400">GB</span></div>
+          <div style="font-size:.75rem;color:var(--color-text-secondary);margin-top:2px">&rarr; <strong>{{ "%.1f"|format(summary.total_size_gb) }} GB</strong> on S3 Iceberg</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">SQL Surface Confidence <span class="tip tooltip-icon" tabindex="0" data-tip="How much of your actual SQL the tool could see. This caps the reliability of every query-complexity rating in this report.">i</span></div>
+          <div class="stat-value">
+            <span class="badge badge-{{ summary.sql_surface_confidence|lower }} tip" tabindex="0" data-tip="{{ help.CONFIDENCE_HELP['sql_surface'][summary.sql_surface_confidence] }}" style="font-size:.875rem;padding:5px 14px">
+              {{ summary.sql_surface_confidence }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Migration Readiness -->
+{% import '_donut.j2' as charts %}
+<div class="section">
+  <div class="section-header">
+    <h2>Migration Readiness</h2>
+  </div>
+
+  <div class="donut-row">
+    {{ charts.donut("Migration Effort", [
+      {"label": "Auto", "count": summary.effort_counts.AUTO or 0, "color": "green"},
+      {"label": "Assisted", "count": summary.effort_counts.ASSISTED or 0, "color": "amber"},
+      {"label": "Manual", "count": summary.effort_counts.MANUAL or 0, "color": "red"},
+    ]) }}
+    {{ charts.donut("Query Complexity", [
+      {"label": "Portable", "count": summary.complexity_counts.PORTABLE or 0, "color": "green"},
+      {"label": "Adapt", "count": summary.complexity_counts.ADAPT or 0, "color": "amber"},
+      {"label": "Rewrite", "count": summary.complexity_counts.REWRITE or 0, "color": "red"},
+    ]) }}
+  </div>
+</div>
+
+<!-- Cost Comparison -->
+<div class="section">
+  <div class="section-header">
+    <h2>Cost Comparison</h2>
+    <span class="section-badge">monthly estimate</span>
+  </div>
+
+  <div class="cost-hero">
+    <div class="cost-hero__block">
+      <div class="cost-hero__label">BigQuery (Current)</div>
+      <div class="cost-hero__value">{{ cost.bigquery_monthly|currency_precise }}</div>
+      <div class="cost-hero__sub">{{ cost.bq_pricing_model }}{% if cost.bq_pricing_region %} &middot; {{ cost.bq_pricing_region }}{% endif %}</div>
+    </div>
+    <div class="cost-hero__arrow">
+      <svg viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      {{ cost.monthly_delta_low|savings }}
+    </div>
+    <div class="cost-hero__block cost-hero__block--aws">
+      <div class="cost-hero__label">AWS Lakehouse{% if cost.recommendation %} ({{ cost.recommendation.recommended_scenario }}){% endif %}</div>
+      <div class="cost-hero__value" style="color: var(--color-severity-success);">{% if cost.aws_monthly_low == cost.aws_monthly_high %}{{ cost.aws_monthly_low|currency_precise }}{% else %}{{ cost.aws_monthly_low|currency_precise }} &ndash; {{ cost.aws_monthly_high|currency_precise }}{% endif %}</div>
+      <div class="cost-hero__sub">{% if cost.aws_pricing_region %}{{ cost.aws_pricing_region }}{% endif %}</div>
+    </div>
+  </div>
+
+  <div class="row" style="margin-bottom: var(--space-lg);">
+    <div class="col-6">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Monthly Savings</div>
+          <div class="fs-3 fw-bold" style="color: var(--color-severity-success);">{{ cost.monthly_delta_low|savings }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Annual Savings</div>
+          <div class="fs-3 fw-bold" style="color: var(--color-severity-success);">{{ cost.annual_savings_low|savings }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if cost.recommendation %}
+  <div class="card" style="border-left: 4px solid var(--color-severity-success); margin-bottom: var(--space-lg);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem;color:var(--color-severity-success)">Recommendation: {{ cost.recommendation.recommended_scenario }}</h3>
+      <p style="margin-bottom:0;font-size:.8125rem;color:var(--color-text-secondary)">{{ cost.recommendation.reasoning }}</p>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if cost.aws_scenarios %}
+  <h3 style="margin-bottom: var(--space-md);">AWS Deployment Options</h3>
+  {% for scenario in cost.aws_scenarios %}
+  <details class="scenario{% if scenario.is_recommended %} scenario-recommended{% endif %}"{% if scenario.is_recommended %} open{% endif %}>
+    <summary>
+      <span class="scenario-row">
+        <span class="scenario-label">
+          {{ scenario.label }}
+          {% if scenario.is_recommended %}<span class="badge badge-high" style="margin-left:.5rem">RECOMMENDED</span>{% endif %}
+        </span>
+        <span class="scenario-cost">{{ scenario.monthly_total|currency_precise }}</span>
+        <span class="scenario-delta">
+          {% set delta = cost.bigquery_monthly - scenario.monthly_total %}
+          {% if delta > 0 %}
+            <span style="color:var(--color-severity-success)">Save {{ delta|currency_precise }}/mo</span>
+          {% elif delta < -1 %}
+            <span style="color:var(--color-severity-error)">+{{ (delta * -1)|currency_precise }}/mo</span>
+          {% else %}
+            <span style="color:var(--color-text-muted)">Comparable</span>
+          {% endif %}
+        </span>
+        <span class="badge badge-{{ scenario.confidence|lower }} tip" tabindex="0" data-tip="{{ help.CONFIDENCE_HELP['cost'][scenario.confidence] }}">
+          {{ scenario.confidence }}
+        </span>
+      </span>
+    </summary>
+    <div class="card">
+      <div class="card-body" style="font-size:.8125rem">
+        {% if scenario.justification %}<p style="margin:0 0 .5rem 0;color:var(--color-text-secondary)">{{ scenario.justification }}</p>{% endif %}
+        {% if scenario.workload_fit_notes %}
+        <ul style="margin:0;padding-left:1.25rem">
+          {% for note in scenario.workload_fit_notes %}
+          <li>{{ note }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+    </div>
+  </details>
+  {% endfor %}
+  {% endif %}
+
+  {% if cost.scope_notes %}
+  <div class="card" style="border-left: 4px solid var(--color-severity-error); margin-top: var(--space-lg);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem;color:var(--color-severity-error)">What This Estimate Covers</h3>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        {% for note in cost.scope_notes %}
+        <li>{{ note }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
+  <h3 style="margin-top: var(--space-xl); margin-bottom: var(--space-md);">BigQuery Cost Breakdown</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Line Item</th>
+        <th style="text-align:right">Monthly</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for line in cost.bigquery_breakdown %}
+      <tr>
+        <td><strong>{{ line.label }}</strong></td>
+        <td style="text-align:right">{{ line.monthly|currency_precise }}</td>
+        <td>
+          <span class="badge badge-{{ line.confidence|lower }} tip" tabindex="0" data-tip="{{ help.CONFIDENCE_HELP['cost'][line.confidence] }}">
+            {{ line.confidence }}
+          </span>
+        </td>
+        <td class="text-muted">{{ line.source_note }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <h3 style="margin-top: var(--space-xl); margin-bottom: var(--space-md);">AWS Cost Breakdown (Recommended Option)</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Line Item</th>
+        <th style="text-align:right">Monthly</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for line in cost.aws_lines %}
+      <tr>
+        <td><strong>{{ line.label }}</strong></td>
+        <td style="text-align:right">
+          {% if line.monthly is not none %}
+            {{ line.monthly|currency_precise }}
+          {% elif line.monthly_low is not none and line.monthly_high is not none %}
+            {{ line.monthly_low|currency_precise }} &ndash; {{ line.monthly_high|currency_precise }}
+          {% elif line.monthly_low is not none %}
+            {{ line.monthly_low|currency_precise }}
+          {% else %}
+            &ndash;
+          {% endif %}
+        </td>
+        <td>
+          <span class="badge badge-{{ line.confidence|lower }} tip" tabindex="0" data-tip="{{ help.CONFIDENCE_HELP['cost'][line.confidence] }}">
+            {{ line.confidence }}
+          </span>
+        </td>
+        <td class="text-muted">{{ line.source_note }}</td>
+      </tr>
+    {% endfor %}
+    <tr style="border-top: 2px solid var(--color-border-divider); font-weight:700">
+      <td>Total</td>
+      <td style="text-align:right">{% if cost.aws_monthly_low == cost.aws_monthly_high %}{{ cost.aws_monthly_low|currency_precise }}{% else %}{{ cost.aws_monthly_low|currency_precise }} &ndash; {{ cost.aws_monthly_high|currency_precise }}{% endif %}</td>
+      <td colspan="2"></td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- Assumptions -->
+<div class="section">
+  <div class="section-header">
+    <h2>Assumptions &amp; Methodology</h2>
+  </div>
+
+  <div class="card" style="border-left: 4px solid var(--color-brand-orange); margin-bottom: var(--space-md);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem">Target Architecture</h3>
+      <p style="margin-bottom:.5rem;font-size:.8125rem;color:var(--color-text-secondary)">This assessment models the AWS lakehouse as a <strong>decoupled storage + compute</strong> architecture:</p>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        <li><strong>Storage:</strong> Amazon S3 Tables (managed Apache Iceberg) for Serverless, or Redshift Managed Storage for Provisioned</li>
+        <li><strong>Compute:</strong> Multiple options evaluated — Redshift Serverless (RPU-based, auto-scaling, with Reservation discounts) and Redshift Provisioned RG Graviton4 (node-based, with Reserved Instance discounts)</li>
+        <li><strong>Best-fit selection:</strong> Actual workload profile (query volume, concurrency, active hours) determines the recommendation</li>
+      </ul>
+    </div>
+  </div>
+
+  {% if cost.recommendation and cost.recommendation.workload_profile and cost.recommendation.workload_profile.has_data %}
+  <div class="card" style="border-left: 4px solid var(--color-severity-success); margin-bottom: var(--space-md);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem">Your Workload Profile (Used for Sizing)</h3>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        {% set wp = cost.recommendation.workload_profile %}
+        <li><strong>Query volume:</strong> {{ "{:,.0f}".format(wp.queries_per_day) }} queries/day ({{ "{:,.0f}".format(wp.total_queries) }} total over {{ wp.lookback_days }} days)</li>
+        <li><strong>Data scanned:</strong> {{ "{:,.0f}".format(wp.monthly_scanned_tb) }} TB/month (avg {{ "{:,.0f}".format(wp.avg_bytes_per_query / 1048576) }} MB per query)</li>
+        <li><strong>Concurrency:</strong> ~{{ "{:.0f}".format(wp.avg_concurrent_queries) }} avg / ~{{ "{:.0f}".format(wp.peak_concurrent_queries) }} peak concurrent queries</li>
+        <li><strong>Active hours:</strong> {{ "{:.0%}".format(wp.active_hour_fraction) }} of hours have active queries</li>
+        <li><strong>Stored data:</strong> {{ "{:,.1f}".format(wp.total_stored_gb / 1000) }} TB</li>
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="card" style="border-left: 4px solid var(--color-severity-warning); margin-bottom: var(--space-md);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem">Storage Assumptions</h3>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        <li><strong>Serverless path:</strong> S3 Tables Standard (managed Iceberg) — tiered from ${{ pricing.s3_tables_tier1_per_gb }}/GB ({{ pricing.aws_region }}), includes automatic compaction</li>
+        <li><strong>Provisioned path:</strong> Redshift Managed Storage @ ${{ pricing.rms_per_gb }}/GB-month — included with RG Graviton4 nodes</li>
+        {% if storage_basis == "measured" %}
+        <li>Storage sized on <strong>measured physical bytes</strong> from BigQuery TABLE_STORAGE &mdash; 1:1 to S3 Iceberg (both store compressed Parquet)</li>
+        <li style="font-size:.75rem;color:var(--color-text-tertiary)">Limitations: TABLE_STORAGE may lag ~1 day for recent changes; clones/snapshots report full size (conservative)</li>
+        {% elif storage_basis == "mixed" %}
+        <li>Storage sized on <strong>mixed basis</strong> — tables covered by BigQuery TABLE_STORAGE use measured physical bytes (1:1 to S3 Iceberg); the remainder assumed at {{ pricing.physical_ratio }}&times; logical</li>
+        <li style="font-size:.75rem;color:var(--color-text-tertiary)">Limitations: TABLE_STORAGE may lag ~1 day for recent changes; clones/snapshots report full size (conservative)</li>
+        {% else %}
+        <li>Physical bytes unavailable &mdash; storage sized at <strong>{{ pricing.physical_ratio }}&times; logical</strong> (1 GiB BQ logical &asymp; {{ pricing.physical_ratio }} GiB S3 Iceberg; conservative estimate)</li>
+        <li style="font-size:.75rem;color:var(--color-text-tertiary)">Typical Parquet compression is 2&ndash;5&times;; {{ pricing.physical_ratio }} is a floor to avoid overstating the monthly run-rate delta</li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+
+  <div class="card" style="border-left: 4px solid var(--color-severity-warning); margin-bottom: var(--space-md);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem">Compute Pricing Assumptions</h3>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        <li><strong>Serverless On-Demand:</strong> ${{ pricing.serverless_rpu_hr }}/RPU-hr ({{ pricing.aws_region }}). BQ slot&rarr;RPU ratio: {{ pricing.slot_to_rpu_ratio }} (evidence range 0.06&ndash;0.25)</li>
+        <li><strong>Serverless Reserved (1yr):</strong> ~{{ pricing.serverless_1yr_discount_pct }}% discount (${{ pricing.serverless_1yr_rpu_hr }}/RPU-hr). Break-even at ~{{ pricing.serverless_1yr_breakeven_pct }}% utilization</li>
+        <li><strong>Serverless Reserved (3yr):</strong> ~{{ pricing.serverless_3yr_discount_pct }}% discount (${{ pricing.serverless_3yr_rpu_hr }}/RPU-hr). Break-even at ~{{ pricing.serverless_3yr_breakeven_pct }}% utilization</li>
+        <li><strong>Provisioned On-Demand:</strong> RG Graviton4 rg.4xlarge @ ${{ pricing.rg_4xl_ondemand_hr }}/node-hr. {{ pricing.hours_per_month }} hours/month</li>
+        <li><strong>Provisioned 1yr RI:</strong> ~{{ pricing.ri_1yr_discount_pct }}% discount vs on-demand</li>
+        <li><strong>Provisioned 3yr RI:</strong> ~{{ pricing.ri_3yr_discount_pct }}% discount vs on-demand</li>
+        <li><strong>Cluster sizing:</strong> based on peak concurrent query load with 1.5 vCPU/query heuristic and 3&times; burst factor</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card" style="border-left: 4px solid var(--color-severity-neutral); margin-bottom: var(--space-md);">
+    <div class="card-body">
+      <h3 style="margin-top:0;font-size:.9375rem">Key Caveats</h3>
+      <ul style="margin:0;padding-left:1.25rem;font-size:.8125rem;color:var(--color-text-secondary)">
+        <li>BigQuery priced for <strong>{{ pricing.bq_region }}</strong> (${{ pricing.bq_ondemand_per_tib }}/TiB, storage ${{ pricing.bq_storage_active_per_gib }}/GiB-mo); AWS priced for <strong>{{ pricing.region }}</strong></li>
+        <li>The slot&rarr;RPU bridge ({{ pricing.slot_to_rpu_ratio }} ratio, set above the evidence midpoint of 0.06&ndash;0.25 so AWS compute errs high) is a <strong>research-based estimate</strong> — validate with <code>SYS_SERVERLESS_USAGE</code></li>
+        <li>Provisioned cluster sizing uses <strong>estimated concurrency</strong> — validate with a pilot workload</li>
+        <li>Data transfer costs (one-time migration) are <strong>not included</strong></li>
+        <li>Redshift Spectrum, ML features, and cross-region replication are <strong>not modeled</strong></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% if failures %}
+<div class="section">
+  <div class="section-header">
+    <h2>Failures</h2>
+    <span class="section-badge">{{ failures|length }} items</span>
+  </div>
+  <table>
+    <thead>
+      <tr><th>Entity</th><th>Stage</th><th>Error</th></tr>
+    </thead>
+    <tbody>
+    {% for f in failures %}
+      <tr>
+        <td><strong>{{ f.entity_name }}</strong></td>
+        <td>{{ f.stage }}</td>
+        <td class="text-muted">{{ f.error }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+</div><!-- end tab-landing -->
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- TAB: MIGRATION EFFORT                                                  -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<div id="tab-effort" class="tab-content">
+
+<div class="section">
+  <div class="section-header">
+    <h2>Migration Effort by Entity</h2>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="AUTO" data-filter-target="effort" data-accent="green">
+        <div class="card-body">
+          <div class="card-title">Auto</div>
+          <div class="stat-value" style="color:var(--color-severity-success)">{{ summary.effort_counts.AUTO or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="ASSISTED" data-filter-target="effort" data-accent="amber">
+        <div class="card-body">
+          <div class="card-title">Assisted</div>
+          <div class="stat-value" style="color:var(--color-severity-warning)">{{ summary.effort_counts.ASSISTED or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="MANUAL" data-filter-target="effort" data-accent="red">
+        <div class="card-body">
+          <div class="card-title">Manual</div>
+          <div class="stat-value" style="color:var(--color-severity-error)">{{ summary.effort_counts.MANUAL or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="ALL" data-filter-target="effort">
+        <div class="card-body">
+          <div class="card-title">Total Tables</div>
+          <div class="stat-value">{{ summary.total_tables }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <span class="filter-reset" data-filter-target="effort">Clear filter</span>
+</div>
+
+<div class="section">
+  <p class="text-muted" style="font-size:.8125rem; margin-bottom: var(--space-sm);">Click a row to expand conversion details (DDL, lossy casts, warnings).</p>
+  <div class="table-toolbar">
+    <input type="search" class="search-input" data-search-target="effort" placeholder="Filter by entity name&hellip;" aria-label="Filter tables by entity name">
+  </div>
+  <table id="table-effort">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Population</th>
+        <th style="text-align:right">Rows</th>
+        <th style="text-align:right">Projected Size (GB)</th>
+        <th>Effort</th>
+        <th style="text-align:right">Score</th>
+        <th>Confidence</th>
+      </tr>
+    </thead>
+    <tbody data-page-size="100"></tbody>
+  </table>
+</div>
+
+</div><!-- end tab-effort -->
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- TAB: QUERY COMPLEXITY                                                  -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<div id="tab-query" class="tab-content">
+
+{% if summary.sql_surface_confidence == "LOW" %}
+<div class="alert alert-warning">
+  <strong>Low Confidence SQL Analysis</strong><br>
+  SQL surface confidence is low. Query logs were not provided or are incomplete. Re-run with query logs for higher confidence.
+</div>
+{% endif %}
+
+<div class="section">
+  <div class="section-header">
+    <h2>Query Complexity by Entity</h2>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="PORTABLE" data-filter-target="query" data-accent="green">
+        <div class="card-body">
+          <div class="card-title">Portable</div>
+          <div class="stat-value" style="color:var(--color-severity-success)">{{ summary.complexity_counts.PORTABLE or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="ADAPT" data-filter-target="query" data-accent="amber">
+        <div class="card-body">
+          <div class="card-title">Adapt</div>
+          <div class="stat-value" style="color:var(--color-severity-warning)">{{ summary.complexity_counts.ADAPT or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="REWRITE" data-filter-target="query" data-accent="red">
+        <div class="card-body">
+          <div class="card-title">Rewrite</div>
+          <div class="stat-value" style="color:var(--color-severity-error)">{{ summary.complexity_counts.REWRITE or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center filter-card" data-filter-category="ALL" data-filter-target="query">
+        <div class="card-body">
+          <div class="card-title">Total Entities</div>
+          <div class="stat-value">{{ summary.total_entities }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <span class="filter-reset" data-filter-target="query">Clear filter</span>
+</div>
+
+<div class="section">
+  <p class="text-muted" style="font-size:.8125rem; margin-bottom: var(--space-sm);">Click a row to expand analysis details (flags, rewrite guidance, translated SQL, placement). Entities with no visible SQL surface have no details.</p>
+  <div class="table-toolbar">
+    <input type="search" class="search-input" data-search-target="query" placeholder="Filter by entity name&hellip;" aria-label="Filter entities by name">
+  </div>
+  <table id="table-query">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Population</th>
+        <th>Complexity</th>
+        <th style="text-align:right">Score</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody data-page-size="100"></tbody>
+  </table>
+</div>
+
+</div><!-- end tab-query -->
+
+<div class="footer">
+  Generated by <strong>bq-assess</strong> &middot; {{ generated_at|timestamp }}
+  <div class="disclaimer">
+    <strong>Beta &amp; Disclaimer Notice</strong>
+    {% for para in disclaimer_paragraphs %}
+    <p>{{ para }}</p>
+    {% endfor %}
+  </div>
+</div>
+
+</div><!-- end container -->
+
+<script type="application/json" id="report-data">{{ report_rows|tojson }}</script>
+<script type="application/json" id="help-data">{{ {
+  "confidence": {
+    "effort": help.CONFIDENCE_HELP["effort"],
+    "complexity": help.CONFIDENCE_HELP["complexity"],
+    "placement": help.CONFIDENCE_HELP["placement"],
+  },
+  "category": help.CATEGORY_HELP,
+  "flags": help.FLAG_INFO,
+  "sources": help.SOURCE_LABELS,
+  "text": help.UI_TEXT,
+}|tojson }}</script>
+
+<script nonce="{{ csp_nonce }}">
+document.querySelectorAll('.nav-links a[data-tab]').forEach(function(link) {
+  link.addEventListener('click', function(e) {
+    e.preventDefault();
+    document.querySelectorAll('.tab-content').forEach(function(t) { t.classList.remove('active') });
+    document.querySelectorAll('.nav-links a').forEach(function(a) { a.classList.remove('active') });
+    document.getElementById('tab-' + this.dataset.tab).classList.add('active');
+    this.classList.add('active');
+    window.scrollTo(0, 0);
+  });
+});
+
+// Entity tables render client-side from embedded JSON. Only the current page of
+// rows exists in the DOM, and a row's detail panel is built on first expand —
+// this keeps the report responsive for warehouses with tens of thousands of
+// entities. All content is inserted via textContent / createElement, never
+// parsed as markup, so entity names and SQL from the source project stay inert.
+var DATA = JSON.parse(document.getElementById('report-data').textContent);
+var HELP = JSON.parse(document.getElementById('help-data').textContent);
+
+function el(tag, className, text) {
+  var node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined && text !== null) node.textContent = text;
+  return node;
+}
+
+function tipSpan(text, tip, className) {
+  // Without tip text, render a plain span: an empty data-tip would still pop an
+  // empty tooltip bubble and steal keyboard focus.
+  if (!tip) return el('span', null, text);
+  var s = el('span', (className || 'tip'), text);
+  s.setAttribute('tabindex', '0');
+  s.setAttribute('data-tip', tip);
+  return s;
+}
+
+function badge(text, cls, tip) {
+  var s = tipSpan(text, tip, 'badge badge-' + cls + ' tip');
+  if (!tip) s.className = 'badge badge-' + cls;
+  return s;
+}
+
+function categoryBadge(cat) {
+  return badge(cat, String(cat).toLowerCase(), HELP.category[cat] || '');
+}
+
+function confidenceBadge(level, context) {
+  return badge(level, String(level).toLowerCase(), (HELP.confidence[context] || {})[level] || '');
+}
+
+function flagChip(flag) {
+  var info = HELP.flags[flag];
+  var label = info ? info[0] : flag.replace(/_/g, ' ');
+  var tip = info ? info[1] : flag;
+  return badge(label, 'flag', tip);
+}
+
+function preCode(text) {
+  var p = document.createElement('pre');
+  p.appendChild(el('code', null, text));
+  return p;
+}
+
+function scoreBreakdown(reasoning) {
+  var p = el('p', 'text-muted');
+  p.style.fontSize = '.8125rem';
+  var label = tipSpan('Score breakdown', HELP.text.score_tip);
+  label.style.borderBottom = '1px dotted var(--color-text-muted)';
+  label.style.cursor = 'help';
+  p.appendChild(label);
+  p.appendChild(document.createTextNode(': ' + reasoning));
+  return p;
+}
+
+function flagsParagraph(labelText, flags) {
+  var p = el('p');
+  p.appendChild(el('strong', null, labelText + ' '));
+  flags.forEach(function(f) {
+    p.appendChild(flagChip(f));
+    p.appendChild(document.createTextNode(' '));
+  });
+  return p;
+}
+
+function sectionHeading(text, tip) {
+  var h = el('h3', null, text + ' ');
+  h.style.marginTop = '1rem';
+  if (tip) h.appendChild(tipSpan('i', tip, 'tip tooltip-icon'));
+  return h;
+}
+
+function bulletList(items, muted) {
+  var ul = el('ul', muted ? 'text-muted' : null);
+  ul.style.margin = '.25rem 0';
+  ul.style.paddingLeft = '1.25rem';
+  items.forEach(function(item) { ul.appendChild(el('li', null, item)); });
+  return ul;
+}
+
+function buildEffortDetail(e) {
+  var td = document.createElement('td');
+  td.setAttribute('colspan', '9');
+  var eff = e.effort;
+
+  if (eff.reasoning) td.appendChild(scoreBreakdown(eff.reasoning));
+  if (eff.flags && eff.flags.length) td.appendChild(flagsParagraph('What to review:', eff.flags));
+
+  if (e.conversion) {
+    td.appendChild(sectionHeading('Iceberg DDL', 'Generated CREATE TABLE statement for the Iceberg target. Review before running — especially any flagged type casts or partition decisions.'));
+    td.appendChild(preCode(e.conversion.ddl));
+
+    var pm = e.conversion.partition_mapping;
+    if (pm) {
+      var p = el('p');
+      p.appendChild(el('strong', null, 'Partitioning: '));
+      if (pm.iceberg_transforms && pm.iceberg_transforms.length) {
+        p.appendChild(el('code', null, pm.iceberg_transforms.join(', ')));
+      } else {
+        p.appendChild(document.createTextNode('none'));
+      }
+      if (pm.sort_order && pm.sort_order.length) {
+        p.appendChild(document.createTextNode(' · '));
+        p.appendChild(el('strong', null, 'Sort order: '));
+        p.appendChild(el('code', null, pm.sort_order.join(', ')));
+      }
+      p.appendChild(el('span', 'text-muted', pm.auto_derived
+        ? HELP.text.partition_auto
+        : HELP.text.partition_manual));
+      td.appendChild(p);
+    }
+
+    var casts = e.conversion.lossy_casts;
+    if (casts && casts.length) {
+      var cp = el('p');
+      cp.appendChild(el('strong', null, 'Type casts that lose information '));
+      cp.appendChild(tipSpan('i', 'These columns have no exact Iceberg equivalent, so the mapped type loses precision or range. Confirm each one is acceptable for your data before loading.', 'tip tooltip-icon'));
+      td.appendChild(cp);
+      var table = document.createElement('table');
+      table.style.fontSize = '.8125rem';
+      table.style.marginTop = '.25rem';
+      var thead = document.createElement('thead');
+      var hr = document.createElement('tr');
+      ['Column', 'BigQuery Type', 'Iceberg Type', 'Impact'].forEach(function(h) { hr.appendChild(el('th', null, h)); });
+      thead.appendChild(hr);
+      table.appendChild(thead);
+      var tbody = document.createElement('tbody');
+      casts.forEach(function(c) {
+        var tr = document.createElement('tr');
+        var colTd = document.createElement('td');
+        colTd.appendChild(el('code', null, c.column));
+        tr.appendChild(colTd);
+        tr.appendChild(el('td', null, c.source_type));
+        tr.appendChild(el('td', null, c.iceberg_type));
+        tr.appendChild(el('td', 'text-muted', c.loss_description));
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      td.appendChild(table);
+    }
+
+    if (e.conversion.warnings && e.conversion.warnings.length) {
+      var wp = el('p');
+      wp.appendChild(el('strong', null, 'Warnings:'));
+      td.appendChild(wp);
+      td.appendChild(bulletList(e.conversion.warnings));
+    }
+  }
+
+  if (e.load_sync_dml) {
+    td.appendChild(sectionHeading('Load/Sync DML', 'Suggested statements for the initial data load and, where a sync signal was detected, the recurring MERGE to keep the target current. Adjust staging schema names to your environment.'));
+    td.appendChild(preCode(e.load_sync_dml));
+  }
+  return td;
+}
+
+function buildQueryDetail(e) {
+  var td = document.createElement('td');
+  td.setAttribute('colspan', '8');
+  var c = e.complexity;
+
+  if (c.reasoning === 'no BigQuery-specific constructs detected') {
+    td.appendChild(el('p', 'text-muted', 'No BigQuery-specific SQL was found in this entity’s definition — it should run on Redshift with little or no change.'));
+  } else if (c.reasoning && c.reasoning !== 'no SQL surface visible — cannot assess query complexity') {
+    td.appendChild(scoreBreakdown(c.reasoning));
+  }
+
+  if (c.flags && c.flags.length) td.appendChild(flagsParagraph('What needs attention:', c.flags));
+
+  if (e.depends_on && e.depends_on.length) {
+    var dp = el('p');
+    dp.appendChild(el('strong', null, 'Reads from: '));
+    e.depends_on.forEach(function(dep, i) {
+      dp.appendChild(el('span', 'text-muted', dep));
+      if (i < e.depends_on.length - 1) dp.appendChild(document.createTextNode(', '));
+    });
+    td.appendChild(dp);
+  }
+
+  if (e.rewrite_guidance && e.rewrite_guidance.length) {
+    td.appendChild(sectionHeading('How to rewrite for Redshift'));
+    td.appendChild(bulletList(e.rewrite_guidance));
+  }
+
+  if (e.translated_sql) {
+    td.appendChild(sectionHeading('Suggested Redshift SQL', 'Machine-translated from the BigQuery definition (via sqlglot) as a starting point — validate before production use. Iceberg table references may need an external schema prefix.'));
+    if (e.translated_sql.confidence === 'LOW') {
+      var lb = badge('LOW CONFIDENCE', 'low', 'The translator hit constructs it could not fully convert — expect to hand-edit this SQL.');
+      lb.style.marginBottom = '.5rem';
+      td.appendChild(lb);
+    }
+    if (e.translated_sql.warnings && e.translated_sql.warnings.length) {
+      var wl = bulletList(e.translated_sql.warnings, true);
+      wl.style.fontSize = '.8125rem';
+      td.appendChild(wl);
+    }
+    td.appendChild(preCode(e.translated_sql.redshift_sql));
+  }
+
+  if (e.placement) {
+    td.appendChild(sectionHeading('Where should this live?', 'Views, materialized views, and UDFs can live either inside Redshift (engine-local) or in the shared Iceberg catalog (queryable by multiple engines). This recommendation weighs how the object is structured and consumed.'));
+    var hp = el('p');
+    hp.appendChild(el('strong', null, 'Recommended home: '));
+    hp.appendChild(document.createTextNode(e.placement.home === 'REDSHIFT' ? 'Redshift (engine-local) ' : 'Iceberg catalog (open, multi-engine) '));
+    hp.appendChild(confidenceBadge(e.placement.confidence, 'placement'));
+    td.appendChild(hp);
+    var signals = e.placement.signals || [];
+    if (signals.length) {
+      var whyP = el('p');
+      whyP.appendChild(el('strong', null, 'Why:'));
+      td.appendChild(whyP);
+      td.appendChild(bulletList(signals, true));
+    }
+  }
+  return td;
+}
+
+function nonEmpty(v) {
+  // Mirrors Jinja truthiness: empty arrays are falsy (unlike JS).
+  return Array.isArray(v) ? v.length > 0 : !!v;
+}
+
+function effortHasDetail(e) {
+  return !!(e.effort.reasoning || nonEmpty(e.effort.flags) || e.conversion || e.load_sync_dml);
+}
+
+function queryHasDetail(e) {
+  return !!(e.complexity.score > 0 || nonEmpty(e.complexity.flags) || nonEmpty(e.rewrite_guidance) || e.placement || e.translated_sql);
+}
+
+function renderEffortRow(e, tr) {
+  // Explicit null checks: 0 rows / 0 GB are real values (empty table), not missing data.
+  var num = el('td', null, e.rows != null ? Number(e.rows).toLocaleString('en-US') : '—');
+  num.style.textAlign = 'right';
+  var sizeTd = document.createElement('td');
+  sizeTd.style.textAlign = 'right';
+  sizeTd.appendChild(tipSpan(
+    e.physical_size_gb != null ? Number(e.physical_size_gb).toFixed(2) : '—',
+    'BigQuery logical: ' + Number(e.logical_size_gb || 0).toFixed(2) + ' GB'
+  ));
+  var nameTd = document.createElement('td');
+  nameTd.appendChild(el('strong', null, e.full_name));
+  tr.appendChild(nameTd);
+  tr.appendChild(el('td', null, e.entity_type));
+  tr.appendChild(el('td', null, e.population));
+  tr.appendChild(num);
+  tr.appendChild(sizeTd);
+  var catTd = document.createElement('td');
+  catTd.appendChild(categoryBadge(e.effort.category));
+  tr.appendChild(catTd);
+  var scoreTd = el('td', null, String(e.effort.score));
+  scoreTd.style.textAlign = 'right';
+  tr.appendChild(scoreTd);
+  var confTd = document.createElement('td');
+  confTd.appendChild(confidenceBadge(e.effort.confidence, 'effort'));
+  tr.appendChild(confTd);
+}
+
+function renderQueryRow(e, tr) {
+  var nameTd = document.createElement('td');
+  nameTd.appendChild(el('strong', null, e.full_name));
+  tr.appendChild(nameTd);
+  tr.appendChild(el('td', null, e.entity_type));
+  tr.appendChild(el('td', null, e.population));
+  var catTd = document.createElement('td');
+  catTd.appendChild(categoryBadge(e.complexity.category));
+  tr.appendChild(catTd);
+  var scoreTd = el('td', null, String(e.complexity.score));
+  scoreTd.style.textAlign = 'right';
+  tr.appendChild(scoreTd);
+  var confTd = document.createElement('td');
+  confTd.appendChild(confidenceBadge(e.complexity.confidence, 'complexity'));
+  tr.appendChild(confTd);
+  var srcTd = el('td', 'text-muted');
+  var src = e.complexity.confidence_source;
+  srcTd.appendChild(tipSpan(HELP.sources[src] || String(src || '').replace(/_/g, ' '),
+    HELP.text.source_tip));
+  tr.appendChild(srcTd);
+}
+
+function EntityTable(opts) {
+  var table = document.getElementById(opts.tableId);
+  var tbody = table.querySelector('tbody');
+  var columnCount = table.querySelector('thead tr').children.length;
+  var pageSize = parseInt(tbody.dataset.pageSize, 10) || 100;
+  var state = { category: 'ALL', query: '', page: 0 };
+
+  // Lowercase once at load; the filter runs per keystroke over up to ~100k rows.
+  opts.rows.forEach(function(e) { e._nameLower = e.full_name.toLowerCase(); });
+  var matched = opts.rows;  // cached filter result — page turns reuse it
+
+  var controls = el('div', 'pagination-controls');
+  var prev = el('button', 'pg-prev', '« Prev');
+  var info = el('span', 'page-info');
+  var next = el('button', 'pg-next', 'Next »');
+  controls.appendChild(prev);
+  controls.appendChild(info);
+  controls.appendChild(next);
+  table.parentNode.insertBefore(controls, table);
+  prev.addEventListener('click', function() { if (state.page > 0) { state.page--; render(); } });
+  next.addEventListener('click', function() { state.page++; render(); });
+
+  function refilter() {
+    matched = opts.rows.filter(function(e) {
+      if (state.category !== 'ALL' && opts.categoryOf(e) !== state.category) return false;
+      if (state.query && e._nameLower.indexOf(state.query) === -1) return false;
+      return true;
+    });
+  }
+
+  function render() {
+    var items = matched;
+    var totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+    if (state.page >= totalPages) state.page = totalPages - 1;
+    var start = state.page * pageSize, end = Math.min(start + pageSize, items.length);
+
+    tbody.textContent = '';
+    if (!items.length) {
+      var emptyTr = el('tr', 'empty-row');
+      var emptyTd = el('td', 'text-muted', 'No matching entities.');
+      emptyTd.colSpan = columnCount;
+      emptyTd.style.textAlign = 'center';
+      emptyTr.appendChild(emptyTd);
+      tbody.appendChild(emptyTr);
+    }
+    items.slice(start, end).forEach(function(e) {
+      var hasDetail = opts.hasDetail(e);
+      var tr = el('tr', 'entity-row' + (hasDetail ? ' has-detail' : ''));
+      var expand = el('td', 'expand-cell');
+      if (hasDetail) expand.appendChild(el('span', 'chevron'));
+      tr.appendChild(expand);
+      opts.renderRow(e, tr);
+      tbody.appendChild(tr);
+      if (hasDetail) {
+        tr.addEventListener('click', function() {
+          if (window.getSelection && String(window.getSelection())) return; // don't toggle while selecting text
+          var detail = tr.nextElementSibling;
+          if (!detail || !detail.classList.contains('detail-row')) {
+            detail = el('tr', 'detail-row');
+            detail.appendChild(opts.buildDetail(e));  // built lazily, on first expand
+            tr.parentNode.insertBefore(detail, tr.nextSibling);
+          }
+          var opening = !tr.classList.contains('expanded');
+          tr.classList.toggle('expanded', opening);
+          detail.classList.toggle('open', opening);
+        });
+      }
+    });
+
+    var showControls = items.length > pageSize;
+    controls.style.display = showControls ? '' : 'none';
+    if (showControls) {
+      var label = state.category !== 'ALL' ? ' (' + state.category + ')' : '';
+      info.textContent = 'Showing ' + (start + 1) + '–' + end + ' of ' + items.length + label;
+      prev.disabled = state.page === 0;
+      next.disabled = state.page >= totalPages - 1;
+    }
+  }
+
+  this.setCategory = function(cat) { state.category = cat; state.page = 0; refilter(); render(); };
+  this.setQuery = function(q) { state.query = q.toLowerCase().trim(); state.page = 0; refilter(); render(); };
+  render();
+}
+
+var tables = {
+  effort: new EntityTable({
+    tableId: 'table-effort', rows: DATA.effort,
+    categoryOf: function(e) { return e.effort.category; },
+    hasDetail: effortHasDetail, renderRow: renderEffortRow, buildDetail: buildEffortDetail,
+  }),
+  query: new EntityTable({
+    tableId: 'table-query', rows: DATA.query,
+    categoryOf: function(e) { return e.complexity.category; },
+    hasDetail: queryHasDetail, renderRow: renderQueryRow, buildDetail: buildQueryDetail,
+  }),
+};
+
+function applyFilter(target, category) {
+  tables[target].setCategory(category);
+  var isAll = category === 'ALL';
+  var resetEl = document.querySelector('.filter-reset[data-filter-target="' + target + '"]');
+  if (resetEl) resetEl.classList.toggle('visible', !isAll);
+  document.querySelectorAll('.filter-card[data-filter-target="' + target + '"]').forEach(function(card) {
+    card.classList.toggle('active-filter', card.dataset.filterCategory === category);
+  });
+}
+
+function clearAllFilters(target) {
+  var input = document.querySelector('.search-input[data-search-target="' + target + '"]');
+  if (input) input.value = '';
+  tables[target].setQuery('');
+  applyFilter(target, 'ALL');
+}
+
+document.querySelectorAll('.filter-card').forEach(function(card) {
+  card.addEventListener('click', function() {
+    var target = this.dataset.filterTarget;
+    var category = this.dataset.filterCategory;
+    if (this.classList.contains('active-filter') && category !== 'ALL') {
+      applyFilter(target, 'ALL');
+    } else {
+      applyFilter(target, category);
+    }
+  });
+});
+
+document.querySelectorAll('.filter-reset').forEach(function(elm) {
+  elm.addEventListener('click', function() {
+    clearAllFilters(this.dataset.filterTarget);
+  });
+});
+
+document.querySelectorAll('.search-input[data-search-target]').forEach(function(input) {
+  var timer = null;
+  input.addEventListener('input', function() {
+    var target = this.dataset.searchTarget, value = this.value;
+    clearTimeout(timer);
+    timer = setTimeout(function() { tables[target].setQuery(value); }, 150);
+  });
+});
+</script>
+</body>
+</html>

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/effort.html.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/effort.html.j2
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Migration Effort — {{ project_id }}</title>
+<style>
+{% include '_styles.j2' %}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="container">
+    <div class="header-inner">
+      <div class="header-logo">
+        <div class="aws-cube">BQ</div>
+        <div>
+          <h1 style="color:#fff;margin:0;font-size:1.125rem">Migration Assessment</h1>
+          <p style="color:rgba(255,255,255,.5);margin:2px 0 0 0;font-size:.75rem">BigQuery &rarr; Amazon Redshift (Lakehouse)</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        Project: <strong>{{ project_id }}</strong> &middot;
+        {{ generated_at|timestamp }} &middot;
+        {{ assessment_id }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="nav">
+  <div class="container">
+    <div class="nav-links">
+      <a href="{{ sibling_landing }}">Landing</a>
+      <a href="{{ sibling_effort }}" class="active">Migration Effort</a>
+      <a href="{{ sibling_query }}">Query Complexity</a>
+    </div>
+  </div>
+</div>
+
+<div class="container" style="padding-top: var(--space-xl); padding-bottom: var(--space-xl);">
+
+<div class="section">
+  <div class="section-header">
+    <h2>Migration Effort by Entity</h2>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center" data-accent="green">
+        <div class="card-body">
+          <div class="card-title">Auto</div>
+          <div class="stat-value" style="color:var(--color-severity-success)">{{ summary.effort_counts.AUTO or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center" data-accent="amber">
+        <div class="card-body">
+          <div class="card-title">Assisted</div>
+          <div class="stat-value" style="color:var(--color-severity-warning)">{{ summary.effort_counts.ASSISTED or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center" data-accent="red">
+        <div class="card-body">
+          <div class="card-title">Manual</div>
+          <div class="stat-value" style="color:var(--color-severity-error)">{{ summary.effort_counts.MANUAL or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Tables</div>
+          <div class="stat-value">{{ summary.total_tables }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <table>
+    <thead>
+      <tr>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Population</th>
+        <th style="text-align:right">Rows</th>
+        <th style="text-align:right">Size (GB)</th>
+        <th>Effort</th>
+        <th style="text-align:right">Score</th>
+        <th>Confidence</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for e in entities %}
+      {% if e.effort %}
+      <tr>
+        <td><strong>{{ e.full_name }}</strong></td>
+        <td>{{ e.entity_type }}</td>
+        <td>{{ e.population }}</td>
+        <td style="text-align:right">{{ "{:,}".format(e.rows) if e.rows else "—" }}</td>
+        <td style="text-align:right">{{ "%.2f"|format(e.size_gb) if e.size_gb else "—" }}</td>
+        <td>
+          <span class="badge {% if e.effort.category == 'AUTO' %}badge-auto{% elif e.effort.category == 'ASSISTED' %}badge-assisted{% else %}badge-manual{% endif %}">
+            {{ e.effort.category }}
+          </span>
+        </td>
+        <td style="text-align:right">{{ e.effort.score }}</td>
+        <td>
+          <span class="badge {% if e.effort.confidence == 'HIGH' %}badge-high{% elif e.effort.confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ e.effort.confidence }}
+          </span>
+        </td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="section">
+  <div class="section-header">
+    <h2>Per-Entity Details</h2>
+    <span class="section-badge">{{ entities|length }} entities</span>
+  </div>
+  {% for e in entities %}
+    {% if e.effort %}
+    <details>
+      <summary>
+        {{ e.full_name }}
+        <span class="badge {% if e.effort.category == 'AUTO' %}badge-auto{% elif e.effort.category == 'ASSISTED' %}badge-assisted{% else %}badge-manual{% endif %}" style="margin-left:.5rem">
+          {{ e.effort.category }}
+        </span>
+        <span class="text-muted" style="font-weight:400;margin-left:.5rem">score {{ e.effort.score }}</span>
+      </summary>
+      <div class="card">
+        <div class="card-body">
+          <p><strong>Type:</strong> {{ e.entity_type }} &middot; <strong>Population:</strong> {{ e.population }}</p>
+          {% if e.rows %}
+          <p><strong>Rows:</strong> {{ "{:,}".format(e.rows) }} &middot; <strong>Size:</strong> {{ "%.2f"|format(e.size_gb) }} GB</p>
+          {% endif %}
+
+          {% if e.effort.reasoning %}
+          <p class="text-muted" style="font-style:italic">{{ e.effort.reasoning }}</p>
+          {% endif %}
+
+          {% if e.effort.flags %}
+          <p><strong>Flags:</strong>
+            {% for flag in e.effort.flags %}
+            <span class="badge badge-flag">{{ flag }}</span>
+            {% endfor %}
+          </p>
+          {% endif %}
+
+          {% if e.conversion %}
+          <h3 style="margin-top:1rem">Iceberg DDL</h3>
+          <pre><code>{{ e.conversion.ddl }}</code></pre>
+
+          {% if e.conversion.partition_mapping %}
+          <p><strong>Partition Mapping:</strong> {{ e.conversion.partition_mapping }}</p>
+          {% endif %}
+
+          {% if e.conversion.lossy_casts %}
+          <p><strong>Lossy Casts:</strong></p>
+          <table style="font-size:.8125rem;margin-top:.25rem">
+            <thead>
+              <tr>
+                <th>Column</th>
+                <th>BigQuery Type</th>
+                <th>Iceberg Type</th>
+                <th>Impact</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for cast in e.conversion.lossy_casts %}
+              <tr>
+                <td><code>{{ cast.column }}</code></td>
+                <td>{{ cast.source_type }}</td>
+                <td>{{ cast.iceberg_type }}</td>
+                <td class="text-muted">{{ cast.loss_description }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+
+          {% if e.conversion.warnings %}
+          <p><strong>Warnings:</strong></p>
+          <ul style="margin:.25rem 0;padding-left:1.25rem">
+            {% for w in e.conversion.warnings %}
+            <li>{{ w }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+          {% endif %}
+
+          {% if e.load_sync_dml %}
+          <h3 style="margin-top:1rem">Load/Sync DML</h3>
+          <pre><code>{{ e.load_sync_dml }}</code></pre>
+          {% endif %}
+        </div>
+      </div>
+    </details>
+    {% endif %}
+  {% endfor %}
+</div>
+
+<div class="footer">
+  Generated by <strong>bq-assess</strong> &middot; {{ generated_at|timestamp }}
+</div>
+
+</div>
+</body>
+</html>

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/landing.html.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/landing.html.j2
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Migration Assessment Landing — {{ project_id }}</title>
+<style>
+{% include '_styles.j2' %}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="container">
+    <div class="header-inner">
+      <div class="header-logo">
+        <div class="aws-cube">BQ</div>
+        <div>
+          <h1 style="color:#fff;margin:0;font-size:1.125rem">Migration Assessment</h1>
+          <p style="color:rgba(255,255,255,.5);margin:2px 0 0 0;font-size:.75rem">BigQuery &rarr; Amazon Redshift (Lakehouse)</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        Project: <strong>{{ project_id }}</strong> &middot;
+        {{ generated_at|timestamp }} &middot;
+        {{ assessment_id }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="nav">
+  <div class="container">
+    <div class="nav-links">
+      <a href="{{ sibling_landing }}" class="active">Landing</a>
+      <a href="{{ sibling_effort }}">Migration Effort</a>
+      <a href="{{ sibling_query }}">Query Complexity</a>
+    </div>
+  </div>
+</div>
+
+<div class="container" style="padding-top: var(--space-xl); padding-bottom: var(--space-xl);">
+
+{% if cost.compute_confidence == "LOW" %}
+<div class="alert alert-warning" id="low-confidence-warning">
+  <strong>Low Confidence Cost Estimate</strong><br>
+  Compute cost estimates are based on incomplete data. Review the cost breakdown notes below.
+</div>
+{% endif %}
+
+<!-- Overview -->
+<div class="section">
+  <div class="section-header">
+    <h2>Overview</h2>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Entities</div>
+          <div class="stat-value">{{ summary.total_entities }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Tables</div>
+          <div class="stat-value">{{ summary.total_tables }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Size</div>
+          <div class="stat-value">{{ "%.1f"|format(summary.total_size_gb) }} <span style="font-size:.875rem;font-weight:400">GB</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">SQL Surface Confidence</div>
+          <div class="stat-value">
+            <span class="badge {% if summary.sql_surface_confidence == 'HIGH' %}badge-high{% elif summary.sql_surface_confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}" style="font-size:.875rem;padding:5px 14px">
+              {{ summary.sql_surface_confidence }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Migration Readiness -->
+<div class="section">
+  <div class="section-header">
+    <h2>Migration Readiness</h2>
+  </div>
+
+  {% import '_donut.j2' as charts %}
+  <div class="donut-row">
+    {{ charts.donut("Migration Effort", [
+      {"label": "Auto", "count": summary.effort_counts.AUTO or 0, "color": "green"},
+      {"label": "Assisted", "count": summary.effort_counts.ASSISTED or 0, "color": "amber"},
+      {"label": "Manual", "count": summary.effort_counts.MANUAL or 0, "color": "red"},
+    ]) }}
+    {{ charts.donut("Query Complexity", [
+      {"label": "Portable", "count": summary.complexity_counts.PORTABLE or 0, "color": "green"},
+      {"label": "Adapt", "count": summary.complexity_counts.ADAPT or 0, "color": "amber"},
+      {"label": "Rewrite", "count": summary.complexity_counts.REWRITE or 0, "color": "red"},
+    ]) }}
+  </div>
+</div>
+
+<!-- Cost Comparison -->
+<div class="section">
+  <div class="section-header">
+    <h2>Cost Comparison</h2>
+    <span class="section-badge">monthly estimate</span>
+  </div>
+
+  <div class="cost-hero">
+    <div class="cost-hero__block">
+      <div class="cost-hero__label">BigQuery (Current)</div>
+      <div class="cost-hero__value">{{ cost.bigquery_monthly|currency_precise }}</div>
+      <div class="cost-hero__sub">{{ cost.bq_pricing_model }}</div>
+    </div>
+    <div class="cost-hero__arrow">
+      <svg viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      {{ cost.monthly_delta_low|savings }}
+    </div>
+    <div class="cost-hero__block cost-hero__block--aws">
+      <div class="cost-hero__label">AWS Lakehouse (Projected)</div>
+      <div class="cost-hero__value" style="color: var(--color-severity-success);">{% if cost.aws_monthly_low == cost.aws_monthly_high %}{{ cost.aws_monthly_low|currency_precise }}{% else %}{{ cost.aws_monthly_low|currency_precise }} &ndash; {{ cost.aws_monthly_high|currency_precise }}{% endif %}</div>
+      <div class="cost-hero__sub">per month</div>
+    </div>
+  </div>
+
+  <div class="row" style="margin-bottom: var(--space-lg);">
+    <div class="col-6">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Monthly Savings</div>
+          <div class="fs-3 fw-bold" style="color: var(--color-severity-success);">{{ cost.monthly_delta_low|savings }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Annual Savings</div>
+          <div class="fs-3 fw-bold" style="color: var(--color-severity-success);">{{ cost.annual_savings_low|savings }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cost Breakdown -->
+  <h3 style="margin-top: var(--space-xl); margin-bottom: var(--space-md);">BigQuery Cost Breakdown</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Line Item</th>
+        <th style="text-align:right">Monthly</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for line in cost.bigquery_breakdown %}
+      <tr>
+        <td><strong>{{ line.label }}</strong></td>
+        <td style="text-align:right">{{ line.monthly|currency_precise }}</td>
+        <td>
+          <span class="badge {% if line.confidence == 'HIGH' %}badge-high{% elif line.confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ line.confidence }}
+          </span>
+        </td>
+        <td class="text-muted">{{ line.source_note }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <h3 style="margin-top: var(--space-xl); margin-bottom: var(--space-md);">AWS Cost Breakdown</h3>
+  <table>
+    <thead>
+      <tr>
+        <th>Line Item</th>
+        <th style="text-align:right">Monthly (Low)</th>
+        <th style="text-align:right">Monthly (High)</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for line in cost.aws_lines %}
+      <tr>
+        <td><strong>{{ line.label }}</strong></td>
+        <td style="text-align:right">{{ (line.monthly_low | default(line.monthly))|currency_precise }}</td>
+        <td style="text-align:right">{{ (line.monthly_high | default(line.monthly))|currency_precise }}</td>
+        <td>
+          <span class="badge {% if line.confidence == 'HIGH' %}badge-high{% elif line.confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ line.confidence }}
+          </span>
+        </td>
+        <td class="text-muted">{{ line.source_note }}</td>
+      </tr>
+    {% endfor %}
+    <tr style="border-top: 2px solid var(--color-border-divider); font-weight:700">
+      <td>Total</td>
+      <td style="text-align:right">{{ cost.aws_monthly_low|currency_precise }}</td>
+      <td style="text-align:right">{{ cost.aws_monthly_high|currency_precise }}</td>
+      <td colspan="2"></td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+{% if failures %}
+<div class="section">
+  <div class="section-header">
+    <h2>Failures</h2>
+    <span class="section-badge">{{ failures|length }} items</span>
+  </div>
+  <table>
+    <thead>
+      <tr><th>Entity</th><th>Stage</th><th>Error</th></tr>
+    </thead>
+    <tbody>
+    {% for f in failures %}
+      <tr>
+        <td><strong>{{ f.entity_name }}</strong></td>
+        <td>{{ f.stage }}</td>
+        <td class="text-muted">{{ f.error }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+<div class="footer">
+  Generated by <strong>bq-assess</strong> &middot; {{ generated_at|timestamp }}
+</div>
+
+</div>
+</body>
+</html>

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/query.html.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/query.html.j2
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Query Complexity — {{ project_id }}</title>
+<style>
+{% include '_styles.j2' %}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="container">
+    <div class="header-inner">
+      <div class="header-logo">
+        <div class="aws-cube">BQ</div>
+        <div>
+          <h1 style="color:#fff;margin:0;font-size:1.125rem">Migration Assessment</h1>
+          <p style="color:rgba(255,255,255,.5);margin:2px 0 0 0;font-size:.75rem">BigQuery &rarr; Amazon Redshift (Lakehouse)</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        Project: <strong>{{ project_id }}</strong> &middot;
+        {{ generated_at|timestamp }} &middot;
+        {{ assessment_id }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="nav">
+  <div class="container">
+    <div class="nav-links">
+      <a href="{{ sibling_landing }}">Landing</a>
+      <a href="{{ sibling_effort }}">Migration Effort</a>
+      <a href="{{ sibling_query }}" class="active">Query Complexity</a>
+    </div>
+  </div>
+</div>
+
+<div class="container" style="padding-top: var(--space-xl); padding-bottom: var(--space-xl);">
+
+{% if summary.sql_surface_confidence == "LOW" %}
+<div class="alert alert-warning" id="low-confidence-warning">
+  <strong>Low Confidence SQL Analysis</strong><br>
+  SQL surface confidence is low. Query logs were not provided or are incomplete. Re-run with query logs for higher confidence.
+</div>
+{% endif %}
+
+<div class="section">
+  <div class="section-header">
+    <h2>Query Complexity by Entity</h2>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center" data-accent="green">
+        <div class="card-body">
+          <div class="card-title">Portable</div>
+          <div class="stat-value" style="color:var(--color-severity-success)">{{ summary.complexity_counts.PORTABLE or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center" data-accent="amber">
+        <div class="card-body">
+          <div class="card-title">Adapt</div>
+          <div class="stat-value" style="color:var(--color-severity-warning)">{{ summary.complexity_counts.ADAPT or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center" data-accent="red">
+        <div class="card-body">
+          <div class="card-title">Rewrite</div>
+          <div class="stat-value" style="color:var(--color-severity-error)">{{ summary.complexity_counts.REWRITE or 0 }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Entities</div>
+          <div class="stat-value">{{ summary.total_entities }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <table>
+    <thead>
+      <tr>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Population</th>
+        <th>Complexity</th>
+        <th style="text-align:right">Score</th>
+        <th>Confidence</th>
+        <th>Source</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for e in entities %}
+      {% if e.complexity %}
+      <tr>
+        <td><strong>{{ e.full_name }}</strong></td>
+        <td>{{ e.entity_type }}</td>
+        <td>{{ e.population }}</td>
+        <td>
+          <span class="badge {% if e.complexity.category == 'PORTABLE' %}badge-portable{% elif e.complexity.category == 'ADAPT' %}badge-adapt{% else %}badge-rewrite{% endif %}">
+            {{ e.complexity.category }}
+          </span>
+        </td>
+        <td style="text-align:right">{{ e.complexity.score }}</td>
+        <td>
+          <span class="badge {% if e.complexity.confidence == 'HIGH' %}badge-high{% elif e.complexity.confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ e.complexity.confidence }}
+          </span>
+        </td>
+        <td class="text-muted">{{ e.complexity.confidence_source }}</td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="section">
+  <div class="section-header">
+    <h2>Per-Entity Details</h2>
+    <span class="section-badge">{{ entities|length }} entities</span>
+  </div>
+  {% for e in entities %}
+    {% if e.complexity and (e.complexity.score > 0 or e.complexity.flags or e.rewrite_guidance or e.placement) %}
+    <details>
+      <summary>
+        {{ e.full_name }}
+        <span class="badge {% if e.complexity.category == 'PORTABLE' %}badge-portable{% elif e.complexity.category == 'ADAPT' %}badge-adapt{% else %}badge-rewrite{% endif %}" style="margin-left:.5rem">
+          {{ e.complexity.category }}
+        </span>
+        <span class="text-muted" style="font-weight:400;margin-left:.5rem">score {{ e.complexity.score }}</span>
+      </summary>
+      <div class="card">
+        <div class="card-body">
+          <p><strong>Type:</strong> {{ e.entity_type }} &middot; <strong>Population:</strong> {{ e.population }}</p>
+
+          {% if e.complexity.reasoning and e.complexity.reasoning != "no SQL surface visible — cannot assess query complexity" %}
+          <p class="text-muted" style="font-style:italic">{{ e.complexity.reasoning }}</p>
+          {% endif %}
+
+          {% if e.complexity.flags %}
+          <p><strong>Flags:</strong>
+            {% for flag in e.complexity.flags %}
+            <span class="badge badge-flag">{{ flag }}</span>
+            {% endfor %}
+          </p>
+          {% endif %}
+
+          {% if e.depends_on %}
+          <p><strong>Dependencies:</strong>
+            {% for dep in e.depends_on %}
+            <span class="text-muted">{{ dep }}</span>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </p>
+          {% endif %}
+
+          {% if e.rewrite_guidance %}
+          <h3 style="margin-top:1rem">Rewrite Guidance</h3>
+          <ul style="margin:.25rem 0;padding-left:1.25rem">
+            {% for g in e.rewrite_guidance %}
+            <li>{{ g }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+
+          {% if e.placement %}
+          <h3 style="margin-top:1rem">Placement Recommendation</h3>
+          <p><strong>Home:</strong> {{ e.placement.home }}
+            <span class="badge {% if e.placement.confidence == 'HIGH' %}badge-high{% elif e.placement.confidence == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}" style="margin-left:.5rem">
+              {{ e.placement.confidence }}
+            </span>
+          </p>
+          {% set real_signals = e.placement.signals | reject("equalto", "insufficient cross-engine signals — defaulting to Redshift") | list %}
+          {% if real_signals %}
+          <p><strong>Signals:</strong></p>
+          <ul style="margin:.25rem 0;padding-left:1.25rem">
+            {% for sig in real_signals %}
+            <li class="text-muted">{{ sig }}</li>
+            {% endfor %}
+          </ul>
+          {% elif e.placement.confidence != 'HIGH' %}
+          <p class="text-muted" style="font-size:.8125rem">Default placement — no specific workload signals detected.</p>
+          {% endif %}
+          {% endif %}
+        </div>
+      </div>
+    </details>
+    {% endif %}
+  {% endfor %}
+
+  {% set excluded = [] %}
+  {% for e in entities %}
+    {% if e.complexity and e.complexity.score == 0 and not e.complexity.flags and not e.rewrite_guidance and not e.placement %}
+      {% if excluded.append(e) %}{% endif %}
+    {% endif %}
+  {% endfor %}
+  {% if excluded %}
+  <details style="margin-top: var(--space-lg);">
+    <summary class="text-muted" style="cursor:pointer;font-size:.8125rem">{{ excluded|length }} entities excluded from details (no SQL surface visible)</summary>
+    <div class="card" style="margin-top:.5rem">
+      <div class="card-body" style="font-size:.8125rem">
+        <p class="text-muted">The following entities have no query logs or view definitions available, so query complexity cannot be assessed beyond the default PORTABLE classification.</p>
+        <ul style="margin:.25rem 0;padding-left:1.25rem">
+          {% for e in excluded %}
+          <li class="text-muted">{{ e.full_name }} ({{ e.entity_type }})</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </details>
+  {% endif %}
+</div>
+
+<div class="footer">
+  Generated by <strong>bq-assess</strong> &middot; {{ generated_at|timestamp }}
+</div>
+
+</div>
+</body>
+</html>

--- a/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/report.html.j2
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/report/templates/report.html.j2
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BigQuery Migration Assessment — {{ report.project_id }}</title>
+<style>
+/* AWS-native color scheme and layout */
+:root {
+  --aws-navy: #232F3E;
+  --aws-navy-light: #37475A;
+  --aws-orange: #FF9900;
+  --aws-orange-hover: #EC7211;
+  --aws-blue: #0073BB;
+  --aws-green: #1D8102;
+  --aws-yellow: #D4AC0D;
+  --aws-red: #D13212;
+  --aws-bg: #F2F3F3;
+  --aws-card-bg: #FFFFFF;
+  --aws-border: #D5DBDB;
+  --aws-text: #16191F;
+  --aws-text-secondary: #545B64;
+  --aws-text-light: #687078;
+}
+
+*,*::before,*::after { box-sizing: border-box }
+body {
+  font-family: "Amazon Ember", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px; line-height: 1.5; color: var(--aws-text); background: var(--aws-bg); margin: 0; padding: 0;
+}
+.container { max-width: 1200px; margin: 0 auto; padding: 0 20px }
+h1,h2,h3 { margin-top: 0; margin-bottom: .5rem; font-weight: 700; line-height: 1.2; color: var(--aws-navy) }
+h1 { font-size: 1.75rem } h2 { font-size: 1.25rem; border-bottom: 2px solid var(--aws-orange); padding-bottom: .5rem; margin-bottom: 1rem } h3 { font-size: 1.1rem }
+p { margin-top: 0; margin-bottom: 1rem }
+a { color: var(--aws-blue); text-decoration: none }
+a:hover { text-decoration: underline }
+
+/* Layout */
+.row { display: flex; flex-wrap: wrap; margin: 0 -10px }
+.col { flex: 1 0 0%; padding: 0 10px }
+.col-3 { flex: 0 0 25%; max-width: 25%; padding: 0 10px }
+.col-4 { flex: 0 0 33.333%; max-width: 33.333%; padding: 0 10px }
+.col-6 { flex: 0 0 50%; max-width: 50%; padding: 0 10px }
+.col-12 { flex: 0 0 100%; max-width: 100%; padding: 0 10px }
+
+/* AWS-style header */
+.header {
+  background: var(--aws-navy); color: #fff; padding: 0; margin-bottom: 1.5rem;
+  border-bottom: 3px solid var(--aws-orange);
+}
+.header-inner { display: flex; align-items: center; padding: 1rem 0 }
+.header-logo {
+  display: flex; align-items: center; gap: .75rem;
+  font-size: 1.1rem; font-weight: 700; color: #fff; margin-right: 2rem;
+}
+.header-logo .aws-cube {
+  width: 36px; height: 36px; background: var(--aws-orange); border-radius: 4px;
+  display: flex; align-items: center; justify-content: center; font-weight: 900; font-size: 14px; color: var(--aws-navy);
+}
+.header-meta { color: rgba(255,255,255,.7); font-size: .85rem }
+.header h1 { color: #fff; margin: 0; font-size: 1.25rem; font-weight: 700 }
+.header p { color: rgba(255,255,255,.7); margin: .25rem 0 0 0; font-size: .8rem }
+
+/* Card */
+.card {
+  position: relative; display: flex; flex-direction: column; background: var(--aws-card-bg);
+  border: 1px solid var(--aws-border); border-radius: 8px; margin-bottom: 12px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+}
+.card-body { flex: 1 1 auto; padding: 1rem }
+.card-title { margin-bottom: .5rem; font-size: .85rem; font-weight: 600; color: var(--aws-text-secondary); text-transform: uppercase; letter-spacing: .5px }
+
+/* Stat cards */
+.stat-value { font-size: 2rem; font-weight: 700; line-height: 1.2; color: var(--aws-navy) }
+.stat-label { font-size: .8rem; color: var(--aws-text-light); margin-top: .25rem }
+
+/* Table */
+table { width: 100%; margin-bottom: 1rem; border-collapse: collapse; background: var(--aws-card-bg); border: 1px solid var(--aws-border); border-radius: 8px; overflow: hidden }
+thead th {
+  padding: .6rem .75rem; text-align: left; font-size: .75rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .5px; color: var(--aws-text-secondary);
+  background: #FAFAFA; border-bottom: 2px solid var(--aws-border);
+}
+td { padding: .6rem .75rem; text-align: left; border-bottom: 1px solid #EAEDED; font-size: .875rem }
+tbody tr:hover { background: #F7F8F8 }
+tbody tr:last-child td { border-bottom: none }
+
+/* Badge */
+.badge {
+  display: inline-block; padding: .2em .6em; font-size: .7rem; font-weight: 700;
+  line-height: 1; text-align: center; white-space: nowrap; vertical-align: baseline;
+  border-radius: 4px; color: #fff; letter-spacing: .3px;
+}
+.badge-auto { background: var(--aws-green) }
+.badge-review { background: var(--aws-yellow); color: var(--aws-text) }
+.badge-manual { background: var(--aws-red) }
+.badge-high { background: var(--aws-green) }
+.badge-medium { background: var(--aws-yellow); color: var(--aws-text) }
+.badge-low { background: var(--aws-red) }
+.badge-flag { background: var(--aws-navy-light); font-weight: 600 }
+
+/* Alert */
+.alert {
+  position: relative; padding: 1rem; margin-bottom: 1rem;
+  border-radius: 8px; border-left: 4px solid; font-size: .875rem;
+}
+.alert-warning { color: #664d03; background: #FEF8E7; border-left-color: var(--aws-orange) }
+.alert-info { color: #055160; background: #E6F6FB; border-left-color: var(--aws-blue) }
+
+/* Details / Accordion */
+details { margin-bottom: 8px }
+details summary {
+  cursor: pointer; padding: .6rem .75rem; background: var(--aws-card-bg);
+  border: 1px solid var(--aws-border); border-radius: 8px; font-weight: 600;
+  font-size: .875rem; color: var(--aws-navy); transition: background .15s;
+}
+details summary:hover { background: #F7F8F8 }
+details[open] summary { border-radius: 8px 8px 0 0; margin-bottom: 0; border-bottom: none }
+details[open] .card { border-radius: 0 0 8px 8px; margin-top: 0 }
+
+/* Code */
+pre {
+  background: #FAFAFA; border: 1px solid var(--aws-border); border-radius: 4px;
+  padding: .75rem; overflow-x: auto; font-size: .8rem;
+}
+code { font-family: "Source Code Pro", SFMono-Regular, Menlo, Monaco, Consolas, monospace }
+
+/* Section */
+.section { margin-bottom: 2rem }
+
+/* Utility */
+.text-center { text-align: center }
+.text-muted { color: var(--aws-text-light) }
+.mt-2 { margin-top: .5rem } .mt-3 { margin-top: 1rem } .mt-4 { margin-top: 1.5rem }
+.mb-2 { margin-bottom: .5rem } .mb-3 { margin-bottom: 1rem } .mb-4 { margin-bottom: 1.5rem }
+.fw-bold { font-weight: 700 }
+.fs-3 { font-size: 1.5rem; color: var(--aws-navy) }
+
+/* Footer */
+.footer { text-align: center; padding: 1.5rem 0; color: var(--aws-text-light); font-size: .8rem; border-top: 1px solid var(--aws-border); margin-top: 2rem }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="container">
+    <div class="header-inner">
+      <div class="header-logo">
+        <div class="aws-cube">BQ</div>
+        <div>
+          <h1>Migration Assessment</h1>
+          <p>BigQuery → Amazon Redshift</p>
+        </div>
+      </div>
+      <div class="header-meta" style="margin-left:auto">
+        Project: <strong>{{ report.project_id }}</strong> &middot;
+        {{ report.generated_at }} &middot;
+        {{ report.assessment_id }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container">
+
+{% if report.executive_summary %}
+<div class="card" style="border-left: 4px solid var(--aws-orange); margin-bottom: 1.5rem">
+  <div class="card-body">
+    <div class="card-title">Migration Summary</div>
+    <p style="margin-bottom:0;font-size:.9rem;line-height:1.6">{{ report.executive_summary }}</p>
+  </div>
+</div>
+{% endif %}
+
+{% if report.optimization_confidence.value == "LOW" %}
+<div class="alert alert-warning" id="low-confidence-warning">
+  <strong>⚠ Low Confidence Recommendations</strong><br>
+  Query logs were not provided. Optimization recommendations (DISTKEY/SORTKEY) are heuristic-based.
+  Re-run with <code>--include-query-logs</code> for higher confidence.
+</div>
+{% endif %}
+
+<!-- Summary Dashboard -->
+<div class="section" id="summary-dashboard">
+  <h2>Summary</h2>
+  <div class="row">
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Tables Scanned</div>
+          <div class="stat-value">{{ report.summary.total_tables }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Total Size</div>
+          <div class="stat-value">{{ "%.1f"|format(report.summary.total_size_gb) }} <span style="font-size:1rem;font-weight:400">GB</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Confidence</div>
+          <div style="margin-top:.5rem">
+            <span class="confidence-indicator badge {% if report.optimization_confidence.value == 'HIGH' %}badge-high{% elif report.optimization_confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}" style="font-size:.9rem;padding:.3em .8em">
+              {{ report.optimization_confidence.value }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Query Logs</div>
+          <div class="stat-value" style="font-size:1.25rem">{% if report.query_logs_provided %}Provided{% else %}Not Provided{% endif %}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Complexity breakdown -->
+  <div class="row">
+    <div class="col-4">
+      <div class="card text-center" style="border-top: 3px solid var(--aws-green)">
+        <div class="card-body">
+          <div class="card-title">Auto-Migrate</div>
+          <div class="stat-value" style="color:var(--aws-green)">{{ report.summary.auto_count }}</div>
+          <div class="stat-label">tables ready for automated migration</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card text-center" style="border-top: 3px solid var(--aws-yellow)">
+        <div class="card-body">
+          <div class="card-title">Needs Review</div>
+          <div class="stat-value" style="color:var(--aws-yellow)">{{ report.summary.review_count }}</div>
+          <div class="stat-label">tables require review before migration</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card text-center" style="border-top: 3px solid var(--aws-red)">
+        <div class="card-body">
+          <div class="card-title">Manual Effort</div>
+          <div class="stat-value" style="color:var(--aws-red)">{{ report.summary.manual_count }}</div>
+          <div class="stat-label">tables need manual migration work</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Deployment Recommendation -->
+{% if report.deployment_recommendation %}
+<div class="section" id="deployment-recommendation">
+  <h2>Deployment Recommendation</h2>
+  <div class="row">
+    <div class="col-4">
+      <div class="card text-center" style="border-top: 3px solid {% if report.deployment_recommendation.deployment_type.value == 'SERVERLESS' %}var(--aws-blue){% else %}var(--aws-orange){% endif %}">
+        <div class="card-body">
+          <div class="card-title">Recommended Mode</div>
+          <div class="stat-value" style="font-size:1.5rem;color:{% if report.deployment_recommendation.deployment_type.value == 'SERVERLESS' %}var(--aws-blue){% else %}var(--aws-orange){% endif %}">{{ report.deployment_recommendation.deployment_type.value }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Estimated Monthly Cost</div>
+          <div class="stat-value">${{ "%.2f"|format(report.deployment_recommendation.estimated_monthly_cost) }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Confidence</div>
+          <div style="margin-top:.5rem">
+            <span class="badge {% if report.deployment_recommendation.confidence.value == 'HIGH' %}badge-high{% elif report.deployment_recommendation.confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}" style="font-size:.9rem;padding:.3em .8em">
+              {{ report.deployment_recommendation.confidence.value }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body">
+      <div class="card-title">Reasoning</div>
+      <ul style="margin:0;padding-left:1.25rem">
+        {% for reason in report.deployment_recommendation.reasons %}
+        <li style="margin-bottom:.35rem">{{ reason }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Cost Comparison -->
+<div class="section" id="cost-comparison">
+  <h2>Cost Comparison</h2>
+  <div class="row">
+    <div class="col-6">
+      <div class="card">
+        <div class="card-body">
+          <div class="card-title">BigQuery (Current)</div>
+          <div class="stat-value">${{ "%.2f"|format(report.cost_analysis.bigquery_monthly) }}</div>
+          <div class="stat-label">per month</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6">
+      <div class="card" style="border-top: 3px solid var(--aws-orange)">
+        <div class="card-body">
+          <div class="card-title">Amazon Redshift (Projected)</div>
+          <div class="stat-value">${{ "%.2f"|format(report.cost_analysis.redshift_monthly) }}</div>
+          <div class="stat-label">per month</div>
+          {% if report.cost_analysis.redshift_reasoning %}
+          <div class="text-muted" style="font-size:.8rem;font-style:italic;margin-top:.5rem">{{ report.cost_analysis.redshift_reasoning }}</div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="card text-center">
+        <div class="card-body">
+          <div class="card-title">Annual Savings</div>
+          <div class="fs-3 fw-bold">${{ "%.2f"|format(report.cost_analysis.annual_savings) }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Per-Table Details -->
+<div class="section" id="table-details">
+  <h2>Per-Table Details ({{ report.tables|length }} tables)</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Table</th>
+        <th>Dataset</th>
+        <th>Rows</th>
+        <th>Size (GB)</th>
+        <th>Complexity</th>
+        <th>Score</th>
+        <th>DISTKEY</th>
+        <th>SORTKEY</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for t in report.tables %}
+      <tr>
+        <td><strong>{{ t.name }}</strong></td>
+        <td>{{ t.dataset }}</td>
+        <td>{{ "{:,}".format(t.rows) }}</td>
+        <td>{{ "%.2f"|format(t.size_gb) }}</td>
+        <td>
+          <span class="badge {% if t.complexity.value == 'AUTO' %}badge-auto{% elif t.complexity.value == 'REVIEW' %}badge-review{% else %}badge-manual{% endif %}">
+            {{ t.complexity.value }}
+          </span>
+        </td>
+        <td>{{ t.score }}</td>
+        <td>
+          {% if t.distkey %}{{ t.distkey }}{% else %}<span class="text-muted">EVEN</span>{% endif %}
+          <span class="confidence-indicator badge {% if t.distkey_confidence.value == 'HIGH' %}badge-high{% elif t.distkey_confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ t.distkey_confidence.value }}
+          </span>
+        </td>
+        <td>
+          {% if t.sortkey %}{{ t.sortkey }}{% else %}<span class="text-muted">—</span>{% endif %}
+          <span class="confidence-indicator badge {% if t.sortkey_confidence.value == 'HIGH' %}badge-high{% elif t.sortkey_confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">
+            {{ t.sortkey_confidence.value }}
+          </span>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  {% for t in report.tables %}
+  <details>
+    <summary>
+      {{ t.name }}
+      <span class="badge {% if t.complexity.value == 'AUTO' %}badge-auto{% elif t.complexity.value == 'REVIEW' %}badge-review{% else %}badge-manual{% endif %}" style="margin-left:.5rem">
+        {{ t.complexity.value }}
+      </span>
+      <span class="text-muted" style="font-weight:400;margin-left:.5rem">score {{ t.score }}</span>
+    </summary>
+    <div class="card">
+      <div class="card-body">
+        {% if t.complexity_reasoning %}
+        <p class="text-muted" style="font-style:italic;margin-bottom:.75rem">{{ t.complexity_reasoning }}</p>
+        {% endif %}
+        {% if t.flags %}
+        <p><strong>Complexity Flags:</strong>
+          {% for flag in t.flags %}
+          <span class="badge badge-flag">{{ flag }}</span>
+          {% endfor %}
+        </p>
+        {% endif %}
+        <p><strong>DISTKEY:</strong> {{ t.distkey or "EVEN" }}
+          <span class="confidence-indicator badge {% if t.distkey_confidence.value == 'HIGH' %}badge-high{% elif t.distkey_confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">{{ t.distkey_confidence.value }}</span>
+          <span class="text-muted">({{ t.distkey_source }})</span>
+          {% if t.distkey_reasoning %}<br><span class="text-muted" style="font-size:.8rem;font-style:italic">{{ t.distkey_reasoning }}</span>{% endif %}
+        </p>
+        <p><strong>SORTKEY:</strong> {{ t.sortkey or "None" }}
+          <span class="confidence-indicator badge {% if t.sortkey_confidence.value == 'HIGH' %}badge-high{% elif t.sortkey_confidence.value == 'MEDIUM' %}badge-medium{% else %}badge-low{% endif %}">{{ t.sortkey_confidence.value }}</span>
+          <span class="text-muted">({{ t.sortkey_source }})</span>
+          {% if t.sortkey_reasoning %}<br><span class="text-muted" style="font-size:.8rem;font-style:italic">{{ t.sortkey_reasoning }}</span>{% endif %}
+        </p>
+        <p><strong>Redshift DDL:</strong></p>
+        <pre><code>{{ t.redshift_ddl }}</code></pre>
+      </div>
+    </div>
+  </details>
+  {% endfor %}
+</div>
+
+{% if report.failures %}
+<div class="section">
+  <h2>Failures ({{ report.failures|length }})</h2>
+  <table>
+    <thead>
+      <tr><th>Table</th><th>Stage</th><th>Error</th></tr>
+    </thead>
+    <tbody>
+    {% for f in report.failures %}
+      <tr><td>{{ f.table_name }}</td><td>{{ f.stage }}</td><td>{{ f.error }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+<div class="footer">
+  Generated by <strong>bq-assess</strong> &middot; {{ report.generated_at }}
+</div>
+
+</div>
+</body>
+</html>

--- a/solution-architecture/clis/bq-assess/src/bq_assess/scanner.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/scanner.py
@@ -1,0 +1,3 @@
+"""Backward-compatible re-export — scanner moved to bq_assess.core.scanner."""
+from bq_assess.core.scanner import *  # noqa: F401,F403
+from bq_assess.core.scanner import BigQueryScanner, ScannerError, _retry, RETRY_CONFIG  # noqa: F401

--- a/solution-architecture/clis/bq-assess/src/bq_assess/scoring/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/scoring/__init__.py
@@ -1,0 +1,4 @@
+"""Scoring axes: Migration Effort (Tables only) and Query Complexity (entities with SQL surface).
+
+Two independent axes, never merged into one number (ADR-0002).
+"""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/scoring/complexity.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/scoring/complexity.py
@@ -1,0 +1,113 @@
+"""Query Complexity scorer (R11) — two-axis model.
+
+Scores every entity with SQL surface on detected BigQuery-specific constructs.
+Categories: PORTABLE / ADAPT / REWRITE. Confidence ladder: LOW (no surface) →
+MEDIUM (auto-captured view/UDF defs) → HIGH (query logs).
+"""
+from __future__ import annotations
+
+from bq_assess.models import (
+    ComplexityCategory,
+    ComplexityResult,
+    ConfidenceLevel,
+    ConfidenceSource,
+    DetectedConstruct,
+    EntityMetadata,
+)
+
+_WEIGHTS: dict[str, int] = {
+    "JS_UDF": 4,
+    "UNNEST": 2,
+    "ARRAY_FN": 2,
+    "STRUCT_NAV": 1,
+    "FUNCTION_DRIFT": 1,
+}
+
+
+class ComplexityScorer:
+    """Score query complexity for entities with SQL surface (R11)."""
+
+    @staticmethod
+    def build_dep_counts(relationships) -> dict[str, int]:
+        """Pre-compute dependent counts from relationships (O(R) once)."""
+        counts: dict[str, int] = {}
+        if relationships is None:
+            return counts
+        for r in getattr(relationships, "relationships", []):
+            tgt = getattr(r, "target_table", None)
+            if tgt:
+                counts[tgt] = counts.get(tgt, 0) + 1
+        return counts
+
+    def score(
+        self,
+        entity: EntityMetadata,
+        constructs: list[DetectedConstruct],
+        relationships=None,
+        has_logs: bool = False,
+        dep_counts: dict[str, int] | None = None,
+    ) -> ComplexityResult:
+        """Score query complexity based on detected constructs."""
+        points = 0
+        flags: list[str] = []
+        reasons: list[str] = []
+
+        seen_classes: set[str] = set()
+        for c in constructs:
+            weight = _WEIGHTS.get(c.construct_class, 1)
+            # FUNCTION_DRIFT counts per distinct instance; all others count once per class
+            if c.construct_class == "FUNCTION_DRIFT":
+                points += weight
+                reasons.append(f"{c.construct_class} (+{weight})")
+            elif c.construct_class not in seen_classes:
+                points += weight
+                reasons.append(f"{c.construct_class} (+{weight})")
+            if c.construct_class not in seen_classes:
+                seen_classes.add(c.construct_class)
+                flags.append(c.construct_class)
+
+        # Hub entity bonus — O(1) lookup via pre-computed dict
+        if dep_counts is not None:
+            dep_count = dep_counts.get(entity.full_name, 0)
+            if dep_count >= 3:
+                points += 1
+                flags.append("hub_entity")
+                reasons.append(f"hub entity ({dep_count} dependents) (+1)")
+
+        # Category
+        if points == 0:
+            category = ComplexityCategory.PORTABLE
+        elif points <= 3:
+            category = ComplexityCategory.ADAPT
+        else:
+            category = ComplexityCategory.REWRITE
+
+        # Confidence ladder
+        has_surface = bool(
+            entity.view_query or entity.mview_query or
+            (entity.routine and entity.routine.body)
+        )
+        if has_logs:
+            confidence = ConfidenceLevel.HIGH
+            confidence_source = ConfidenceSource.QUERY_LOGS
+        elif has_surface:
+            confidence = ConfidenceLevel.MEDIUM
+            confidence_source = ConfidenceSource.VIEW_DEFINITION
+        else:
+            confidence = ConfidenceLevel.LOW
+            confidence_source = ConfidenceSource.SCHEMA_ONLY
+
+        reasoning = "; ".join(reasons) if reasons else (
+            "no SQL surface visible — cannot assess query complexity"
+            if not has_surface else "no BigQuery-specific constructs detected"
+        )
+
+        return ComplexityResult(
+            category=category,
+            score=points,
+            constructs=constructs,
+            flags=flags,
+            reasoning=reasoning,
+            confidence=confidence,
+            confidence_source=confidence_source,
+        )

--- a/solution-architecture/clis/bq-assess/src/bq_assess/scoring/effort.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/scoring/effort.py
@@ -1,0 +1,103 @@
+"""Migration Effort scorer (R9) — Tables only.
+
+Factors: data-volume tier (dominant), lossy-cast count, ongoing-sync need,
+non-clean partition/sort mapping. Nesting and clean partitioning contribute
+zero (R9.3, ADR-0002).
+"""
+from __future__ import annotations
+
+from bq_assess.models import (
+    ConfidenceLevel,
+    ConversionResult,
+    EffortCategory,
+    EffortResult,
+    EntityMetadata,
+)
+
+_ONE_GB = 1024**3
+_LARGE_THRESHOLD = 1 * _ONE_GB
+_HUGE_THRESHOLD = 100 * _ONE_GB
+
+_SYNC_SIGNALS = {"_partitiontime", "updated_at", "modified_at", "ingestion_time"}
+
+
+class EffortScorer:
+    """Score migration effort for TABLE-population entities."""
+
+    def score(self, entity: EntityMetadata, conversion: ConversionResult) -> EffortResult:
+        if not conversion.success:
+            return EffortResult(
+                category=EffortCategory.MANUAL,
+                score=99,
+                flags=["conversion_failed"],
+                reasoning="Iceberg DDL conversion failed — manual migration design required.",
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+        points = 0
+        flags: list[str] = []
+        reasons: list[str] = []
+
+        # Data-volume tier (dominant factor)
+        size_bytes = entity.num_bytes or 0
+        if size_bytes >= _HUGE_THRESHOLD:
+            points += 2
+            flags.append("data_volume_huge")
+            reasons.append(f"huge volume ({size_bytes / _ONE_GB:.0f} GB) — partition-wise load (+2)")
+        elif size_bytes >= _LARGE_THRESHOLD:
+            points += 1
+            flags.append("data_volume_large")
+            reasons.append(f"large volume ({size_bytes / _ONE_GB:.1f} GB) — staged COPY (+1)")
+
+        # Lossy casts
+        n_lossy = len(conversion.lossy_casts)
+        if n_lossy > 0:
+            points += n_lossy
+            flags.append("lossy_casts")
+            reasons.append(f"{n_lossy} lossy cast(s) — manual type review (+{n_lossy})")
+
+        # Ongoing-sync need
+        if self._has_sync_signal(entity):
+            points += 1
+            flags.append("ongoing_sync")
+            reasons.append("ongoing-sync signal detected — recurring MERGE needed (+1)")
+
+        # Non-clean partition/sort
+        if conversion.partition_mapping and conversion.partition_mapping.decision_flags:
+            for flag in conversion.partition_mapping.decision_flags:
+                if flag in ("partition_decision_required", "sort_decision_required"):
+                    points += 1
+                    flags.append(flag)
+                    reasons.append(f"{flag.replace('_', ' ')} (+1)")
+
+        # Category
+        if points == 0:
+            category = EffortCategory.AUTO
+        elif points <= 2:
+            category = EffortCategory.ASSISTED
+        else:
+            category = EffortCategory.MANUAL
+
+        # Confidence
+        if entity.num_bytes is None:
+            confidence = ConfidenceLevel.LOW
+        else:
+            confidence = ConfidenceLevel.HIGH
+
+        return EffortResult(
+            category=category,
+            score=points,
+            flags=flags,
+            reasoning="; ".join(reasons) if reasons else "No effort factors detected — fully automatable.",
+            confidence=confidence,
+        )
+
+    def _has_sync_signal(self, entity: EntityMetadata) -> bool:
+        if entity.time_partitioning:
+            field = entity.time_partitioning.field or ""
+            if field and (field.upper() == "_PARTITIONTIME" or field.lower() in _SYNC_SIGNALS):
+                return True
+        for col in entity.columns:
+            if col.name and col.name.lower() in _SYNC_SIGNALS:
+                return True
+        return False

--- a/solution-architecture/clis/bq-assess/src/bq_assess/targets/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/targets/__init__.py
@@ -1,0 +1,1 @@
+"""Target-specific modules for migration assessment."""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/__init__.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/__init__.py
@@ -1,0 +1,5 @@
+"""Iceberg Storage Target: schema conversion (DDL), partition/sort mapping, Load/Sync DML.
+
+Replaces the retired ``targets/redshift/`` storage-coupled target (ADR-0001). See
+``.kiro/specs/phase1-assessment-tool/SCRUM_NOTES.md`` for the #2 restructure decision.
+"""

--- a/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/constants.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/constants.py
@@ -1,0 +1,41 @@
+"""Verified constants for Iceberg conversion (V6, V9).
+
+All values are overridable. Every constant carries source URL + confirmation date.
+
+References:
+- V6: https://docs.aws.amazon.com/redshift/latest/dg/querying-iceberg-supported-data-types.html
+- V9: https://docs.aws.amazon.com/cli/latest/reference/s3tables/create-table.html
+"""
+
+# V6 — TIME is lossy (Redshift cannot read Iceberg time type)
+# Confirmed: 2026-06-06
+V6_TIME_IS_LOSSY: bool = True
+V6_TIME_ICEBERG_TYPE: str = "string"
+V6_TIME_LOSS_DESCRIPTION: str = (
+    "BigQuery TIME: Iceberg has native time but Redshift cannot read it "
+    "over Iceberg. Stored as ISO 8601 string."
+)
+
+# V6 — JSON is lossy (no native Iceberg JSON type)
+V6_JSON_IS_LOSSY: bool = True
+V6_JSON_ICEBERG_TYPE: str = "string"
+V6_JSON_LOSS_DESCRIPTION: str = (
+    "No native Iceberg JSON type (v2 spec). Stored as string; "
+    "structured query semantics lost."
+)
+
+# V9 — S3 Tables CreateTable partition transforms
+# Confirmed: 2026-06-06
+V9_SUPPORTED_PARTITION_TRANSFORMS = (
+    "identity", "year", "month", "day", "hour", "bucket", "truncate",
+)
+
+# BigQuery time-partition type to Iceberg transform (clean, ADR-0003)
+BQ_TO_ICEBERG_PARTITION_TRANSFORM = {
+    "DAY": "day",
+    "HOUR": "hour",
+    "MONTH": "month",
+    "YEAR": "year",
+}
+
+RANGE_PARTITION_IS_CLEAN: bool = False

--- a/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/converter.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/converter.py
@@ -1,0 +1,297 @@
+"""Iceberg Converter — BigQuery schema → Iceberg DDL (R6, R7, R8, R23.3).
+
+Emits CREATE TABLE in Iceberg SQL syntax with:
+- Native nesting: STRUCT→struct, ARRAY→list, ARRAY<STRUCT>→list<struct> (R6.2, P10)
+- Partition/sort mapping per ADR-0003: clean=annotation, non-clean=flagged (R7, P12)
+- Lossy Cast detection with warnings, never silent (R8, P11)
+- No DDL for REBUILT entities (R4.4, P6)
+
+Type mapping per design.md § Authoritative BigQuery → Iceberg Type Mapping.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from bq_assess.models import (
+    ColumnSchema,
+    ConversionResult,
+    EntityMetadata,
+    EntityPopulation,
+    LossyCast,
+    PartitionMapping,
+)
+from bq_assess.targets.iceberg.constants import (
+    BQ_TO_ICEBERG_PARTITION_TRANSFORM,
+    V6_JSON_ICEBERG_TYPE,
+    V6_JSON_IS_LOSSY,
+    V6_JSON_LOSS_DESCRIPTION,
+    V6_TIME_ICEBERG_TYPE,
+    V6_TIME_IS_LOSSY,
+    V6_TIME_LOSS_DESCRIPTION,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---- Clean type map (round-trippable, P9) ----
+
+CLEAN_TYPE_MAP: dict[str, str] = {
+    "STRING": "string",
+    "INT64": "long",
+    "INTEGER": "long",
+    "FLOAT64": "double",
+    "FLOAT": "double",
+    "BOOL": "boolean",
+    "BOOLEAN": "boolean",
+    "BYTES": "binary",
+    "DATE": "date",
+    "TIMESTAMP": "timestamptz",
+    "DATETIME": "timestamp",
+    "NUMERIC": "decimal(38,9)",
+}
+
+# ---- Lossy type map (contribute to Effort score) ----
+
+LOSSY_TYPE_MAP: dict[str, tuple[str, str]] = {
+    "GEOGRAPHY": (
+        "string",
+        "No native Iceberg GEOGRAPHY; stored as WKT string. Spatial semantics lost.",
+    ),
+    "INTERVAL": (
+        "string",
+        "No native Iceberg INTERVAL; stored as ISO 8601 duration string.",
+    ),
+}
+
+if V6_TIME_IS_LOSSY:
+    LOSSY_TYPE_MAP["TIME"] = (V6_TIME_ICEBERG_TYPE, V6_TIME_LOSS_DESCRIPTION)
+if V6_JSON_IS_LOSSY:
+    LOSSY_TYPE_MAP["JSON"] = (V6_JSON_ICEBERG_TYPE, V6_JSON_LOSS_DESCRIPTION)
+
+_NESTED_TYPES = {"STRUCT", "RECORD"}
+
+_BIGNUMERIC_ICEBERG = "decimal(38,18)"
+_BIGNUMERIC_LOSS = (
+    "BIGNUMERIC (76 digits: 38 integer + 38 fractional) exceeds Iceberg/Redshift max "
+    "precision (38). Mapped to decimal(38,18): 20 integer + 18 fractional digits retained."
+)
+
+
+class IcebergConverter:
+    """Convert BigQuery EntityMetadata to Iceberg CREATE TABLE DDL.
+
+    Contract (design.md § Component Interfaces):
+        def convert(self, entity: EntityMetadata) -> ConversionResult
+    """
+
+    def convert(self, entity: EntityMetadata) -> ConversionResult:
+        """Convert entity schema to Iceberg DDL.
+
+        - REBUILT entities → empty DDL, success=True (R4.4, P6)
+        - On exception → success=False (maps to Effort MANUAL, R23.3)
+        """
+        if entity.population == EntityPopulation.REBUILT:
+            return ConversionResult(
+                ddl="",
+                partition_mapping=None,
+                lossy_casts=[],
+                warnings=[],
+                success=True,
+            )
+
+        try:
+            return self._convert_table(entity)
+        except Exception as exc:
+            logger.error("Iceberg conversion failed for %s: %s", entity.full_name, exc)
+            return ConversionResult(
+                ddl="",
+                partition_mapping=None,
+                lossy_casts=[],
+                warnings=[f"Conversion failed: {exc}"],
+                success=False,
+            )
+
+    # ------------------------------------------------------------------
+
+    def _convert_table(self, entity: EntityMetadata) -> ConversionResult:
+        lossy_casts: list[LossyCast] = []
+        warnings: list[str] = []
+
+        # Map columns
+        col_defs: list[str] = []
+        for col in entity.columns:
+            iceberg_type = self._resolve_type(col, lossy_casts)
+            nullable = " NOT NULL" if col.mode == "REQUIRED" else ""
+            col_defs.append(f"  {col.name} {iceberg_type}{nullable}")
+
+        columns_sql = ",\n".join(col_defs)
+
+        # Partition/sort mapping (R7, ADR-0003)
+        partition_mapping = self._derive_partition_mapping(entity)
+
+        # Build DDL
+        partition_clause = ""
+        if partition_mapping and partition_mapping.iceberg_transforms:
+            transforms = ", ".join(partition_mapping.iceberg_transforms)
+            partition_clause = f"\nPARTITION BY ({transforms})"
+
+        sort_clause = ""
+        if partition_mapping and partition_mapping.sort_order:
+            sorts = ", ".join(partition_mapping.sort_order)
+            sort_clause = f"\nSORT BY ({sorts})"
+
+        ddl = f"CREATE TABLE {entity.full_name} (\n{columns_sql}\n){partition_clause}{sort_clause};"
+
+        # Lossy cast warnings
+        for lc in lossy_casts:
+            warnings.append(
+                f"Lossy cast: column '{lc.column}' ({lc.source_type}) → "
+                f"{lc.iceberg_type}: {lc.loss_description}"
+            )
+
+        # Non-clean partition/sort warnings
+        if partition_mapping and not partition_mapping.auto_derived:
+            for flag in partition_mapping.decision_flags:
+                warnings.append(f"Partition/sort decision required: {flag}")
+
+        return ConversionResult(
+            ddl=ddl,
+            partition_mapping=partition_mapping,
+            lossy_casts=lossy_casts,
+            warnings=warnings,
+            success=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Type resolution (handles nesting recursively)
+    # ------------------------------------------------------------------
+
+    def _resolve_type(self, col: ColumnSchema, lossy: list[LossyCast]) -> str:
+        """Resolve a column to its Iceberg type string, preserving nesting (P10)."""
+        field_type = col.field_type.upper()
+
+        # REPEATED → list<element> (R6.2)
+        if col.mode == "REPEATED":
+            if field_type in _NESTED_TYPES:
+                inner = self._struct_fields(col.fields, lossy)
+                return f"list<struct<{inner}>>"
+            else:
+                elem = self._scalar_type(col, lossy)
+                return f"list<{elem}>"
+
+        # STRUCT/RECORD → struct<...> (R6.2)
+        if field_type in _NESTED_TYPES:
+            inner = self._struct_fields(col.fields, lossy)
+            return f"struct<{inner}>"
+
+        return self._scalar_type(col, lossy)
+
+    def _struct_fields(self, fields: list[ColumnSchema], lossy: list[LossyCast]) -> str:
+        """Render struct fields recursively.
+
+        Nested-field nullability is honored per R6.4: a REQUIRED sub-field gets a
+        ``NOT NULL`` marker just like a top-level column; NULLABLE/REPEATED stay optional.
+        """
+        parts: list[str] = []
+        for f in fields:
+            f_type = self._resolve_type(f, lossy)
+            nullable = " NOT NULL" if f.mode == "REQUIRED" else ""
+            parts.append(f"{f.name}: {f_type}{nullable}")
+        return ", ".join(parts)
+
+    def _scalar_type(self, col: ColumnSchema, lossy: list[LossyCast]) -> str:
+        """Map a scalar BigQuery type to Iceberg (R6.1, R8)."""
+        field_type = col.field_type.upper()
+
+        # Clean
+        if field_type in CLEAN_TYPE_MAP:
+            return CLEAN_TYPE_MAP[field_type]
+
+        # BIGNUMERIC — always treated as lossy (can't know precision from schema)
+        if field_type == "BIGNUMERIC":
+            lossy.append(LossyCast(
+                column=col.name,
+                source_type="BIGNUMERIC",
+                iceberg_type=_BIGNUMERIC_ICEBERG,
+                loss_description=_BIGNUMERIC_LOSS,
+            ))
+            return _BIGNUMERIC_ICEBERG
+
+        # Known lossy
+        if field_type in LOSSY_TYPE_MAP:
+            iceberg_type, loss_desc = LOSSY_TYPE_MAP[field_type]
+            lossy.append(LossyCast(
+                column=col.name,
+                source_type=field_type,
+                iceberg_type=iceberg_type,
+                loss_description=loss_desc,
+            ))
+            return iceberg_type
+
+        # Unknown type → string fallback + lossy warning (R8.4)
+        lossy.append(LossyCast(
+            column=col.name,
+            source_type=field_type,
+            iceberg_type="string",
+            loss_description=f"Unknown BigQuery type '{field_type}'; fallback to string.",
+        ))
+        return "string"
+
+    # ------------------------------------------------------------------
+    # Partition / sort mapping (R7, ADR-0003)
+    # ------------------------------------------------------------------
+
+    def _derive_partition_mapping(self, entity: EntityMetadata) -> PartitionMapping | None:
+        """Derive Iceberg partition transforms + sort order."""
+        transforms: list[str] = []
+        sort_order: list[str] = []
+        auto_derived = True
+        decision_flags: list[str] = []
+
+        # Time partitioning (R7.1, R7.3)
+        if entity.time_partitioning is not None:
+            tp = entity.time_partitioning
+            if tp.field is not None:
+                # Explicit-field → clean (R7.1, zero effort)
+                transform = BQ_TO_ICEBERG_PARTITION_TRANSFORM.get(tp.type.upper(), "day")
+                transforms.append(f"{transform}({tp.field})")
+            else:
+                # Ingestion-time → non-clean (R7.3). Emit a syntactically valid
+                # transform suggestion; the review caveat lives in decision_flags
+                # (kept out of the transform list so the DDL stays valid).
+                auto_derived = False
+                decision_flags.append(
+                    "ingestion-time partition (no real column) — "
+                    "suggested day(_ingestion_time); review before applying"
+                )
+                transforms.append("day(_ingestion_time)")
+
+        # Range partitioning (R7.4)
+        if entity.range_partitioning is not None:
+            rp = entity.range_partitioning
+            auto_derived = False
+            decision_flags.append(
+                f"range partition on '{rp.field}' ({rp.start}..{rp.end}, "
+                f"interval={rp.interval}) — no clean Iceberg equivalent; "
+                f"suggested bucket(16, {rp.field}) is not equivalent to range, review before applying"
+            )
+            transforms.append(f"bucket(16, {rp.field})")
+
+        # Clustering → sort order (R7.2, R7.5)
+        if entity.clustering_fields:
+            for field in entity.clustering_fields:
+                sort_order.append(field)
+            # BQ allows max 4 clustering fields; >4 would be ambiguous (R7.5)
+            if len(entity.clustering_fields) > 4:
+                auto_derived = False
+                decision_flags.append("ambiguous multi-column clustering")
+
+        if not transforms and not sort_order:
+            return None
+
+        return PartitionMapping(
+            iceberg_transforms=transforms,
+            sort_order=sort_order,
+            auto_derived=auto_derived,
+            decision_flags=decision_flags,
+        )

--- a/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/dml.py
+++ b/solution-architecture/clis/bq-assess/src/bq_assess/targets/iceberg/dml.py
@@ -1,0 +1,198 @@
+"""Load/Sync DML Generator — initial load + ongoing MERGE on Iceberg (R12).
+
+Emits per-Table:
+- Initial-load SQL by volume tier (INSERT…SELECT / staged COPY / partition-wise)
+- Ongoing-upsert MERGE when a sync signal is present
+- Text only — never executes (R12.3)
+- None for REBUILT entities (R12.5)
+- Non-clean partition caveat inline when flagged (R12.4)
+
+V8 confirmed (2026-06-15): INSERT, UPDATE, MERGE all work on partitioned S3 Tables
+(Iceberg) from Redshift Serverless. Supported transforms: identity, year, month, day,
+hour, bucket, truncate.
+"""
+
+from __future__ import annotations
+
+from bq_assess.models import (
+    ConversionResult,
+    EffortResult,
+    EntityMetadata,
+    EntityPopulation,
+)
+
+# Volume tier thresholds (bytes)
+SMALL_THRESHOLD = 1 * 1024**3        # 1 GB — single INSERT…SELECT
+LARGE_THRESHOLD = 100 * 1024**3      # 100 GB — staged COPY via S3
+
+
+class DMLGenerator:
+    """Generate Load/Sync DML for migrating Tables to Iceberg (R12).
+
+    Contract (design.md § Component Interfaces):
+        def generate(self, entity: EntityMetadata, effort: EffortResult,
+                     conversion: ConversionResult | None) -> str | None
+    """
+
+    def generate(
+        self,
+        entity: EntityMetadata,
+        effort: EffortResult,
+        conversion: ConversionResult | None = None,
+    ) -> str | None:
+        """Generate load/sync DML for an entity.
+
+        Returns:
+            DML text for Tables, or None for REBUILT entities (R12.5).
+        """
+        # No DML for views/MVs/UDFs (R12.5)
+        if entity.population == EntityPopulation.REBUILT:
+            return None
+
+        parts: list[str] = []
+
+        # Non-clean partition caveat (R12.4)
+        if conversion and conversion.partition_mapping:
+            pm = conversion.partition_mapping
+            if not pm.auto_derived:
+                parts.append(self._partition_caveat(pm.decision_flags))
+
+        # Initial load (R12.1)
+        parts.append(self._initial_load(entity))
+
+        # Ongoing sync via MERGE if sync signal present (R12.2)
+        if self._has_sync_signal(entity):
+            parts.append(self._merge_upsert(entity))
+
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Initial load by volume tier (R12.1)
+    # ------------------------------------------------------------------
+
+    def _initial_load(self, entity: EntityMetadata) -> str:
+        target = entity.full_name
+        # Assume source is accessible via external schema or federated query
+        source = f"bq_source.{entity.full_name.replace('.', '_')}"
+
+        if entity.num_bytes <= SMALL_THRESHOLD:
+            return self._load_small(target, source)
+        elif entity.num_bytes <= LARGE_THRESHOLD:
+            return self._load_large(target, source, entity)
+        else:
+            return self._load_huge(target, source, entity)
+
+    def _load_small(self, target: str, source: str) -> str:
+        return (
+            f"-- Initial load (small table, single INSERT…SELECT)\n"
+            f"INSERT INTO {target}\n"
+            f"SELECT * FROM {source};"
+        )
+
+    def _load_large(self, target: str, source: str, entity: EntityMetadata) -> str:
+        s3_path = f"s3://migration-staging/{entity.full_name.replace('.', '/')}/"
+        return (
+            f"-- Initial load (large table, staged via S3)\n"
+            f"-- Step 1: Export from BigQuery to S3 staging\n"
+            f"--   bq extract → {s3_path}\n"
+            f"-- Step 2: COPY into Iceberg table\n"
+            f"COPY {target}\n"
+            f"FROM '{s3_path}'\n"
+            f"FORMAT PARQUET;"
+        )
+
+    def _load_huge(self, target: str, source: str, entity: EntityMetadata) -> str:
+        s3_path = f"s3://migration-staging/{entity.full_name.replace('.', '/')}/"
+        partition_hint = ""
+        if entity.time_partitioning and entity.time_partitioning.field:
+            field = entity.time_partitioning.field
+            partition_hint = (
+                f"\n-- Recommend: partition-wise export by {field} to parallelize load"
+            )
+        return (
+            f"-- Initial load (huge table, partition-by-partition via S3)\n"
+            f"-- Step 1: Export partitions from BigQuery to S3 staging{partition_hint}\n"
+            f"--   bq extract --partition → {s3_path}<partition>/\n"
+            f"-- Step 2: COPY each partition into Iceberg table\n"
+            f"COPY {target}\n"
+            f"FROM '{s3_path}'\n"
+            f"FORMAT PARQUET;\n"
+            f"-- Repeat per partition for parallel ingestion"
+        )
+
+    # ------------------------------------------------------------------
+    # Ongoing sync via MERGE (R12.2, V8 confirmed)
+    # ------------------------------------------------------------------
+
+    def _has_sync_signal(self, entity: EntityMetadata) -> bool:
+        """Detect if a table needs ongoing sync (CDC/append pattern).
+
+        Signals: ingestion-time partition (append pattern), or presence of
+        time-partitioning on a real field (implies ongoing data arrival).
+        """
+        if entity.time_partitioning is not None:
+            return True
+        # Could also detect updated_at/created_at columns as sync signals
+        sync_columns = {"updated_at", "created_at", "modified_at", "ingestion_time"}
+        col_names = {col.name.lower() for col in entity.columns}
+        return bool(sync_columns & col_names)
+
+    def _merge_upsert(self, entity: EntityMetadata) -> str:
+        target = entity.full_name
+        staging = f"staging.{entity.full_name.replace('.', '_')}_delta"
+
+        # Detect merge key (prefer _id columns or first REQUIRED column)
+        merge_key = self._detect_merge_key(entity)
+
+        col_names = [col.name for col in entity.columns]
+        update_cols = [c for c in col_names if c != merge_key]
+
+        update_clause = ",\n    ".join(
+            f"target.{c} = source.{c}" for c in update_cols[:10]  # cap for readability
+        )
+        if len(update_cols) > 10:
+            update_clause += "\n    -- ... (remaining columns omitted for brevity)"
+
+        insert_cols = ", ".join(col_names[:10])
+        if len(col_names) > 10:
+            insert_cols += ", ..."
+        insert_vals = ", ".join(f"source.{c}" for c in col_names[:10])
+        if len(col_names) > 10:
+            insert_vals += ", ..."
+
+        return (
+            f"-- Ongoing sync (MERGE upsert, V8 confirmed on partitioned Iceberg)\n"
+            f"MERGE INTO {target} AS target\n"
+            f"USING {staging} AS source\n"
+            f"ON target.{merge_key} = source.{merge_key}\n"
+            f"WHEN MATCHED THEN UPDATE SET\n"
+            f"    {update_clause}\n"
+            f"WHEN NOT MATCHED THEN INSERT ({insert_cols})\n"
+            f"    VALUES ({insert_vals});"
+        )
+
+    def _detect_merge_key(self, entity: EntityMetadata) -> str:
+        """Best-effort merge key detection."""
+        # Prefer columns ending in _id or named 'id'
+        for col in entity.columns:
+            if col.name.lower() == "id" or col.name.lower().endswith("_id"):
+                return col.name
+        # Fall back to first REQUIRED column
+        for col in entity.columns:
+            if col.mode == "REQUIRED":
+                return col.name
+        # Last resort: first column
+        return entity.columns[0].name
+
+    # ------------------------------------------------------------------
+    # Partition caveat (R12.4)
+    # ------------------------------------------------------------------
+
+    def _partition_caveat(self, decision_flags: list[str]) -> str:
+        flags_text = "; ".join(decision_flags)
+        return (
+            f"-- ⚠️ REVIEW REQUIRED: partition/sort mapping was flagged as non-clean.\n"
+            f"-- Flags: {flags_text}\n"
+            f"-- Verify the target table's partition layout before running this DML.\n"
+            f"-- The suggested transform may not match your access pattern."
+        )

--- a/solution-architecture/clis/bq-assess/tests/__init__.py
+++ b/solution-architecture/clis/bq-assess/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/solution-architecture/clis/bq-assess/tests/conftest.py
+++ b/solution-architecture/clis/bq-assess/tests/conftest.py
@@ -1,0 +1,647 @@
+"""Shared test fixtures and Hypothesis strategies."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import hypothesis.strategies as st
+import pytest
+
+from bq_assess import models as m  # normative lakehouse model (issue #3)
+from bq_assess.core.analyzer import JoinPattern, QueryAnalysis
+from bq_assess.models import ColumnSchema
+
+
+# Valid BigQuery types from TYPE_MAP in the design
+BQ_TYPES = [
+    "STRING", "INT64", "FLOAT64", "BOOL", "TIMESTAMP", "DATE",
+    "STRUCT", "ARRAY", "GEOGRAPHY", "BYTES", "NUMERIC", "BIGNUMERIC",
+    "TIME", "JSON", "INTERVAL",
+]
+
+BQ_MODES = ["NULLABLE", "REQUIRED", "REPEATED"]
+
+PARTITION_TYPES = ["DAY", "HOUR", "MONTH", "YEAR"]
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,19}", fullmatch=True)
+
+
+@st.composite
+def column_schema(draw: st.DrawFn, *, max_depth: int = 2) -> ColumnSchema:
+    """Generate a valid ColumnSchema with proper nesting rules.
+
+    STRUCT types get nested fields; non-STRUCT types get an empty list.
+    """
+    name = draw(_identifier)
+    mode = draw(st.sampled_from(BQ_MODES))
+
+    if max_depth <= 0:
+        # At max depth, avoid STRUCT to prevent infinite recursion
+        field_type = draw(st.sampled_from([t for t in BQ_TYPES if t != "STRUCT"]))
+        return ColumnSchema(name=name, field_type=field_type, mode=mode, fields=[])
+
+    field_type = draw(st.sampled_from(BQ_TYPES))
+
+    if field_type == "STRUCT":
+        nested = draw(
+            st.lists(column_schema(max_depth=max_depth - 1), min_size=1, max_size=3)
+        )
+        return ColumnSchema(name=name, field_type=field_type, mode=mode, fields=nested)
+
+    return ColumnSchema(name=name, field_type=field_type, mode=mode, fields=[])
+
+
+@st.composite
+def query_analysis(draw: st.DrawFn) -> QueryAnalysis:
+    """Generate a valid QueryAnalysis with table counts, joins, and WHERE columns."""
+    table_names = draw(st.lists(_identifier, min_size=1, max_size=6, unique=True))
+
+    table_query_counts = {t: draw(st.integers(min_value=1, max_value=10000)) for t in table_names}
+
+    join_patterns: dict[str, list[JoinPattern]] = {}
+    for t in table_names:
+        n_joins = draw(st.integers(min_value=0, max_value=3))
+        patterns = []
+        for _ in range(n_joins):
+            right = draw(st.sampled_from(table_names))
+            patterns.append(JoinPattern(
+                left_table=t,
+                right_table=right,
+                join_column=draw(_identifier),
+                frequency=draw(st.integers(min_value=1, max_value=500)),
+            ))
+        if patterns:
+            join_patterns[t] = patterns
+
+    where_columns: dict[str, list[str]] = {}
+    for t in table_names:
+        cols = draw(st.lists(_identifier, min_size=0, max_size=4))
+        if cols:
+            where_columns[t] = cols
+
+    # Hub tables: tables with >5 distinct join partners
+    hub_tables = [
+        t for t in table_names
+        if len({jp.right_table for jp in join_patterns.get(t, [])}) > 5
+    ]
+
+    return QueryAnalysis(
+        table_query_counts=table_query_counts,
+        join_patterns=join_patterns,
+        where_columns=where_columns,
+        hub_tables=hub_tables,
+        anonymized=draw(st.booleans()),
+    )
+
+
+@st.composite
+def sql_query_with_literals(draw: st.DrawFn) -> str:
+    """Generate SQL strings containing string literals and numeric literals.
+
+    Useful for testing query anonymization — the generated SQL will always
+    contain at least one single-quoted string literal and one numeric literal.
+    """
+    table = draw(_identifier)
+    col1 = draw(_identifier)
+    col2 = draw(_identifier)
+
+    # Generate a string literal (single-quoted, no internal quotes for simplicity)
+    str_value = draw(st.text(
+        min_size=1,
+        max_size=20,
+        alphabet=st.characters(whitelist_categories=("L", "N"), whitelist_characters=" "),
+    ))
+    num_value = draw(st.one_of(
+        st.integers(min_value=-999999, max_value=999999),
+        st.floats(min_value=-9999.0, max_value=9999.0, allow_nan=False, allow_infinity=False),
+    ))
+
+    # Build a realistic SQL query with both literal types
+    template = draw(st.sampled_from([
+        f"SELECT * FROM {table} WHERE {col1} = '{str_value}' AND {col2} = {num_value}",
+        f"SELECT {col1}, {col2} FROM {table} WHERE {col1} IN ('{str_value}') AND {col2} > {num_value}",
+        f"SELECT COUNT(*) FROM {table} WHERE {col1} LIKE '{str_value}%' AND {col2} BETWEEN {num_value} AND {num_value + 100}",
+    ]))
+
+    return template
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies — normative lakehouse model (issue #4, design.md § Data Models)
+#
+# These build the new `bq_assess.models` (aliased `m`) dataclasses used by Phase 1+
+# implementations and their P-tests. They sit alongside the legacy strategies above,
+# which still serve the not-yet-rewritten code until each phase migrates (see SCRUM_NOTES).
+# `column_schema()` is reused as-is — ColumnSchema is shared single-identity between models.
+# ---------------------------------------------------------------------------
+
+# Construct classes the SQL surface detector recognizes (design.md DetectedConstruct / R10.3)
+SQL_CONSTRUCT_CLASSES = ["UNNEST", "FUNCTION_DRIFT", "ARRAY_FN", "STRUCT_NAV", "JS_UDF"]
+
+# Snippets that exercise each BigQuery-specific construct class, keyed by class.
+_CONSTRUCT_SNIPPETS = {
+    "UNNEST": "SELECT x FROM t, UNNEST(items) AS x",
+    "FUNCTION_DRIFT": "SELECT DATE_DIFF(d2, d1, DAY) FROM t",
+    "ARRAY_FN": "SELECT ARRAY_LENGTH(tags) FROM t",
+    "STRUCT_NAV": "SELECT payload.user.id FROM t",
+    "JS_UDF": "CREATE TEMP FUNCTION f(x FLOAT64) RETURNS FLOAT64 LANGUAGE js AS 'return x*2;'",
+}
+
+ENTITY_TYPES = list(m.EntityType)
+TABLE_TYPES = [m.EntityType.TABLE, m.EntityType.EXTERNAL]
+REBUILT_TYPES = [m.EntityType.VIEW, m.EntityType.MATERIALIZED_VIEW, m.EntityType.ROUTINE]
+ROUTINE_LANGUAGES = ["SQL", "JAVASCRIPT"]
+
+
+@st.composite
+def time_partition_config(draw: st.DrawFn) -> m.TimePartitionConfig:
+    """Generate a TimePartitionConfig; field=None models ingestion-time (non-clean, R7.3)."""
+    return m.TimePartitionConfig(
+        type=draw(st.sampled_from(PARTITION_TYPES)),
+        field=draw(st.one_of(st.none(), _identifier)),
+    )
+
+
+@st.composite
+def range_partition_config(draw: st.DrawFn) -> m.RangePartitionConfig:
+    """Generate a RangePartitionConfig with start < end and a positive interval (R3.8)."""
+    start = draw(st.integers(min_value=0, max_value=10**6))
+    end = draw(st.integers(min_value=start + 1, max_value=start + 10**6 + 1))
+    return m.RangePartitionConfig(
+        field=draw(_identifier),
+        start=start,
+        end=end,
+        interval=draw(st.integers(min_value=1, max_value=10**5)),
+    )
+
+
+@st.composite
+def routine_metadata(draw: st.DrawFn) -> m.RoutineMetadata:
+    """Generate a RoutineMetadata (UDF / stored procedure) — R3.3."""
+    language = draw(st.sampled_from(ROUTINE_LANGUAGES))
+    body = (
+        "return x + 1;" if language == "JAVASCRIPT"
+        else "SELECT 1"
+    )
+    return m.RoutineMetadata(
+        name=draw(_identifier),
+        language=language,
+        arguments=draw(st.lists(_identifier, max_size=4)),
+        body=body,
+        routine_type=draw(st.sampled_from(["SCALAR_FUNCTION", "PROCEDURE"])),
+    )
+
+
+def _population_for(entity_type: m.EntityType) -> m.EntityPopulation:
+    """The total, disjoint EntityType -> EntityPopulation mapping (R4.2/R4.3)."""
+    return (
+        m.EntityPopulation.TABLE
+        if entity_type in (m.EntityType.TABLE, m.EntityType.EXTERNAL)
+        else m.EntityPopulation.REBUILT
+    )
+
+
+@st.composite
+def entity_metadata(
+    draw: st.DrawFn,
+    *,
+    entity_type: m.EntityType | None = None,
+) -> m.EntityMetadata:
+    """Generate a valid EntityMetadata covering all types and both partitionings.
+
+    Population is derived from the type (R4.2/R4.3). View/MV entities carry their
+    `*_query`; routines carry `routine`; tables may carry either/both partitionings.
+    Optionally pin `entity_type` to force a specific population in a test.
+    """
+    etype = entity_type if entity_type is not None else draw(st.sampled_from(ENTITY_TYPES))
+    population = _population_for(etype)
+
+    dataset_id = draw(_identifier)
+    entity_id = draw(_identifier)
+    columns = draw(st.lists(column_schema(), min_size=1, max_size=8))
+
+    # Partitionings / clustering only make sense for Tables; views/routines leave them None.
+    if population is m.EntityPopulation.TABLE:
+        time_part = draw(st.one_of(st.none(), time_partition_config()))
+        range_part = draw(st.one_of(st.none(), range_partition_config()))
+        clustering = draw(st.one_of(st.none(), st.lists(_identifier, min_size=1, max_size=4)))
+        num_rows = draw(st.integers(min_value=0, max_value=10**12))
+    else:
+        time_part = None
+        range_part = None
+        clustering = None
+        num_rows = 0  # views/mviews/routines (design.md: 0 for non-tables)
+
+    view_query = draw(st.text(min_size=10, max_size=60)) if etype is m.EntityType.VIEW else None
+    mview_query = (
+        draw(st.text(min_size=10, max_size=60))
+        if etype is m.EntityType.MATERIALIZED_VIEW else None
+    )
+    routine = draw(routine_metadata()) if etype is m.EntityType.ROUTINE else None
+
+    ts = draw(st.datetimes(
+        min_value=datetime(2020, 1, 1),
+        max_value=datetime(2025, 12, 31),
+        timezones=st.just(timezone.utc),
+    ))
+
+    return m.EntityMetadata(
+        entity_id=entity_id,
+        dataset_id=dataset_id,
+        full_name=f"{dataset_id}.{entity_id}",
+        entity_type=etype,
+        population=population,
+        num_rows=num_rows,
+        num_bytes=draw(st.integers(min_value=0, max_value=10**15)),
+        columns=columns,
+        time_partitioning=time_part,
+        range_partitioning=range_part,
+        clustering_fields=clustering,
+        view_query=view_query,
+        mview_query=mview_query,
+        routine=routine,
+        depends_on=draw(st.lists(_identifier, max_size=5)),
+        last_modified=ts,
+    )
+
+
+@st.composite
+def slot_jobs(draw: st.DrawFn, *, min_size: int = 1, max_size: int = 50) -> list[dict]:
+    """Generate a list of BigQuery job-metadata dicts for workload/slot analysis (R17).
+
+    Each job carries the fields the Workload Analyzer reads: total_slot_ms,
+    total_bytes_processed, creation_time, and — mirroring real BigQuery data —
+    total_bytes_billed in one of THREE shapes (added 2026-07-03, widened 2026-07-04):
+    normal (>= processed, 10 MiB per-query minimums), cache-hit/reservation-served
+    (billed=0 with processed>0), or ABSENT entirely (old query-log exports). The
+    absent/zero shapes exist so property tests can reach the processed-fallback and
+    billed-zero branches in the cost model. Always non-empty by default so the
+    utilization curve (avg/P50/P99/peak) is well-defined.
+    """
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    # Per-FILE shape (not per-job): a real export either carries the column or predates
+    # it; the workload analyzer treats mixed files as not-carrying (all-or-nothing).
+    billed_shape = draw(st.sampled_from(["normal", "zero", "absent"]))
+    jobs: list[dict] = []
+    for _ in range(n):
+        creation = draw(st.datetimes(
+            min_value=datetime(2024, 1, 1),
+            max_value=datetime(2025, 12, 31),
+            timezones=st.just(timezone.utc),
+        ))
+        processed = draw(st.integers(min_value=0, max_value=10**13))
+        job = {
+            "total_slot_ms": draw(st.integers(min_value=0, max_value=10**9)),
+            "total_bytes_processed": processed,
+            "creation_time": creation,
+        }
+        if billed_shape == "normal":
+            job["total_bytes_billed"] = draw(st.integers(
+                min_value=processed, max_value=processed + 10 * 1024**2))
+        elif billed_shape == "zero":
+            job["total_bytes_billed"] = 0
+        jobs.append(job)
+    return jobs
+
+
+# ---- Pricing-detection strategies (issue 5.1, R16 / V5) ----
+#
+# pricing_jobs() extends slot_jobs() with the three INFORMATION_SCHEMA.JOBS columns the
+# Pricing Detector classifies on: reservation_id (NULL ⇒ on-demand, non-null ⇒ capacity),
+# edition, and statement_type (SCRIPT parents report NULL reservation_id even under capacity).
+# slot_jobs() is left untouched — the Workload Analyzer tests pin its 3-key shape.
+
+# Edition values must match the keys in V4_EDITION_SLOT_HOUR_USD so a CAPACITY result the
+# detector emits is priceable by the Cost Estimator (R18.2).
+PRICING_EDITIONS = ["STANDARD", "ENTERPRISE", "ENTERPRISE_PLUS"]
+# PricingDetection.commitment_plan vocabulary (models.py).
+COMMITMENT_PLANS = ["FLEX", "MONTHLY", "ANNUAL", "THREE_YEAR"]
+# A non-null reservation_id is a path: ADMIN_PROJECT:LOCATION.RESERVATION_NAME (V5).
+_reservation_path = st.from_regex(
+    r"[a-z0-9-]{1,20}:[a-z-]{2,10}\.[a-z0-9_-]{1,20}", fullmatch=True
+)
+# Non-SCRIPT leaf statement types (jobs that carry a real reservation_id signal).
+_LEAF_STATEMENT_TYPES = ["SELECT", "INSERT", "MERGE", "UPDATE"]
+
+
+@st.composite
+def pricing_jobs(
+    draw: st.DrawFn,
+    *,
+    min_size: int = 1,
+    max_size: int = 30,
+    force: str | None = None,
+) -> list[dict]:
+    """Generate INFORMATION_SCHEMA.JOBS rows carrying the detector's signal (R16, V5).
+
+    Each row is a superset of a slot_jobs() row plus ``reservation_id``, ``edition``, and
+    ``statement_type``. ``force`` pins an arm so a test can request a deterministic shape:
+
+    - ``"ondemand"`` — all leaf jobs, every ``reservation_id`` NULL.
+    - ``"capacity"`` — all leaf jobs, every ``reservation_id`` a non-null path + an edition.
+    - ``"all_script"`` — every row a SCRIPT parent (NULL reservation_id by design).
+    - ``"empty"``     — no jobs at all (the undeterminable / no-signal case).
+    - ``None``        — free mix of SCRIPT parents and on-demand/capacity leaf jobs.
+    """
+    if force == "empty":
+        return []
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    jobs: list[dict] = []
+    for _ in range(n):
+        creation = draw(st.datetimes(
+            min_value=datetime(2024, 1, 1),
+            max_value=datetime(2025, 12, 31),
+            timezones=st.just(timezone.utc),
+        ))
+        is_script = force == "all_script" or (force is None and draw(st.booleans()))
+        if is_script:
+            # SCRIPT parent: NULL reservation_id even under capacity billing (the trap).
+            stmt, resv, edition = "SCRIPT", None, None
+        elif force == "ondemand":
+            stmt, resv, edition = draw(st.sampled_from(_LEAF_STATEMENT_TYPES)), None, None
+        elif force == "capacity":
+            stmt = draw(st.sampled_from(_LEAF_STATEMENT_TYPES))
+            resv = draw(_reservation_path)
+            edition = draw(st.sampled_from(PRICING_EDITIONS))
+        else:  # free leaf job: either billing model
+            stmt = draw(st.sampled_from(_LEAF_STATEMENT_TYPES))
+            if draw(st.booleans()):
+                resv = draw(_reservation_path)
+                edition = draw(st.sampled_from(PRICING_EDITIONS))
+            else:
+                resv, edition = None, None
+        processed = draw(st.integers(min_value=0, max_value=10**13))
+        jobs.append({
+            "total_slot_ms": draw(st.integers(min_value=0, max_value=10**9)),
+            "total_bytes_processed": processed,
+            # Cache hits legitimately bill 0 while processing >0 bytes.
+            "total_bytes_billed": draw(st.one_of(
+                st.just(0),
+                st.integers(min_value=processed, max_value=processed + 10 * 1024**2),
+            )),
+            "creation_time": creation,
+            "reservation_id": resv,
+            "edition": edition,
+            "statement_type": stmt,
+        })
+    return jobs
+
+
+@st.composite
+def reservation_config(draw: st.DrawFn, *, edition: str | None = None) -> dict:
+    """Generate a --reservation-config dict (R1.4): edition + slot/commitment figures.
+
+    Mirrors the manual figures a user supplies from the Slot Estimator or their bill —
+    a confidence rung above auto-detection (R16.2). Pin ``edition`` to force one.
+    """
+    base = draw(st.integers(min_value=0, max_value=10000))
+    return {
+        "edition": edition or draw(st.sampled_from(PRICING_EDITIONS)),
+        "baseline_slots": base,
+        "max_slots": draw(st.integers(min_value=base, max_value=base + 10000)),
+        "commitment_slots": draw(st.integers(min_value=0, max_value=base + 10000)),
+        "commitment_plan": draw(st.sampled_from(COMMITMENT_PLANS)),
+    }
+
+
+@st.composite
+def sql_with_constructs(draw: st.DrawFn) -> tuple[str, list[str]]:
+    """Generate SQL containing >=1 BigQuery-specific construct, with the expected classes.
+
+    Returns (sql_text, expected_construct_classes) so a detector test can assert that
+    every embedded construct is found. Construct snippets are joined into one statement.
+    """
+    classes = draw(st.lists(
+        st.sampled_from(SQL_CONSTRUCT_CLASSES),
+        min_size=1,
+        max_size=len(SQL_CONSTRUCT_CLASSES),
+        unique=True,
+    ))
+    parts = [_CONSTRUCT_SNIPPETS[c] for c in classes]
+    sql = "\n".join(parts)
+    return sql, classes
+
+
+@st.composite
+def cost_line(draw: st.DrawFn) -> m.CostLine:
+    """Generate a CostLine — either a point value or a labelled range, with a source_note."""
+    is_range = draw(st.booleans())
+    if is_range:
+        low = draw(st.floats(min_value=0.0, max_value=50000.0, allow_nan=False, allow_infinity=False))
+        high = draw(st.floats(min_value=low, max_value=low + 50000.0, allow_nan=False, allow_infinity=False))
+        monthly = None
+    else:
+        monthly = draw(st.floats(min_value=0.0, max_value=100000.0, allow_nan=False, allow_infinity=False))
+        low = None
+        high = None
+    return m.CostLine(
+        label=draw(_identifier),
+        monthly=monthly,
+        monthly_low=low,
+        monthly_high=high,
+        confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+        source_note=draw(st.text(min_size=5, max_size=60)),
+    )
+
+
+@st.composite
+def assessment(draw: st.DrawFn) -> m.Assessment:
+    """Generate a valid normative Assessment with a consistent entity/summary graph.
+
+    Effort axis is present only for Tables (None for REBUILT); Query axis may be present
+    for any entity. Summary counts are derived from the generated entities so they agree.
+    """
+    n = draw(st.integers(min_value=0, max_value=8))
+    entities: list[m.EntityReport] = []
+    effort_counts = {"AUTO": 0, "ASSISTED": 0, "MANUAL": 0}
+    complexity_counts = {"PORTABLE": 0, "ADAPT": 0, "REWRITE": 0}
+    total_tables = 0
+    total_size = 0.0
+
+    for _ in range(n):
+        etype = draw(st.sampled_from(ENTITY_TYPES))
+        population = _population_for(etype)
+        dataset = draw(_identifier)
+        ename = draw(_identifier)
+        size_gb = draw(st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False))
+        total_size += size_gb
+
+        # Effort axis — Tables only.
+        if population is m.EntityPopulation.TABLE:
+            total_tables += 1
+            ecat = draw(st.sampled_from(list(m.EffortCategory)))
+            effort_counts[ecat.value] += 1
+            effort = m.EffortResult(
+                category=ecat,
+                score=draw(st.integers(min_value=0, max_value=10)),
+                flags=draw(st.lists(_identifier, max_size=4)),
+                reasoning=draw(st.text(max_size=60)),
+                confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+            )
+            conversion = m.ConversionResult(
+                ddl=f"CREATE TABLE {dataset}.{ename} (id long);",
+                partition_mapping=None,
+                lossy_casts=[],
+                warnings=[],
+                success=True,
+            )
+            load_sync_dml = draw(st.one_of(st.none(), st.text(min_size=5, max_size=40)))
+        else:
+            effort = None
+            conversion = None
+            load_sync_dml = None
+
+        # Query axis — may be present for any entity.
+        ccat = draw(st.sampled_from(list(m.ComplexityCategory)))
+        complexity_counts[ccat.value] += 1
+        complexity = m.ComplexityResult(
+            category=ccat,
+            score=draw(st.integers(min_value=0, max_value=10)),
+            constructs=[],
+            flags=draw(st.lists(_identifier, max_size=4)),
+            reasoning=draw(st.text(max_size=60)),
+            confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+            confidence_source=draw(st.sampled_from(list(m.ConfidenceSource))),
+        )
+        placement = None
+        if population is m.EntityPopulation.REBUILT:
+            placement = m.PlacementRecommendation(
+                home=draw(st.sampled_from(["REDSHIFT", "ICEBERG_CATALOG"])),
+                signals=draw(st.lists(_identifier, min_size=1, max_size=3)),
+                confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+                refresh_unverified=draw(st.booleans()),
+            )
+
+        entities.append(m.EntityReport(
+            full_name=f"{dataset}.{ename}",
+            entity_type=etype,
+            population=population,
+            rows=draw(st.integers(min_value=0, max_value=10**12)) if population is m.EntityPopulation.TABLE else 0,
+            size_gb=size_gb,
+            depends_on=draw(st.lists(_identifier, max_size=4)),
+            effort=effort,
+            conversion=conversion,
+            load_sync_dml=load_sync_dml,
+            complexity=complexity,
+            rewrite_guidance=draw(st.lists(st.text(min_size=1, max_size=40), max_size=3)),
+            placement=placement,
+        ))
+
+    summary = m.AssessmentSummary(
+        total_entities=len(entities),
+        total_tables=total_tables,
+        total_size_gb=round(total_size, 4),
+        effort_counts=effort_counts,
+        complexity_counts=complexity_counts,
+        sql_surface_confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+    )
+
+    bq_monthly = draw(st.floats(min_value=0.0, max_value=100000.0, allow_nan=False, allow_infinity=False))
+    aws_low = draw(st.floats(min_value=0.0, max_value=bq_monthly + 1.0, allow_nan=False, allow_infinity=False))
+    aws_high = draw(st.floats(min_value=aws_low, max_value=aws_low + 50000.0, allow_nan=False, allow_infinity=False))
+    cost = m.CostComparison(
+        bq_pricing_model=draw(st.sampled_from(list(m.BQPricingModel))),
+        bigquery_monthly=bq_monthly,
+        bigquery_breakdown=draw(st.lists(cost_line(), max_size=3)),
+        aws_lines=draw(st.lists(cost_line(), min_size=1, max_size=3)),
+        aws_monthly_low=aws_low,
+        aws_monthly_high=aws_high,
+        monthly_delta_low=bq_monthly - aws_high,
+        monthly_delta_high=bq_monthly - aws_low,
+        annual_savings_low=(bq_monthly - aws_high) * 12,
+        annual_savings_high=(bq_monthly - aws_low) * 12,
+        migration_onetime=draw(st.floats(min_value=0.0, max_value=50000.0, allow_nan=False, allow_infinity=False)),
+        breakeven_months_low=draw(st.one_of(
+            st.floats(min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False),
+            st.just(9999.0),
+        )),
+        breakeven_months_high=draw(st.one_of(
+            st.floats(min_value=0.0, max_value=240.0, allow_nan=False, allow_infinity=False),
+            st.just(9999.0),
+        )),
+        compute_confidence=draw(st.sampled_from(list(m.ConfidenceLevel))),
+    )
+
+    failures = [
+        m.FailureRecord(
+            entity_name=draw(_identifier),
+            stage=draw(st.sampled_from(["scan", "classify", "convert", "detect", "score"])),
+            error=draw(st.text(min_size=5, max_size=60)),
+        )
+        for _ in range(draw(st.integers(min_value=0, max_value=3)))
+    ]
+
+    ts = draw(st.datetimes(
+        min_value=datetime(2020, 1, 1),
+        max_value=datetime(2025, 12, 31),
+        timezones=st.just(timezone.utc),
+    ))
+
+    return m.Assessment(
+        assessment_id=f"assess-{draw(st.from_regex(r'[0-9]{8}', fullmatch=True))}-{draw(st.from_regex(r'[a-f0-9]{6}', fullmatch=True))}",
+        generated_at=ts,
+        project_id=draw(_identifier),
+        summary=summary,
+        cost=cost,
+        entities=entities,
+        failures=failures,
+    )
+
+# ---- Normative-model strategy fixtures (issue #4) ----
+
+@pytest.fixture
+def gen_column_schema():
+    """Fixture providing the column_schema Hypothesis strategy."""
+    return column_schema()
+
+
+@pytest.fixture
+def gen_query_analysis():
+    """Fixture providing the query_analysis Hypothesis strategy."""
+    return query_analysis()
+
+
+@pytest.fixture
+def gen_sql_query_with_literals():
+    """Fixture providing the sql_query_with_literals Hypothesis strategy."""
+    return sql_query_with_literals()
+
+@pytest.fixture
+def gen_entity_metadata():
+    """Fixture providing the entity_metadata Hypothesis strategy."""
+    return entity_metadata()
+
+
+@pytest.fixture
+def gen_slot_jobs():
+    """Fixture providing the slot_jobs Hypothesis strategy."""
+    return slot_jobs()
+
+
+@pytest.fixture
+def gen_pricing_jobs():
+    """Fixture providing the pricing_jobs Hypothesis strategy (issue 5.1)."""
+    return pricing_jobs()
+
+
+@pytest.fixture
+def gen_reservation_config():
+    """Fixture providing the reservation_config Hypothesis strategy (issue 5.1)."""
+    return reservation_config()
+
+
+@pytest.fixture
+def gen_sql_with_constructs():
+    """Fixture providing the sql_with_constructs Hypothesis strategy."""
+    return sql_with_constructs()
+
+
+@pytest.fixture
+def gen_assessment():
+    """Fixture providing the assessment Hypothesis strategy."""
+    return assessment()

--- a/solution-architecture/clis/bq-assess/tests/integration/test_bundle_round_trip.py
+++ b/solution-architecture/clis/bq-assess/tests/integration/test_bundle_round_trip.py
@@ -1,0 +1,222 @@
+# Feature: collector/report split (2026-07-08 design) — anti-drift guarantee
+"""Round-trip equivalence: analyze_and_report on an in-memory Bundle vs. the same
+Bundle after write → load produces the same Assessment (modulo id/timestamp).
+
+This is THE invariant that lets us generate a customer's report from their bundle
+and trust it matches what a direct in-environment run would have produced. It also
+covers spec test 7 (assess-emits-bundle self round-trip): the bundle written by an
+assess run is accepted by `report` and reproduces the Assessment.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+
+import pytest
+
+from bq_assess.bundle import Bundle, BundleLoader, BundleWriter
+from bq_assess.bundle.models import QueryRecord
+from bq_assess.cli import analyze_and_report
+from bq_assess.models import (
+    BQPricingModel,
+    ColumnSchema,
+    ConfidenceLevel,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    FailureRecord,
+    PricingDetection,
+    RoutineMetadata,
+    SlotUtilization,
+    TimePartitionConfig,
+)
+
+
+def _fixture_entities() -> list[EntityMetadata]:
+    """A small project: partitioned table, plain table, view, routine."""
+    ts = datetime(2026, 1, 15, tzinfo=timezone.utc)
+    return [
+        EntityMetadata(
+            entity_id="events", dataset_id="analytics", full_name="analytics.events",
+            entity_type=EntityType.TABLE, population=EntityPopulation.TABLE,
+            num_rows=1_000_000, num_bytes=5 * 1024**3,
+            columns=[
+                ColumnSchema("event_id", "STRING", "REQUIRED", []),
+                ColumnSchema("user_id", "STRING", "NULLABLE", []),
+                ColumnSchema("event_date", "DATE", "NULLABLE", []),
+                ColumnSchema("payload", "RECORD", "NULLABLE", [
+                    ColumnSchema("kind", "STRING", "NULLABLE", []),
+                    ColumnSchema("value", "FLOAT64", "NULLABLE", []),
+                ]),
+            ],
+            time_partitioning=TimePartitionConfig(type="DAY", field="event_date"),
+            range_partitioning=None,
+            clustering_fields=["user_id"],
+            view_query=None, mview_query=None, routine=None,
+            depends_on=[], last_modified=ts, physical_bytes=2 * 1024**3,
+        ),
+        EntityMetadata(
+            entity_id="users", dataset_id="analytics", full_name="analytics.users",
+            entity_type=EntityType.TABLE, population=EntityPopulation.TABLE,
+            num_rows=50_000, num_bytes=256 * 1024**2,
+            columns=[
+                ColumnSchema("user_id", "STRING", "REQUIRED", []),
+                ColumnSchema("signup_date", "DATE", "NULLABLE", []),
+            ],
+            time_partitioning=None, range_partitioning=None, clustering_fields=None,
+            view_query=None, mview_query=None, routine=None,
+            depends_on=[], last_modified=ts, physical_bytes=100 * 1024**2,
+        ),
+        EntityMetadata(
+            entity_id="daily_summary", dataset_id="analytics",
+            full_name="analytics.daily_summary",
+            entity_type=EntityType.VIEW, population=EntityPopulation.REBUILT,
+            num_rows=0, num_bytes=0,
+            columns=[ColumnSchema("day", "DATE", "NULLABLE", [])],
+            time_partitioning=None, range_partitioning=None, clustering_fields=None,
+            view_query=(
+                "SELECT e.event_date AS day, COUNT(*) AS n FROM analytics.events e "
+                "JOIN analytics.users u ON e.user_id = u.user_id GROUP BY 1"
+            ),
+            mview_query=None, routine=None,
+            depends_on=["analytics.events", "analytics.users"],
+            last_modified=ts, physical_bytes=0,
+        ),
+        EntityMetadata(
+            entity_id="clean_str", dataset_id="analytics", full_name="analytics.clean_str",
+            entity_type=EntityType.ROUTINE, population=EntityPopulation.REBUILT,
+            num_rows=0, num_bytes=0, columns=[],
+            time_partitioning=None, range_partitioning=None, clustering_fields=None,
+            view_query=None, mview_query=None,
+            routine=RoutineMetadata(
+                name="clean_str", language="SQL", arguments=["s STRING"],
+                body="TRIM(LOWER(s))", routine_type="SCALAR_FUNCTION",
+            ),
+            depends_on=[], last_modified=ts, physical_bytes=0,
+        ),
+    ]
+
+
+def _fixture_bundle() -> Bundle:
+    return Bundle(
+        project_id="fixture-project",
+        bq_location="australia-southeast1",
+        aws_region="ap-southeast-2",
+        entities=_fixture_entities(),
+        failures=[FailureRecord(entity_name="analytics.broken", stage="scan", error="403")],
+        workload=SlotUtilization(
+            avg_slots=12.0, p50_slots=9.0, p99_slots=45.0, peak_slots=60.0,
+            active_hour_fraction=0.35, total_slot_ms=100_000_000, days_sampled=20,
+            total_bytes_processed=8 * 10**12, total_bytes_billed=7 * 10**12,
+            has_billed_bytes=True, total_queries=3400, lookback_days=30,
+        ),
+        pricing=PricingDetection(
+            model=BQPricingModel.ON_DEMAND,
+            confidence=ConfidenceLevel.HIGH,
+            source_note="fixture",
+        ),
+        rates=None,  # hardcoded region-cascaded rates on both sides — deterministic
+        queries=[
+            QueryRecord(
+                query="SELECT event_id FROM analytics.events WHERE event_date > '?'",
+                total_slot_ms=50_000, total_bytes_processed=10**10,
+                total_bytes_billed=10**10, statement_type="SELECT",
+                creation_time="2026-07-01T10:00:00+00:00",
+            ),
+        ],
+        storage_basis="measured",
+        collector_version="0.3.0",
+        created_at="2026-07-08T00:00:00+00:00",
+    )
+
+
+def _normalize(assessment) -> dict:
+    """Assessment as a dict with the run-specific fields (id, timestamp) removed."""
+    d = dataclasses.asdict(assessment)
+    d.pop("assessment_id")
+    d.pop("generated_at")
+    return d
+
+
+@pytest.fixture()
+def report_params(tmp_path):
+    def _params(subdir: str) -> dict:
+        out = tmp_path / subdir
+        out.mkdir()
+        return {
+            "output": str(out),
+            "format": "json,html",
+            "export_bundle": False,
+            "skip_translation": True,  # deterministic + fast
+        }
+    return _params
+
+
+class TestBundleRoundTripEquivalence:
+    def test_in_memory_vs_written_bundle_same_assessment(self, tmp_path, report_params) -> None:
+        """analyze_and_report(bundle) == analyze_and_report(load(write(bundle)))."""
+        direct = analyze_and_report(_fixture_bundle(), report_params("direct"))
+
+        bundle_dir = BundleWriter().write(_fixture_bundle(), str(tmp_path / "handoff"))
+        loaded = BundleLoader().load(bundle_dir)
+        via_disk = analyze_and_report(loaded, report_params("via-disk"))
+
+        assert _normalize(direct) == _normalize(via_disk)
+
+    def test_assess_emitted_bundle_is_reportable(self, tmp_path, report_params) -> None:
+        """Spec test 7: the bundle an assess run writes (export_bundle=True) loads
+        and reproduces the same Assessment."""
+        params = report_params("assess-run")
+        params["export_bundle"] = True
+        direct = analyze_and_report(_fixture_bundle(), params)
+
+        emitted = str(tmp_path / "assess-run" / "bundle")
+        loaded = BundleLoader().load(emitted)
+        rerun = analyze_and_report(loaded, report_params("rerun"))
+
+        assert _normalize(direct) == _normalize(rerun)
+
+    def test_report_outputs_written(self, tmp_path, report_params) -> None:
+        """The report side writes HTML + 3 JSON files from a loaded bundle."""
+        bundle_dir = BundleWriter().write(_fixture_bundle(), str(tmp_path / "b"))
+        loaded = BundleLoader().load(bundle_dir)
+        params = report_params("out")
+        analyze_and_report(loaded, params)
+
+        out = tmp_path / "out"
+        files = {p.name for p in out.iterdir()}
+        assert any(f.endswith("-assessment.html") for f in files)
+        assert any(f.startswith("assessment-landing-") for f in files)
+        assert any(f.startswith("assessment-effort-") for f in files)
+        assert any(f.startswith("assessment-query-") for f in files)
+
+    def test_html_report_carries_disclaimer(self, tmp_path, report_params) -> None:
+        """Spec test 6: the HTML footer contains the beta/legal block."""
+        params = report_params("disc")
+        analyze_and_report(_fixture_bundle(), params)
+
+        html_files = list((tmp_path / "disc").glob("*-assessment.html"))
+        assert html_files, "no HTML report written"
+        html = html_files[0].read_text(encoding="utf-8")
+        assert "Beta &amp; Disclaimer Notice" in html
+        assert "not a quote, offer, or commitment" in html
+        assert "AS IS" in html
+
+    def test_view_definitions_flow_into_relationships(self, report_params) -> None:
+        """The Stage 6 wiring fix: view JOIN clauses produce relationships, which
+        surface as REBUILT placement signals downstream."""
+        assessment = analyze_and_report(_fixture_bundle(), report_params("rels"))
+
+        view_report = next(
+            e for e in assessment.entities if e.full_name == "analytics.daily_summary"
+        )
+        assert view_report.placement is not None
+
+    def test_region_replay_prices_in_bundle_geography(self, report_params) -> None:
+        """Spec test 5: an australia-southeast1 bundle prices AWS in ap-southeast-2,
+        not the us-east-1 default — region provenance survives the hand-off."""
+        assessment = analyze_and_report(_fixture_bundle(), report_params("region"))
+
+        assert assessment.cost.aws_pricing_region == "ap-southeast-2"
+        assert assessment.cost.bq_pricing_region.lower() == "australia-southeast1"

--- a/solution-architecture/clis/bq-assess/tests/integration/test_large_project_e2e.py
+++ b/solution-architecture/clis/bq-assess/tests/integration/test_large_project_e2e.py
@@ -1,0 +1,427 @@
+"""Component integration stress test: 50,000 entities through scoring + reports.
+
+Simulates a large customer environment (like montu-au-raw-prod with 25k+ entities)
+at double scale to verify the pipeline stages complete without hanging or OOM.
+
+Key regressions this catches:
+- Relationship inference cap (100k hard limit prevents combinatorial explosion)
+- Complexity scoring performance with large relationship graphs
+- Report generation for very large HTML/JSON outputs
+- Cache round-trip at scale
+
+NOTE: This test sequences stages manually (not via the CLI pipeline) to isolate
+component performance from network I/O. It validates that each stage handles 50k
+entities within time bounds, NOT that the CLI wires stages correctly.
+
+A separate smaller test validates the mocked scanner + connection pool path.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud import bigquery
+
+from bq_assess.core.cache import MetadataCache
+from bq_assess.core.relationships import RelationshipInferrer
+from bq_assess.core.scanner import BigQueryScanner
+from bq_assess.core.sql_surface import SQLSurfaceAnalyzer
+from bq_assess.engine.redshift.rewrite import RewriteGuide
+from bq_assess.models import (
+    Assessment,
+    AssessmentSummary,
+    BQPricingModel,
+    ColumnSchema,
+    ComplexityCategory,
+    ComplexityResult,
+    ConfidenceLevel,
+    ConfidenceSource,
+    ConversionResult,
+    CostComparison,
+    CostLine,
+    EntityMetadata,
+    EntityPopulation,
+    EntityReport,
+    EntityType,
+    RoutineMetadata,
+)
+from bq_assess.report.html_writer import HTMLWriter
+from bq_assess.report.json_writer import JSONWriter
+from bq_assess.scoring.complexity import ComplexityScorer
+from bq_assess.scoring.effort import EffortScorer
+from bq_assess.targets.iceberg.converter import IcebergConverter
+
+NUM_TABLES = 49_700
+NUM_VIEWS = 250
+NUM_ROUTINES = 50
+TOTAL_ENTITIES = NUM_TABLES + NUM_VIEWS + NUM_ROUTINES
+NUM_SHARED_ID_COLUMNS = 300
+
+PIPELINE_TIMEOUT_SECONDS = 60
+
+
+@pytest.fixture(scope="module")
+def entities_50k():
+    """Build 50,000 EntityMetadata objects mimicking a large BQ project.
+
+    Tables share overlapping _id columns via a sliding window (10 columns per table,
+    300 total). This produces enough column co-occurrence to trigger the relationship
+    inferrer's combinatorial path and validate that the 100k hard cap holds.
+    """
+    now = datetime.now(timezone.utc)
+    id_columns = [f"entity_{i}_id" for i in range(NUM_SHARED_ID_COLUMNS)]
+
+    tables = []
+    for i in range(NUM_TABLES):
+        start = i % (NUM_SHARED_ID_COLUMNS - 10)
+        cols = [
+            ColumnSchema(name=id_columns[j], field_type="STRING", mode="NULLABLE")
+            for j in range(start, start + 10)
+        ]
+        cols.append(ColumnSchema(name="created_at", field_type="TIMESTAMP", mode="NULLABLE"))
+        tables.append(EntityMetadata(
+            entity_id=f"table_{i}",
+            dataset_id=f"ds_{i // 500}",
+            full_name=f"ds_{i // 500}.table_{i}",
+            entity_type=EntityType.TABLE,
+            population=EntityPopulation.TABLE,
+            num_rows=10_000 + (i * 7 % 1_000_000),
+            num_bytes=1_000_000 + (i * 13 % 100_000_000),
+            columns=cols,
+            time_partitioning=None,
+            range_partitioning=None,
+            clustering_fields=["created_at"] if i % 5 == 0 else None,
+            view_query=None,
+            mview_query=None,
+            routine=None,
+            depends_on=[],
+            last_modified=now,
+        ))
+
+    views = []
+    for i in range(NUM_VIEWS):
+        sql = (
+            f"SELECT t1.entity_{i % 50}_id FROM ds_0.table_{i} t1 "
+            f"JOIN ds_1.table_{i + 500} t2 "
+            f"ON t1.entity_{i % 50}_id = t2.entity_{i % 50}_id "
+            f"WHERE t1.created_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)"
+        )
+        views.append(EntityMetadata(
+            entity_id=f"view_{i}",
+            dataset_id="analytics",
+            full_name=f"analytics.view_{i}",
+            entity_type=EntityType.VIEW,
+            population=EntityPopulation.REBUILT,
+            num_rows=0,
+            num_bytes=0,
+            columns=[ColumnSchema(name="id", field_type="STRING", mode="NULLABLE")],
+            time_partitioning=None,
+            range_partitioning=None,
+            clustering_fields=None,
+            view_query=sql,
+            mview_query=None,
+            routine=None,
+            depends_on=[],
+            last_modified=now,
+        ))
+
+    routines = []
+    for i in range(NUM_ROUTINES):
+        body = (
+            f"BEGIN DECLARE v INT64; "
+            f"SET v = (SELECT COUNT(*) FROM ds_0.table_{i}); "
+            f"EXCEPTION WHEN ERROR THEN SELECT @@error.message; END;"
+        )
+        routines.append(EntityMetadata(
+            entity_id=f"proc_{i}",
+            dataset_id="ops",
+            full_name=f"ops.proc_{i}",
+            entity_type=EntityType.ROUTINE,
+            population=EntityPopulation.REBUILT,
+            num_rows=0,
+            num_bytes=0,
+            columns=[],
+            time_partitioning=None,
+            range_partitioning=None,
+            clustering_fields=None,
+            view_query=None,
+            mview_query=None,
+            routine=RoutineMetadata(
+                name=f"proc_{i}", language="SQL", arguments=[], body=body, routine_type="PROCEDURE"
+            ),
+            depends_on=[],
+            last_modified=now,
+        ))
+
+    return tables + views + routines
+
+
+class TestLargeProjectPipeline:
+    """Component integration: relationships → scoring → translation → reports at 50k scale."""
+
+    def test_entity_count(self, entities_50k):
+        """Fixture produces exactly 50,000 entities."""
+        assert len(entities_50k) == TOTAL_ENTITIES
+
+    def test_relationship_inference_capped(self, entities_50k):
+        """Relationship inference stays under 100k with 300 shared _id columns."""
+        tables = [e for e in entities_50k if e.population == EntityPopulation.TABLE]
+
+        t0 = time.time()
+        result = RelationshipInferrer().infer(tables)
+        elapsed = time.time() - t0
+
+        assert len(result.relationships) <= 100_000
+        assert len(result.relationships) > 0
+        assert elapsed < 5.0, f"Relationship inference took {elapsed:.1f}s (limit: 5s)"
+        assert len(result.likely_join_keys) > 0
+
+    def test_full_pipeline_completes(self, entities_50k, tmp_path):
+        """All pipeline components (scoring, conversion, reports) handle 50k entities under 60s."""
+        t_start = time.time()
+        tables = [e for e in entities_50k if e.population == EntityPopulation.TABLE]
+
+        # Stage 3: SQL surface analysis
+        analyzer = SQLSurfaceAnalyzer()
+        all_constructs = {}
+        for e in entities_50k:
+            sql = e.view_query or e.mview_query or (e.routine.body if e.routine else None)
+            if sql:
+                c = analyzer.detect(sql)
+                if c:
+                    all_constructs[e.full_name] = c
+
+        # Stage 4: Iceberg conversion
+        converter = IcebergConverter()
+        conversions = {}
+        for e in tables:
+            conversions[e.full_name] = converter.convert(e)
+
+        # Stage 5: Effort scoring
+        effort_scorer = EffortScorer()
+        dummy_conv = ConversionResult(
+            ddl="", partition_mapping=None, lossy_casts=[], warnings=[], success=True
+        )
+        efforts = {}
+        for e in tables:
+            efforts[e.full_name] = effort_scorer.score(
+                e, conversions.get(e.full_name, dummy_conv)
+            )
+
+        # Stage 6: Relationship inference
+        rel_result = RelationshipInferrer().infer(tables)
+        assert len(rel_result.relationships) <= 100_000
+
+        # Stage 7: Complexity scoring
+        dep_counts = ComplexityScorer.build_dep_counts(rel_result)
+        complexity_scorer = ComplexityScorer()
+        complexities = {}
+        for e in entities_50k:
+            complexities[e.full_name] = complexity_scorer.score(
+                e, all_constructs.get(e.full_name, []),
+                relationships=None, dep_counts=dep_counts,
+            )
+
+        # Stage 12b: SQL translation
+        rg = RewriteGuide()
+        translation_cache = {}
+        for e in entities_50k:
+            sql = e.view_query or e.mview_query or (e.routine.body if e.routine else None)
+            if sql and sql not in translation_cache:
+                translation_cache[sql] = rg.translate(sql)
+
+        # Stage 14: Report generation
+        reports = []
+        for e in entities_50k:
+            reports.append(EntityReport(
+                full_name=e.full_name,
+                entity_type=e.entity_type,
+                population=e.population,
+                rows=e.num_rows,
+                size_gb=e.num_bytes / (1024 ** 3),
+                depends_on=e.depends_on,
+                effort=efforts.get(e.full_name),
+                conversion=conversions.get(e.full_name),
+                load_sync_dml=None,
+                complexity=complexities.get(e.full_name, ComplexityResult(
+                    category=ComplexityCategory.PORTABLE, score=0, constructs=[],
+                    flags=[], reasoning="", confidence=ConfidenceLevel.MEDIUM,
+                    confidence_source=ConfidenceSource.SCHEMA_ONLY,
+                )),
+                rewrite_guidance=[],
+                physical_bytes=e.physical_bytes,
+            ))
+
+        cost = CostComparison(
+            bq_pricing_model=BQPricingModel.ON_DEMAND,
+            bigquery_monthly=8000.0,
+            bigquery_breakdown=[CostLine(
+                label="On-demand queries", monthly=8000.0,
+                monthly_low=8000.0, monthly_high=8000.0,
+                confidence=ConfidenceLevel.HIGH,
+                source_note="BQ on-demand pricing 2024-06",
+            )],
+            aws_lines=[CostLine(
+                label="Redshift Serverless", monthly=5000.0,
+                monthly_low=4500.0, monthly_high=6000.0,
+                confidence=ConfidenceLevel.MEDIUM,
+                source_note="RS serverless estimate",
+            )],
+            aws_monthly_low=4500.0, aws_monthly_high=6000.0,
+            monthly_delta_low=2000.0, monthly_delta_high=3500.0,
+            annual_savings_low=24000.0, annual_savings_high=42000.0,
+            migration_onetime=75000.0,
+            breakeven_months_low=21.4, breakeven_months_high=37.5,
+            compute_confidence=ConfidenceLevel.MEDIUM,
+        )
+
+        effort_counts = {"AUTO": 0, "ASSISTED": 0, "MANUAL": 0}
+        for r in reports:
+            if r.effort:
+                effort_counts[r.effort.category.value] += 1
+
+        complexity_counts = {"PORTABLE": 0, "ADAPT": 0, "REWRITE": 0}
+        for r in reports:
+            if r.complexity:
+                complexity_counts[r.complexity.category.value] += 1
+
+        assessment = Assessment(
+            assessment_id="stress-50k",
+            generated_at=datetime.now(timezone.utc),
+            project_id="stress-test-50k",
+            summary=AssessmentSummary(
+                total_entities=TOTAL_ENTITIES,
+                total_tables=len(tables),
+                total_size_gb=sum(t.num_bytes for t in tables) / (1024 ** 3),
+                effort_counts=effort_counts,
+                complexity_counts=complexity_counts,
+                sql_surface_confidence=ConfidenceLevel.MEDIUM,
+            ),
+            cost=cost,
+            entities=reports,
+            failures=[],
+        )
+
+        out_dir = str(tmp_path / "reports")
+        os.makedirs(out_dir)
+        html_paths = HTMLWriter().write(assessment, out_dir)
+        json_paths = JSONWriter().write(assessment, out_dir)
+
+        t_total = time.time() - t_start
+
+        # Verify outputs. The HTML must stay browser-loadable at 50k entities —
+        # an upper bound, since the client-side renderer exists to keep the
+        # embedded payload small (shrinking it further is an improvement, not a bug).
+        assert len(html_paths) > 0
+        html_size_mb = os.path.getsize(html_paths[0]) / (1024 * 1024)
+        assert html_size_mb < 100.0, (
+            f"50k-entity report is {html_size_mb:.0f} MB — too large to load in a browser"
+        )
+        # And it must actually carry the entity payload (not silently render empty).
+        with open(html_paths[0], encoding="utf-8") as f:
+            html = f.read()
+        assert 'id="report-data"' in html
+        assert len(json_paths) > 0
+        assert t_total < PIPELINE_TIMEOUT_SECONDS, (
+            f"Full pipeline took {t_total:.1f}s (limit: {PIPELINE_TIMEOUT_SECONDS}s)"
+        )
+
+    def test_cache_round_trip_50k(self, entities_50k, tmp_path):
+        """50k entities survive a cache store/load round-trip."""
+        db_path = str(tmp_path / "stress.db")
+        cache = MetadataCache(db_path=db_path)
+
+        cache.store("stress-test-50k", entities_50k)
+        assert cache.has_cache("stress-test-50k")
+
+        loaded = cache.load("stress-test-50k")
+        assert loaded is not None
+        assert len(loaded) == TOTAL_ENTITIES
+
+        loaded_names = {e.full_name for e in loaded}
+        original_names = {e.full_name for e in entities_50k}
+        assert loaded_names == original_names
+
+
+class TestScannerConnectionPool:
+    """Verify scanner connection pool expansion with mocked client."""
+
+    def test_pool_expanded_to_match_concurrency(self):
+        """Connection pool is sized to concurrency + 10 on client init."""
+        from requests.adapters import HTTPAdapter
+
+        scanner = BigQueryScanner(
+            project_id="test-pool", use_adc=True, max_concurrent_requests=50
+        )
+        client = MagicMock(spec=bigquery.Client)
+        client._http = MagicMock()
+        scanner._client = None
+
+        scanner._expand_connection_pool(client)
+
+        mount_calls = client._http.mount.call_args_list
+        assert len(mount_calls) == 2
+        for call in mount_calls:
+            adapter = call[0][1]
+            assert isinstance(adapter, HTTPAdapter)
+            assert adapter._pool_connections >= 60
+            assert adapter._pool_maxsize >= 60
+
+    def test_scanner_scan_with_mock_client(self):
+        """Scanner with mocked client produces correct entities (small scale)."""
+        scanner = BigQueryScanner(
+            project_id="test-small", use_adc=True, max_concurrent_requests=10
+        )
+        client = MagicMock(spec=bigquery.Client)
+
+        ds = MagicMock(spec=bigquery.dataset.DatasetListItem)
+        ds.dataset_id = "test_ds"
+        client.list_datasets.return_value = [ds]
+
+        def _make_field(name, ftype="STRING"):
+            sf = MagicMock(spec=bigquery.SchemaField)
+            sf.name = name
+            sf.field_type = ftype
+            sf.mode = "NULLABLE"
+            sf.fields = []
+            return sf
+
+        items = []
+        table_objs = {}
+        for i in range(100):
+            item = MagicMock(spec=bigquery.table.TableListItem)
+            item.dataset_id = "test_ds"
+            item.table_id = f"t_{i}"
+            ref = MagicMock(spec=bigquery.TableReference)
+            ref.table_id = f"t_{i}"
+            item.reference = ref
+            items.append(item)
+
+            tbl = MagicMock(spec=bigquery.Table)
+            tbl.table_id = f"t_{i}"
+            tbl.dataset_id = "test_ds"
+            tbl.table_type = "TABLE"
+            tbl.num_rows = 1000
+            tbl.num_bytes = 50000
+            tbl.schema = [_make_field("id"), _make_field("name")]
+            tbl.time_partitioning = None
+            tbl.range_partitioning = None
+            tbl.clustering_fields = None
+            tbl.view_query = None
+            tbl.mview_query = None
+            tbl.modified = datetime(2025, 1, 1, tzinfo=timezone.utc)
+            table_objs[f"t_{i}"] = tbl
+
+        client.list_tables.return_value = items
+        client.get_table.side_effect = lambda ref: table_objs[ref.table_id]
+        client.list_routines.return_value = []
+
+        scanner._client = client
+        entities = list(scanner.scan())
+
+        assert len(entities) == 100
+        assert scanner.failures == []

--- a/solution-architecture/clis/bq-assess/tests/integration/test_phase1_end_to_end.py
+++ b/solution-architecture/clis/bq-assess/tests/integration/test_phase1_end_to_end.py
@@ -1,0 +1,249 @@
+"""Phase 1 checkpoint (issue #12 / 1.7): scan → cache → load round-trip, end to end.
+
+Drives the real ``BigQueryScanner`` (against a mocked BigQuery client) over a fixture
+project containing the four entity kinds the checkpoint names — a plain/range-partitioned
+TABLE, a VIEW, a MATERIALIZED_VIEW, and a JavaScript ROUTINE — then stores the scanned
+``EntityMetadata`` in the real ``MetadataCache`` and loads it back, asserting the full
+ingestion contract survives the round-trip.
+
+No live BigQuery and no live filesystem cache beyond a tmp SQLite file — this is a wiring
+test of scanner + classifier + cache together, not a unit test of any one of them.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud import bigquery
+
+from bq_assess.core.cache import MetadataCache
+from bq_assess.core.scanner import BigQueryScanner
+from bq_assess.models import EntityPopulation, EntityType
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a mock BigQuery client describing one dataset with all four kinds
+# ---------------------------------------------------------------------------
+
+_DATASET = "sample_dataset"
+
+
+def _schema_field(name, field_type="STRING", mode="NULLABLE", fields=()):
+    sf = MagicMock(spec=bigquery.SchemaField)
+    sf.name = name
+    sf.field_type = field_type
+    sf.mode = mode
+    sf.fields = list(fields)
+    return sf
+
+
+def _table_list_item(table_id):
+    item = MagicMock(spec=bigquery.table.TableListItem)
+    item.dataset_id = _DATASET
+    item.table_id = table_id
+    item.reference = MagicMock(spec=bigquery.TableReference)
+    item.reference._key = table_id  # marker so get_table can route
+    return item
+
+
+def _routine_list_item(routine_id):
+    item = MagicMock()
+    item.dataset_id = _DATASET
+    item.routine_id = routine_id
+    item.reference = MagicMock()
+    item.reference._key = routine_id
+    return item
+
+
+def _range_partitioned_table():
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = "orders"
+    tbl.dataset_id = _DATASET
+    tbl.table_type = "TABLE"
+    tbl.num_rows = 1_000_000
+    tbl.num_bytes = 5_000_000
+    tbl.schema = [
+        _schema_field("order_id", "INT64", "REQUIRED"),
+        _schema_field("customer_id", "INT64", "REQUIRED"),
+        _schema_field(
+            "items",
+            "STRUCT",
+            "REPEATED",
+            fields=[_schema_field("sku", "STRING"), _schema_field("qty", "INT64")],
+        ),
+    ]
+    tbl.time_partitioning = None
+    rng = MagicMock()
+    rng.start, rng.end, rng.interval = 0, 1000, 10
+    rp = MagicMock()
+    rp.field = "customer_id"
+    rp.range_ = rng
+    tbl.range_partitioning = rp
+    tbl.clustering_fields = ["customer_id"]
+    tbl.view_query = None
+    tbl.mview_query = None
+    tbl.modified = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return tbl
+
+
+def _view():
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = "active_customers"
+    tbl.dataset_id = _DATASET
+    tbl.table_type = "VIEW"
+    tbl.num_rows = 0
+    tbl.num_bytes = 0
+    tbl.schema = [_schema_field("customer_id", "INT64")]
+    tbl.time_partitioning = None
+    tbl.range_partitioning = None
+    tbl.clustering_fields = None
+    tbl.view_query = f"SELECT customer_id FROM {_DATASET}.orders WHERE active"
+    tbl.mview_query = None
+    tbl.modified = datetime(2025, 1, 2, tzinfo=timezone.utc)
+    return tbl
+
+
+def _materialized_view():
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = "daily_totals"
+    tbl.dataset_id = _DATASET
+    tbl.table_type = "MATERIALIZED_VIEW"
+    tbl.num_rows = 0
+    tbl.num_bytes = 0
+    tbl.schema = [_schema_field("day", "DATE"), _schema_field("total", "FLOAT64")]
+    tbl.time_partitioning = None
+    tbl.range_partitioning = None
+    tbl.clustering_fields = None
+    tbl.view_query = None
+    tbl.mview_query = f"SELECT day, SUM(total) FROM {_DATASET}.orders GROUP BY day"
+    tbl.modified = datetime(2025, 1, 3, tzinfo=timezone.utc)
+    return tbl
+
+
+def _js_routine():
+    r = MagicMock()
+    r.routine_id = "js_normalize"
+    r.language = "JAVASCRIPT"
+    arg = MagicMock()
+    arg.name = "raw"
+    r.arguments = [arg]
+    r.body = "return raw.trim().toLowerCase();"
+    r.type_ = "SCALAR_FUNCTION"
+    r.modified = datetime(2025, 1, 4, tzinfo=timezone.utc)
+    return r
+
+
+@pytest.fixture
+def mock_scanner() -> BigQueryScanner:
+    """A scanner whose mock client returns the four-kind fixture for one dataset."""
+    scanner = BigQueryScanner(project_id="my-project", use_adc=True)
+    client = MagicMock(spec=bigquery.Client)
+
+    ds = MagicMock(spec=bigquery.dataset.DatasetListItem)
+    ds.dataset_id = _DATASET
+    client.list_datasets.return_value = [ds]
+
+    table_items = [_table_list_item("orders"), _table_list_item("active_customers"), _table_list_item("daily_totals")]
+    client.list_tables.return_value = table_items
+
+    tables_by_key = {
+        "orders": _range_partitioned_table(),
+        "active_customers": _view(),
+        "daily_totals": _materialized_view(),
+    }
+    client.get_table.side_effect = lambda ref: tables_by_key[ref._key]
+
+    routine_items = [_routine_list_item("js_normalize")]
+    client.list_routines.return_value = routine_items
+    routines_by_key = {"js_normalize": _js_routine()}
+    client.get_routine.side_effect = lambda ref: routines_by_key[ref._key]
+
+    scanner._client = client
+    return scanner
+
+
+# ---------------------------------------------------------------------------
+# The checkpoint test
+# ---------------------------------------------------------------------------
+
+
+def test_scan_all_four_kinds_then_cache_round_trip(mock_scanner, tmp_path):
+    """End to end: scan view+mview+JS routine+range-partitioned table → cache → back."""
+    scanned = list(mock_scanner.scan())
+
+    # No failures; all four entities present
+    assert mock_scanner.failures == []
+    by_name = {e.full_name: e for e in scanned}
+    assert set(by_name) == {
+        f"{_DATASET}.orders",
+        f"{_DATASET}.active_customers",
+        f"{_DATASET}.daily_totals",
+        f"{_DATASET}.js_normalize",
+    }
+
+    # Each required kind classified correctly
+    orders = by_name[f"{_DATASET}.orders"]
+    view = by_name[f"{_DATASET}.active_customers"]
+    mview = by_name[f"{_DATASET}.daily_totals"]
+    routine = by_name[f"{_DATASET}.js_normalize"]
+
+    assert orders.entity_type is EntityType.TABLE
+    assert orders.population is EntityPopulation.TABLE
+    assert orders.range_partitioning is not None  # R3.8 captured distinctly
+    assert orders.time_partitioning is None
+    assert orders.range_partitioning.field == "customer_id"
+
+    assert view.entity_type is EntityType.VIEW
+    assert view.population is EntityPopulation.REBUILT
+    assert view.view_query is not None
+    assert f"{_DATASET}.orders" in view.depends_on  # best-effort dep (R4.5)
+
+    assert mview.entity_type is EntityType.MATERIALIZED_VIEW
+    assert mview.population is EntityPopulation.REBUILT
+    assert mview.mview_query is not None
+
+    assert routine.entity_type is EntityType.ROUTINE
+    assert routine.population is EntityPopulation.REBUILT
+    assert routine.routine is not None
+    assert routine.routine.language == "JAVASCRIPT"
+
+    # --- Round-trip through the real cache ---
+    db_path = os.path.join(str(tmp_path), "phase1.db")
+    cache = MetadataCache(db_path=db_path)
+    cache.store("my-project", scanned)
+
+    assert cache.has_cache("my-project")
+    loaded = cache.load("my-project")
+    assert loaded is not None
+
+    loaded_by_name = {e.full_name: e for e in loaded}
+    assert set(loaded_by_name) == set(by_name)
+
+    # Structural equivalence on the distinguishing fields of each kind
+    lo = loaded_by_name[f"{_DATASET}.orders"]
+    assert lo.range_partitioning is not None
+    assert lo.range_partitioning.field == "customer_id"
+    assert lo.range_partitioning.interval == 10
+    assert lo.clustering_fields == ["customer_id"]
+    # nested struct/array preserved through scan + cache
+    items_col = next(c for c in lo.columns if c.name == "items")
+    assert items_col.field_type == "STRUCT"
+    assert {f.name for f in items_col.fields} == {"sku", "qty"}
+
+    lv = loaded_by_name[f"{_DATASET}.active_customers"]
+    assert lv.entity_type is EntityType.VIEW
+    assert lv.view_query is not None
+    assert f"{_DATASET}.orders" in lv.depends_on
+
+    lm = loaded_by_name[f"{_DATASET}.daily_totals"]
+    assert lm.entity_type is EntityType.MATERIALIZED_VIEW
+    assert lm.mview_query is not None
+
+    lr = loaded_by_name[f"{_DATASET}.js_normalize"]
+    assert lr.entity_type is EntityType.ROUTINE
+    assert lr.routine is not None
+    assert lr.routine.language == "JAVASCRIPT"
+    assert lr.routine.body == "return raw.trim().toLowerCase();"

--- a/solution-architecture/clis/bq-assess/tests/plugin/fixtures/minimal-single-dataset/README.md
+++ b/solution-architecture/clis/bq-assess/tests/plugin/fixtures/minimal-single-dataset/README.md
@@ -1,0 +1,35 @@
+# Fixture: minimal-single-dataset
+
+## Purpose
+
+This fixture represents a small BigQuery warehouse with a single dataset containing approximately 10 tables. It exercises the happy-path flow through all four skill phases.
+
+## Expected Phase Flow
+
+1. **Preflight** — All environment checks pass (`bq-assess` installed, `gcloud` installed, ADC present). The SA provides `gcp_project: my-project` and `datasets: sample_dataset`.
+2. **Scan** — The CLI executes with `--use-adc --format json,html --output reports/` and exits 0. A JSON report is written to `reports/assessment-*.json`.
+3. **Interpret** — The skill reads the JSON report and produces a summary with a mix of AUTO, REVIEW, and MANUAL complexity categories. It highlights the top MANUAL tables by score and the top tables by size, then points the user to the generated HTML report. Because `query_logs_provided` is `false`, the skill calls out LOW confidence and suggests a follow-up run with `--include-query-logs`.
+
+## Reference Dataset
+
+- **GCP Project:** `my-project`
+- **Dataset:** `sample_dataset`
+- **Table count:** ~10 tables (mix of simple flat tables and complex nested/partitioned tables)
+
+## Expected Outputs
+
+- `reference-report.json` exists and is valid JSON matching the `AssessmentReport` schema
+- An HTML report would also be generated in a real run (not included in this fixture)
+- The Interpret phase summary includes all required fields:
+  - Total tables assessed
+  - Total data size (GB)
+  - AUTO / REVIEW / MANUAL counts
+  - Deployment recommendation (Serverless vs Provisioned)
+  - Optimization confidence level
+  - Estimated annual savings
+  - Top MANUAL tables with complexity flag explanations
+  - Top tables by data size
+
+## Usage
+
+This fixture provides a static `reference-report.json` that can be fed directly to the Interpret phase logic for testing, without running the actual CLI against BigQuery.

--- a/solution-architecture/clis/bq-assess/tests/plugin/fixtures/minimal-single-dataset/reference-report.json
+++ b/solution-architecture/clis/bq-assess/tests/plugin/fixtures/minimal-single-dataset/reference-report.json
@@ -1,0 +1,77 @@
+{
+  "assessment_id": "assess-fixture-minimal",
+  "generated_at": "2026-01-01T00:00:00+00:00",
+  "project_id": "my-project",
+  "summary": {
+    "total_tables": 10,
+    "total_size_gb": 0.025,
+    "auto_count": 5,
+    "review_count": 3,
+    "manual_count": 2
+  },
+  "cost_analysis": {
+    "bigquery_monthly": 0.001,
+    "redshift_monthly": 720.0,
+    "migration_onetime": 500.0,
+    "annual_savings": -8639.99,
+    "breakeven_months": 500.0
+  },
+  "query_logs_provided": false,
+  "optimization_confidence": "LOW",
+  "deployment_recommendation": {
+    "deployment_type": "SERVERLESS",
+    "confidence": "LOW",
+    "reasons": [
+      "Small data volume suits serverless.",
+      "No query logs — recommendation based on data volume only."
+    ],
+    "estimated_monthly_cost": 720.0,
+    "details": {
+      "base_rpu": 8,
+      "estimated_rpu_hours": 1920,
+      "storage_cost": 0.0,
+      "compute_cost": 720.0
+    }
+  },
+  "tables": [
+    {
+      "name": "sample_dataset.events",
+      "rows": 10000,
+      "size_gb": 0.005,
+      "complexity": "MANUAL",
+      "score": 4,
+      "flags": [
+        "deeply_nested_structs",
+        "array_of_struct",
+        "time_partitioning"
+      ],
+      "redshift_ddl": "CREATE TABLE events (event_id BIGINT, user_id BIGINT, event_type VARCHAR(256), event_data SUPER, created_at TIMESTAMP);",
+      "recommendations": {
+        "distkey": "user_id",
+        "distkey_confidence": "LOW",
+        "distkey_source": "naming_convention",
+        "sortkey": null,
+        "sortkey_confidence": "LOW",
+        "sortkey_source": "safe_default"
+      }
+    },
+    {
+      "name": "sample_dataset.users",
+      "rows": 5000,
+      "size_gb": 0.003,
+      "complexity": "AUTO",
+      "score": 0,
+      "flags": [],
+      "redshift_ddl": "CREATE TABLE users (user_id BIGINT, email VARCHAR(256), name VARCHAR(256), created_at TIMESTAMP);",
+      "recommendations": {
+        "distkey": "user_id",
+        "distkey_confidence": "LOW",
+        "distkey_source": "naming_convention",
+        "sortkey": null,
+        "sortkey_confidence": "LOW",
+        "sortkey_source": "safe_default"
+      }
+    }
+  ],
+  "failures": []
+}

--- a/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/README.md
+++ b/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/README.md
@@ -1,0 +1,30 @@
+# Fixture: permission-denied
+
+## Purpose
+
+This fixture simulates the CLI failing with a `bigquery.jobs.listAll` permission error during the Scan phase. It verifies that the skill correctly detects the permission-denied pattern and presents the SA with three remediation options.
+
+## Error Pattern
+
+The Scan phase detects this error by matching two substrings in stderr:
+
+- `AnalyzerError`
+- `bigquery.jobs.listAll`
+
+The simulated CLI error output is in `cli-error-output.txt`.
+
+## Expected Skill Behavior
+
+When this error is detected, the skill should present **three options** (documented in `expected-response.md`):
+
+1. **Grant IAM permission** — Show the exact `gcloud projects add-iam-policy-binding` command to grant `roles/bigquery.resourceViewer`
+2. **Re-run without query logs** — Re-run the CLI with `--no-query-logs`, warning about LOW confidence
+3. **Export logs manually** — The SA exports query logs to a JSON file and passes `--query-logs {path}`
+
+The skill should **not** advance to the Interpret phase. It stays in the Scan phase until the SA chooses an option.
+
+## References
+
+- Scan phase error handling: `references/phases/scan.md` → "Permission Denied" section
+- IAM roles: `references/iam-roles.md` → "With Query Log Analysis" section
+- Requirement 5.3: Three-option permission error handling

--- a/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/cli-error-output.txt
+++ b/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/cli-error-output.txt
@@ -1,0 +1,3 @@
+Error: AnalyzerError: Failed to query INFORMATION_SCHEMA.JOBS: 
+Access Denied: Table INFORMATION_SCHEMA.JOBS: User does not have 
+bigquery.jobs.listAll permission on project my-project.

--- a/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/expected-response.md
+++ b/solution-architecture/clis/bq-assess/tests/plugin/fixtures/permission-denied/expected-response.md
@@ -1,0 +1,47 @@
+# Expected Response: Permission Denied — Missing `bigquery.jobs.listAll`
+
+When the CLI fails with the `bigquery.jobs.listAll` permission error, the skill presents the SA with three options:
+
+---
+
+## Option 1: Grant IAM Permission and Retry
+
+Grant the `roles/bigquery.resourceViewer` role, which includes the `bigquery.jobs.listAll` permission:
+
+```bash
+gcloud projects add-iam-policy-binding my-project \
+  --member="user:{sa_email}" \
+  --role="roles/bigquery.resourceViewer"
+```
+
+> Replace `{sa_email}` with the SA's GCP identity (find it with `gcloud auth list`).
+
+After granting the role, the skill retries the same `bq-assess` command.
+
+---
+
+## Option 2: Re-run Without Query Logs
+
+Re-run the CLI with the `--no-query-logs` flag appended to the original command. This skips query log analysis entirely.
+
+**Warning the skill should surface:** The assessment will run with LOW confidence (heuristic-only scoring). Recommendations for DISTKEY, SORTKEY, and deployment mode will be less accurate without query log data.
+
+---
+
+## Option 3: Export Logs Manually
+
+The SA exports query logs from BigQuery to a local JSON file (via `bq query` or the BigQuery console), then re-runs the CLI with:
+
+```bash
+--query-logs {path_to_exported_logs}
+```
+
+This bypasses the `INFORMATION_SCHEMA.JOBS` API call that requires the missing permission.
+
+---
+
+## Skill Behavior Invariants
+
+- The skill does **not** advance to the Interpret phase after this error.
+- The skill stays in the Scan phase until the SA selects an option.
+- The skill asks: "Which option would you like? (1) Grant the permission, (2) Re-run without query logs, or (3) Export logs manually?"

--- a/solution-architecture/clis/bq-assess/tests/plugin/scoring_parity.py
+++ b/solution-architecture/clis/bq-assess/tests/plugin/scoring_parity.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Verify scoring-rules.md matches scorer.py complexity-point constants.
+
+Parses the complexity flags and point values from both:
+- src/bq_assess/scoring/complexity.py  (source of truth)
+- features/bq-assess/skills/bq-assess/references/scoring-rules.md
+
+Fails if any flag or point value has drifted.
+
+Validates: Requirement 8.5, Property 9
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def parse_scorer_py(path: Path) -> dict[str, int]:
+    """Extract flag -> points mapping from scorer.py.
+
+    Matches the pattern used in ComplexityScorer.score():
+        points += N
+        flags.append("flag_name")
+    """
+    content = path.read_text()
+    # The scorer consistently uses: points += N\n ... flags.append("name")
+    # We match across possible whitespace/comments between the two lines.
+    pattern = r'points\s*\+=\s*(\d+)\s*\n\s*flags\.append\("(\w+)"\)'
+    matches = re.findall(pattern, content)
+
+    flags: dict[str, int] = {}
+    for points_str, flag_name in matches:
+        flags[flag_name] = int(points_str)
+
+    return flags
+
+
+def parse_scoring_rules_md(path: Path) -> dict[str, int]:
+    """Extract flag -> points mapping from scoring-rules.md table rows.
+
+    Matches table rows like:
+        | `deeply_nested_structs` | ... | **+2** |
+        | `array_of_struct`       | ... | +1     |
+    """
+    content = path.read_text()
+    flags: dict[str, int] = {}
+
+    for line in content.splitlines():
+        # Match: | `flag_name` | ... | [**]+N[**] |
+        match = re.search(
+            r"\|\s*`(\w+)`\s*\|.*?\|\s*\*{0,2}\+?(\d+)\*{0,2}\s*\|", line
+        )
+        if match:
+            flag_name = match.group(1)
+            points = int(match.group(2))
+            flags[flag_name] = points
+
+    return flags
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    scorer_path = repo_root / "src" / "bq_assess" / "scoring" / "complexity.py"
+    rules_path = (
+        repo_root
+        / "features"
+        / "bq-assess"
+        / "skills"
+        / "bq-assess"
+        / "references"
+        / "scoring-rules.md"
+    )
+
+    if not scorer_path.exists():
+        print(f"FAIL: scorer.py not found at {scorer_path}")
+        return 1
+    if not rules_path.exists():
+        print(f"FAIL: scoring-rules.md not found at {rules_path}")
+        return 1
+
+    scorer_flags = parse_scorer_py(scorer_path)
+    rules_flags = parse_scoring_rules_md(rules_path)
+
+    if not scorer_flags:
+        print("FAIL: No flags parsed from scorer.py — regex may need updating")
+        return 1
+    if not rules_flags:
+        print("FAIL: No flags parsed from scoring-rules.md — regex may need updating")
+        return 1
+
+    errors = 0
+
+    # Check all scorer flags are documented in scoring-rules.md
+    for flag, points in sorted(scorer_flags.items()):
+        if flag not in rules_flags:
+            print(f"FAIL: Flag '{flag}' in scorer.py but missing from scoring-rules.md")
+            errors += 1
+        elif rules_flags[flag] != points:
+            print(
+                f"FAIL: Flag '{flag}' has {points} points in scorer.py "
+                f"but {rules_flags[flag]} in scoring-rules.md"
+            )
+            errors += 1
+        else:
+            print(f"PASS: {flag} = +{points}")
+
+    # Check for extra flags in scoring-rules.md not in scorer.py
+    for flag in sorted(rules_flags):
+        if flag not in scorer_flags:
+            print(f"FAIL: Flag '{flag}' in scoring-rules.md but not in scorer.py")
+            errors += 1
+
+    print()
+    if errors > 0:
+        print(f"FAILED: {errors} parity error(s)")
+        return 1
+
+    print(f"ALL {len(scorer_flags)} FLAGS MATCH")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/solution-architecture/clis/bq-assess/tests/plugin/smoke.sh
+++ b/solution-architecture/clis/bq-assess/tests/plugin/smoke.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke test: runs bq-assess against the reference dataset with skill-default
+# parameters and verifies the JSON report exists and parses.
+#
+# Requires GCP credentials with read access to the target project. Set
+# BQ_SMOKE_PROJECT and BQ_SMOKE_DATASET to a project/dataset you can read.
+# Validates: Requirement 11.3
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+OUTPUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bq-assess-smoke.XXXXXX")"
+
+cleanup() { rm -rf "$OUTPUT_DIR"; }
+trap cleanup EXIT
+
+echo "=== bq-assess smoke test ==="
+echo "Output dir: $OUTPUT_DIR"
+
+# Run with skill-default parameters (mirrors scan.md defaults)
+bq-assess \
+  --gcp-project "${BQ_SMOKE_PROJECT:?Set BQ_SMOKE_PROJECT to a GCP project you can read}" \
+  --use-adc \
+  --datasets "${BQ_SMOKE_DATASET:?Set BQ_SMOKE_DATASET to a dataset in that project}" \
+  --format json,html \
+  --output "$OUTPUT_DIR"
+
+# Verify JSON report exists
+JSON_REPORT=$(find "$OUTPUT_DIR" -name "assessment-*.json" -type f | head -1)
+
+if [ -z "$JSON_REPORT" ]; then
+  echo "FAIL: No JSON report found in $OUTPUT_DIR"
+  exit 1
+fi
+
+# Verify JSON is parseable
+if ! python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$JSON_REPORT"; then
+  echo "FAIL: JSON report is not valid JSON: $JSON_REPORT"
+  exit 1
+fi
+
+echo "PASS: Smoke test completed. Report: $JSON_REPORT"

--- a/solution-architecture/clis/bq-assess/tests/plugin/structure.sh
+++ b/solution-architecture/clis/bq-assess/tests/plugin/structure.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Structural validation for the bq-assess Claude Code skill plugin.
+# Runs offline — no GCP credentials or Claude Code required.
+#
+# Validates: Requirement 10.5, Requirement 10.4, Property 11
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_HOME="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLUGIN_ROOT="$PLUGIN_HOME/skills/bq-assess"
+ERRORS=0
+fail() { echo "FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+pass() { echo "PASS: $1"; }
+echo "=== bq-assess plugin structural checks ==="
+echo ""
+# ---------- 1. plugin.json is valid JSON ----------
+MANIFEST="$PLUGIN_HOME/.claude-plugin/plugin.json"
+if [ ! -f "$MANIFEST" ]; then
+  fail "plugin.json not found at $MANIFEST"
+else
+  if python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$MANIFEST" 2>/dev/null; then
+    pass "plugin.json is valid JSON"
+  else
+    fail "plugin.json is not valid JSON"
+  fi
+fi
+# ---------- 2. SKILL.md YAML frontmatter ----------
+SKILL_MD="$PLUGIN_ROOT/SKILL.md"
+if [ ! -f "$SKILL_MD" ]; then
+  fail "SKILL.md not found at $SKILL_MD"
+else
+  python3 - "$SKILL_MD" <<'PYEOF' || ERRORS=$((ERRORS + 1))
+import yaml, sys
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+if not content.startswith("---"):
+    print(f"FAIL: SKILL.md does not start with YAML frontmatter")
+    sys.exit(1)
+parts = content.split("---", 2)
+if len(parts) < 3:
+    print(f"FAIL: SKILL.md frontmatter not properly delimited")
+    sys.exit(1)
+fm = yaml.safe_load(parts[1])
+if not isinstance(fm, dict):
+    print(f"FAIL: SKILL.md frontmatter is not a YAML mapping")
+    sys.exit(1)
+missing = [f for f in ("name", "description") if not fm.get(f)]
+if missing:
+    print(f"FAIL: SKILL.md frontmatter missing required fields: {', '.join(missing)}")
+    sys.exit(1)
+print(f"PASS: SKILL.md frontmatter valid (name={fm['name']})")
+PYEOF
+fi
+# ---------- 3. Phase files referenced in state machine exist ----------
+for phase in preflight scan interpret; do
+  PHASE_FILE="$PLUGIN_ROOT/references/phases/${phase}.md"
+  if [ -f "$PHASE_FILE" ]; then
+    pass "Phase file exists: references/phases/${phase}.md"
+  else
+    fail "Phase file missing: references/phases/${phase}.md"
+  fi
+done
+# ---------- 4. Forbidden-string check (Property 11) ----------
+#
+# No file in the plugin tree may reference an internal hostname. There are
+# no exceptions: the public plugin installs from github.com/awslabs/startups.
+echo ""
+echo "Checking for forbidden strings..."
+FORBIDDEN_FOUND=0
+for pattern in "ssh.gitlab.aws.dev" "w.amazon.com"; do
+  HITS=$(grep -r --include="*.md" --include="*.sh" --include="*.yaml" --include="*.yml" --include="*.json" \
+    -l "$pattern" "$PLUGIN_ROOT" "$PLUGIN_HOME/README.md" "$PLUGIN_HOME/docs" 2>/dev/null \
+    || true)
+  if [ -n "$HITS" ]; then
+    for hit in $HITS; do
+      rel="${hit#$PLUGIN_HOME/}"
+      fail "Forbidden string '$pattern' found in $rel"
+      FORBIDDEN_FOUND=1
+    done
+  fi
+done
+if [ "$FORBIDDEN_FOUND" -eq 0 ]; then
+  pass "No forbidden strings in plugin files"
+fi
+# ---------- Summary ----------
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAILED: $ERRORS check(s) failed"
+  exit 1
+else
+  echo "ALL CHECKS PASSED"
+  exit 0
+fi

--- a/solution-architecture/clis/bq-assess/tests/property/__init__.py
+++ b/solution-architecture/clis/bq-assess/tests/property/__init__.py
@@ -1,0 +1,1 @@
+# property tests package

--- a/solution-architecture/clis/bq-assess/tests/property/test_analyzer_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_analyzer_properties.py
@@ -1,0 +1,201 @@
+# Feature: phase1-assessment-tool, Property 15: Query log extraction completeness
+# Feature: phase1-assessment-tool, Property 16: Query text anonymization
+"""Property tests for the QueryAnalyzer.
+
+Validates: Requirements 9.4, 9.5, 14.4
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess.core.analyzer import QueryAnalyzer
+
+from tests.conftest import sql_query_with_literals
+
+# Shared identifier strategy for generating table/column names
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,19}", fullmatch=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_query_log_entries(queries: list[str]) -> list[dict[str, str]]:
+    """Wrap raw SQL strings into the JSON format expected by analyze_from_file."""
+    return [{"query": q} for q in queries]
+
+
+# ---------------------------------------------------------------------------
+# Strategy: generate realistic SQL queries with FROM (and optional JOIN/WHERE)
+# ---------------------------------------------------------------------------
+
+@st.composite
+def _sql_query_with_from(draw: st.DrawFn) -> str:
+    """Generate a SQL query that always has a FROM clause referencing a table.
+
+    Optionally includes JOIN and WHERE clauses so that the analyzer can
+    extract join_patterns and where_columns.
+    """
+    dataset = draw(_identifier)
+    table = draw(_identifier)
+    _col1 = draw(_identifier)
+    _col2 = draw(_identifier)
+
+    base = f"SELECT * FROM {dataset}.{table}"
+
+    include_join = draw(st.booleans())
+    include_where = draw(st.booleans())
+
+    if include_join:
+        join_dataset = draw(_identifier)
+        join_table = draw(_identifier)
+        join_alias = draw(st.from_regex(r"[a-z]{1,4}", fullmatch=True))
+        base_alias = draw(st.from_regex(r"[a-z]{1,4}", fullmatch=True))
+        join_col = draw(_identifier)
+        base += (
+            f" {base_alias}"
+            f" JOIN {join_dataset}.{join_table} {join_alias}"
+            f" ON {base_alias}.{join_col} = {join_alias}.{join_col}"
+        )
+
+    if include_where:
+        where_alias = draw(st.from_regex(r"[a-z]{1,4}", fullmatch=True))
+        where_col = draw(_identifier)
+        base += f" WHERE {where_alias}.{where_col} = 42"
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Property 15: Query log extraction completeness
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(queries=st.lists(_sql_query_with_from(), min_size=1, max_size=5))
+def test_query_log_extraction_completeness(queries: list[str]) -> None:
+    """Property 15: Query log extraction completeness.
+
+    **Validates: Requirements 9.4**
+
+    Non-empty logs produce non-empty table_query_counts, valid where_columns,
+    join_patterns, and correct hub_tables.  The key invariant is that every
+    generated query has a FROM clause, so table_query_counts must be non-empty.
+    The result must also be marked as anonymized.
+    """
+    # Feature: phase1-assessment-tool, Property 15: Query log extraction completeness
+    analyzer = QueryAnalyzer()
+
+    entries = _build_query_log_entries(queries)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False
+    ) as tmp:
+        json.dump(entries, tmp)
+        tmp_path = tmp.name
+
+    try:
+        result = analyzer.analyze_from_file(tmp_path)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    # Every query has a FROM clause → at least one table must be counted
+    assert len(result.table_query_counts) > 0, (
+        "Expected non-empty table_query_counts for queries with FROM clauses"
+    )
+
+    # Structural checks: fields are the correct types
+    assert isinstance(result.where_columns, dict)
+    assert isinstance(result.join_patterns, dict)
+    assert isinstance(result.hub_tables, list)
+
+    # Hub tables must be a subset of known tables (from table_query_counts
+    # or join_patterns keys)
+    known_tables = set(result.table_query_counts.keys())
+    for patterns_list in result.join_patterns.values():
+        for jp in patterns_list:
+            known_tables.add(jp.left_table)
+            known_tables.add(jp.right_table)
+    for hub in result.hub_tables:
+        assert hub in known_tables, (
+            f"Hub table '{hub}' not found in known tables: {known_tables}"
+        )
+
+    # The result must be anonymized
+    assert result.anonymized is True, "Expected anonymized=True"
+
+
+# ---------------------------------------------------------------------------
+# Property 16: Query text anonymization
+# ---------------------------------------------------------------------------
+
+# Regex to find single-quoted string literals (excluding the placeholder '?')
+_REMAINING_STRING_LITERAL_RE = re.compile(r"'(?!\?')[^']*'")
+
+
+@settings(max_examples=100)
+@given(sql=sql_query_with_literals())
+def test_query_text_anonymization(sql: str) -> None:
+    """Property 16: Query text anonymization.
+
+    **Validates: Requirements 9.5, 14.4**
+
+    String and numeric literals are replaced with placeholders.  No original
+    string literal values remain in the anonymized output.
+    """
+    # Feature: phase1-assessment-tool, Property 16: Query text anonymization
+    analyzer = QueryAnalyzer()
+    result = analyzer.anonymize_query(sql)
+
+    # --- String literal check ---
+    # No single-quoted string literals should remain except the placeholder '?'
+    remaining = _REMAINING_STRING_LITERAL_RE.findall(result)
+    assert remaining == [], (
+        f"Found non-placeholder string literals in anonymized output: {remaining}\n"
+        f"Original: {sql}\nAnonymized: {result}"
+    )
+
+    # Extract the original string literal value from the SQL.
+    # The sql_query_with_literals strategy always embeds at least one 'value'.
+    original_strings = re.findall(r"'([^']+)'", sql)
+    for orig in original_strings:
+        # The original literal value (without quotes) should not appear in
+        # the anonymized result — unless it happens to be a substring of a
+        # table/column name (which is extremely unlikely with the strategy).
+        # We check that the *quoted* form is gone.
+        assert f"'{orig}'" not in result, (
+            f"Original string literal '{orig}' still present in anonymized output.\n"
+            f"Original: {sql}\nAnonymized: {result}"
+        )
+
+    # --- Numeric literal check ---
+    # Extract numeric literals from the original SQL.  The strategy places
+    # them after operators (=, >, BETWEEN, AND).  We look for numbers that
+    # appear after such tokens in the original.
+    original_nums = re.findall(
+        r"(?<=[\s=><!(,+\-*/])-?\d+\.?\d*", sql
+    )
+    for num_str in original_nums:
+        # Skip small numbers (0, 1, etc.) that could appear in identifiers
+        try:
+            val = float(num_str)
+        except ValueError:
+            continue
+        if abs(val) <= 1:
+            continue
+        # The exact numeric token should not appear in the same operator
+        # context in the anonymized result.  We verify the specific token
+        # preceded by an operator is replaced.
+        pattern = re.compile(
+            r"(?<=[\s=><!(,+\-*/])" + re.escape(num_str) + r"(?=[\s,);]|$)"
+        )
+        assert not pattern.search(result), (
+            f"Numeric literal '{num_str}' still present in anonymized output.\n"
+            f"Original: {sql}\nAnonymized: {result}"
+        )

--- a/solution-architecture/clis/bq-assess/tests/property/test_cache_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_cache_properties.py
@@ -1,0 +1,121 @@
+# Feature: bq-assess-lakehouse, Property 8: Cache round-trip
+"""Property P8 — cache round-trip (issue #10 / 1.5).
+
+*For any* list of EntityMetadata, store-then-load SHALL yield structurally-equivalent
+entities — including nested columns, BOTH partitionings, view/mview SQL, and routines.
+**Validates: R5.1, R5.4**
+
+Supersedes the interim round-trip added in #9; this is the canonical, fully-asserting P8.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess.core.cache import MetadataCache
+from bq_assess.models import ColumnSchema, EntityMetadata
+
+from tests.conftest import entity_metadata
+
+
+@st.composite
+def unique_entity_list(draw: st.DrawFn) -> list[EntityMetadata]:
+    """EntityMetadata list with unique (dataset_id, entity_id) — the cache primary key."""
+    entities = draw(st.lists(entity_metadata(), min_size=0, max_size=6))
+    seen: set[tuple[str, str]] = set()
+    unique: list[EntityMetadata] = []
+    for e in entities:
+        key = (e.dataset_id, e.entity_id)
+        if key not in seen:
+            seen.add(key)
+            unique.append(e)
+    return unique
+
+
+@settings(max_examples=100)
+@given(entities=unique_entity_list())
+def test_p8_cache_round_trip(entities: list[EntityMetadata]) -> None:
+    """Property 8: store→load yields structurally-equivalent EntityMetadata."""
+    # Feature: bq-assess-lakehouse, Property 8: Cache round-trip
+    db_path = os.path.join(tempfile.mkdtemp(), "p8_cache.db")
+    cache = MetadataCache(db_path=db_path)
+    cache.store("test-project", entities)
+
+    loaded = cache.load("test-project")
+    assert loaded is not None
+    assert len(loaded) == len(entities)
+
+    key = lambda e: (e.dataset_id, e.entity_id)  # noqa: E731
+    for orig, back in zip(sorted(entities, key=key), sorted(loaded, key=key)):
+        _assert_entity_equivalent(orig, back)
+
+
+def _assert_entity_equivalent(orig: EntityMetadata, back: EntityMetadata) -> None:
+    # Scalar identity / classification
+    assert back.entity_id == orig.entity_id
+    assert back.dataset_id == orig.dataset_id
+    assert back.full_name == orig.full_name
+    assert back.entity_type == orig.entity_type
+    assert back.population == orig.population
+    assert back.num_rows == orig.num_rows
+    assert back.num_bytes == orig.num_bytes
+    assert back.last_modified == orig.last_modified
+
+    # Nested columns (recursive, nesting depth preserved)
+    _assert_columns_equal(orig.columns, back.columns)
+
+    # Both partitionings
+    _assert_time_part_equal(orig.time_partitioning, back.time_partitioning)
+    _assert_range_part_equal(orig.range_partitioning, back.range_partitioning)
+    assert back.clustering_fields == orig.clustering_fields
+
+    # SQL surface
+    assert back.view_query == orig.view_query
+    assert back.mview_query == orig.mview_query
+
+    # Routine
+    if orig.routine is None:
+        assert back.routine is None
+    else:
+        assert back.routine is not None
+        assert back.routine.name == orig.routine.name
+        assert back.routine.language == orig.routine.language
+        assert back.routine.arguments == orig.routine.arguments
+        assert back.routine.body == orig.routine.body
+        assert back.routine.routine_type == orig.routine.routine_type
+
+    # Dependency links
+    assert back.depends_on == orig.depends_on
+
+
+def _assert_columns_equal(original: list[ColumnSchema], loaded: list[ColumnSchema]) -> None:
+    assert len(loaded) == len(original)
+    for orig_col, loaded_col in zip(original, loaded):
+        assert loaded_col.name == orig_col.name
+        assert loaded_col.field_type == orig_col.field_type
+        assert loaded_col.mode == orig_col.mode
+        _assert_columns_equal(orig_col.fields, loaded_col.fields)
+
+
+def _assert_time_part_equal(orig, back) -> None:
+    if orig is None:
+        assert back is None
+    else:
+        assert back is not None
+        assert back.type == orig.type
+        assert back.field == orig.field
+
+
+def _assert_range_part_equal(orig, back) -> None:
+    if orig is None:
+        assert back is None
+    else:
+        assert back is not None
+        assert back.field == orig.field
+        assert back.start == orig.start
+        assert back.end == orig.end
+        assert back.interval == orig.interval

--- a/solution-architecture/clis/bq-assess/tests/property/test_cli_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_cli_properties.py
@@ -1,0 +1,106 @@
+# Feature: bq-assess-lakehouse, Phase 7: CLI properties (P1, P2)
+"""Property tests for CLI config (P1, P2).
+
+Property 1 (P1): CLI override precedence
+- For any key, CLI value always wins over config value
+
+Property 2 (P2): Credential mode exclusivity
+- Exactly one credential mode resolves, or both absent is an error state
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings, assume
+import hypothesis.strategies as st
+
+from bq_assess.cli import _merge_config
+
+
+@settings(max_examples=100)
+@given(
+    key=st.sampled_from(["gcp_project", "output", "format", "datasets", "bigquery_monthly_cost"]),
+    cli_val=st.text(min_size=1, max_size=20),
+    config_val=st.text(min_size=1, max_size=20),
+)
+def test_p1_cli_override_precedence(key, cli_val, config_val):
+    """P1: For any key, CLI value always wins over config value."""
+    assume(cli_val != config_val)
+    merged = _merge_config({key: cli_val}, {key: config_val})
+    assert merged[key] == cli_val
+
+
+@settings(max_examples=100)
+@given(
+    has_credentials=st.booleans(),
+    has_adc=st.booleans(),
+)
+def test_p2_credential_mode_exclusivity(has_credentials, has_adc):
+    """P2: Exactly one credential mode resolves, or both absent is an error state.
+
+    Note: The actual validation of XOR happens in _run_pipeline (lines 221-226 in cli.py),
+    not in _merge_config. This property test validates that the merge operation
+    preserves both credential modes when present, allowing the validation to occur later.
+    """
+    params: dict = {}
+    if has_credentials:
+        params["credentials"] = "/path/to/sa.json"
+    if has_adc:
+        params["use_adc"] = True
+
+    # The merge function itself doesn't enforce XOR - it just merges values
+    # The XOR validation happens in _run_pipeline, after the merge
+    merged = _merge_config(params, {})
+
+    # Verify the merge preserves what was passed in
+    if has_credentials:
+        assert merged.get("credentials") == "/path/to/sa.json"
+    if has_adc:
+        assert merged.get("use_adc") is True
+
+    # Verify the merge doesn't introduce credentials when not provided
+    if not has_credentials:
+        assert "credentials" not in merged or merged.get("credentials") is None
+    if not has_adc:
+        assert "use_adc" not in merged or not merged.get("use_adc")
+
+
+@settings(max_examples=100)
+@given(
+    key=st.sampled_from(["gcp_project", "output", "datasets", "query_logs"]),
+    val=st.text(min_size=1, max_size=30),
+)
+def test_p3_none_cli_value_preserves_config(key, val):
+    """P3: When CLI param is None, config value is preserved in merge."""
+    config = {key: val}
+    cli = {key: None}
+    merged = _merge_config(cli, config)
+    # None values should be skipped, so config value should remain
+    assert merged[key] == val
+
+
+@settings(max_examples=100)
+@given(
+    config_keys=st.lists(
+        st.sampled_from(["output", "format", "datasets", "query_log_days"]),
+        min_size=1,
+        max_size=4,
+        unique=True,
+    ),
+    cli_key=st.sampled_from(["gcp_project", "use_adc"]),
+)
+def test_p4_merge_preserves_disjoint_keys(config_keys, cli_key):
+    """P4: Merge preserves all keys from config that are not in CLI params."""
+    # Build config with the selected keys
+    config = {k: f"config-{k}" for k in config_keys}
+    # Build CLI with one different key
+    cli = {cli_key: f"cli-{cli_key}"}
+
+    merged = _merge_config(cli, config)
+
+    # All config keys should be preserved
+    for k in config_keys:
+        assert k in merged
+        assert merged[k] == f"config-{k}"
+
+    # CLI key should be in result
+    assert merged[cli_key] == f"cli-{cli_key}"

--- a/solution-architecture/clis/bq-assess/tests/property/test_config_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_config_properties.py
@@ -1,0 +1,90 @@
+# Feature: phase1-assessment-tool, Property 1: Config file override precedence
+"""Property test: CLI args override config file values for any shared key.
+
+Validates: Requirements 1.4
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
+from bq_assess.cli import _merge_config
+
+# The config keys that _merge_config may encounter (flat dict keys produced by
+# _load_config and passed from the Click CLI layer).
+CONFIG_KEYS = [
+    "gcp_project",
+    "credentials",
+    "use_adc",
+    "datasets",
+    "include_query_logs",
+    "query_logs",
+    "redshift_type",
+    "bigquery_monthly_cost",
+    "output",
+    "format",
+]
+
+# Strategy: a value that could appear in either a config file dict or CLI params.
+_config_value = st.one_of(
+    st.text(min_size=1, max_size=30, alphabet=st.characters(whitelist_categories=("L", "N"))),
+    st.booleans(),
+    st.floats(min_value=0.0, max_value=100000.0, allow_nan=False, allow_infinity=False),
+    st.integers(min_value=0, max_value=100000),
+)
+
+# Strategy: a dict mapping a subset of CONFIG_KEYS to random non-None values.
+_config_dict = st.fixed_dictionaries(
+    {},
+    optional={k: _config_value for k in CONFIG_KEYS},
+)
+
+# Strategy: CLI params dict — values may be None (meaning "not explicitly set").
+_cli_dict = st.fixed_dictionaries(
+    {},
+    optional={k: st.one_of(st.none(), _config_value) for k in CONFIG_KEYS},
+)
+
+
+@settings(max_examples=100)
+@given(cli_params=_cli_dict, config_values=_config_dict)
+def test_cli_args_override_config_file_values(
+    cli_params: dict,
+    config_values: dict,
+) -> None:
+    """Property 1: Config file override precedence.
+
+    **Validates: Requirements 1.4**
+
+    For any YAML config file and any CLI argument that specifies the same
+    configuration key, the resulting configuration value SHALL equal the CLI
+    argument value, not the config file value.
+    """
+    merged = _merge_config(cli_params, config_values)
+
+    # 1) Every CLI param that is not None must appear in the merged result
+    #    with the CLI value (override).
+    for key, value in cli_params.items():
+        if value is not None:
+            assert key in merged, f"CLI key '{key}' missing from merged result"
+            assert merged[key] == value, (
+                f"Key '{key}': expected CLI value {value!r}, got {merged[key]!r}"
+            )
+
+    # 2) Config-only keys (not overridden by CLI) must retain their config value.
+    for key, value in config_values.items():
+        cli_val = cli_params.get(key)
+        if cli_val is None:
+            assert key in merged, f"Config key '{key}' missing from merged result"
+            assert merged[key] == value, (
+                f"Key '{key}': expected config value {value!r}, got {merged[key]!r}"
+            )
+
+    # 3) No extra keys should appear beyond the union of both dicts.
+    expected_keys = set(config_values.keys()) | {
+        k for k, v in cli_params.items() if v is not None
+    }
+    assert set(merged.keys()) == expected_keys, (
+        f"Unexpected keys in merged result: {set(merged.keys()) - expected_keys}"
+    )

--- a/solution-architecture/clis/bq-assess/tests/property/test_converter_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_converter_properties.py
@@ -1,0 +1,397 @@
+"""Property-based tests for the Iceberg Converter (P6, P9, P10, P11, P12).
+
+Feature: bq-assess-lakehouse
+Task: 2.3 TDD properties — conversion
+Requirements: R4.4, R6.1, R6.2, R6.4, R6.6, R7.1-R7.5, R8.1-R8.4, R12.5
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess import models as m
+from bq_assess.targets.iceberg.converter import (
+    CLEAN_TYPE_MAP,
+    IcebergConverter,
+)
+from tests.conftest import entity_metadata
+
+converter = IcebergConverter()
+
+# ---- Helpers ----
+
+CLEAN_SCALAR_TYPES = list(CLEAN_TYPE_MAP.keys())
+
+LOSSY_TYPES = ["GEOGRAPHY", "INTERVAL", "TIME", "JSON", "BIGNUMERIC"]
+
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,9}", fullmatch=True)
+
+
+@st.composite
+def table_entity_clean_types(draw: st.DrawFn) -> m.EntityMetadata:
+    """Generate a TABLE entity whose columns use ONLY cleanly-mapped scalar types."""
+    n_cols = draw(st.integers(min_value=1, max_value=6))
+    columns = []
+    for i in range(n_cols):
+        col_type = draw(st.sampled_from(CLEAN_SCALAR_TYPES))
+        mode = draw(st.sampled_from(["NULLABLE", "REQUIRED"]))
+        columns.append(m.ColumnSchema(
+            name=f"col_{i}", field_type=col_type, mode=mode, fields=[],
+        ))
+
+    ds = draw(_identifier)
+    tbl = draw(_identifier)
+    return m.EntityMetadata(
+        entity_id=tbl, dataset_id=ds, full_name=f"{ds}.{tbl}",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=1000, columns=columns,
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=None, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+
+
+@st.composite
+def table_entity_with_struct(draw: st.DrawFn) -> m.EntityMetadata:
+    """Generate a TABLE with at least one STRUCT or REPEATED STRUCT column."""
+    inner_fields = [
+        m.ColumnSchema(name="x", field_type="STRING", mode="NULLABLE", fields=[]),
+        m.ColumnSchema(name="y", field_type="INT64", mode="NULLABLE", fields=[]),
+    ]
+    struct_col = m.ColumnSchema(
+        name="nested", field_type="STRUCT", mode="NULLABLE", fields=inner_fields,
+    )
+    array_struct_col = m.ColumnSchema(
+        name="items", field_type="STRUCT", mode="REPEATED", fields=inner_fields,
+    )
+    flat_col = m.ColumnSchema(name="id", field_type="INT64", mode="REQUIRED", fields=[])
+
+    columns = [flat_col, struct_col, array_struct_col]
+    ds = draw(_identifier)
+    tbl = draw(_identifier)
+    return m.EntityMetadata(
+        entity_id=tbl, dataset_id=ds, full_name=f"{ds}.{tbl}",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=50, num_bytes=500, columns=columns,
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=None, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+
+
+@st.composite
+def table_entity_with_lossy_col(draw: st.DrawFn) -> m.EntityMetadata:
+    """Generate a TABLE with at least one lossy-type column."""
+    lossy_type = draw(st.sampled_from(LOSSY_TYPES))
+    lossy_col = m.ColumnSchema(
+        name="lossy_field", field_type=lossy_type, mode="NULLABLE", fields=[],
+    )
+    clean_col = m.ColumnSchema(name="id", field_type="INT64", mode="REQUIRED", fields=[])
+
+    ds = draw(_identifier)
+    tbl = draw(_identifier)
+    return m.EntityMetadata(
+        entity_id=tbl, dataset_id=ds, full_name=f"{ds}.{tbl}",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=10, num_bytes=100, columns=[clean_col, lossy_col],
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=None, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+
+
+# =============================================================================
+# Property 6: No CREATE TABLE for rebuilt entities (R4.4, R12.5)
+# =============================================================================
+
+
+# Feature: bq-assess-lakehouse, Property 6: No CREATE TABLE for rebuilt entities
+@settings(max_examples=100)
+@given(entity=entity_metadata(entity_type=m.EntityType.VIEW))
+def test_p6_no_ddl_for_view(entity: m.EntityMetadata):
+    """REBUILT entities (VIEW) get empty DDL and no load/sync DML."""
+    result = converter.convert(entity)
+    assert result.ddl == ""
+    assert result.lossy_casts == []
+    assert result.success is True
+
+
+@settings(max_examples=100)
+@given(entity=entity_metadata(entity_type=m.EntityType.MATERIALIZED_VIEW))
+def test_p6_no_ddl_for_mview(entity: m.EntityMetadata):
+    """REBUILT entities (MATERIALIZED_VIEW) get empty DDL."""
+    result = converter.convert(entity)
+    assert result.ddl == ""
+    assert result.success is True
+
+
+@settings(max_examples=100)
+@given(entity=entity_metadata(entity_type=m.EntityType.ROUTINE))
+def test_p6_no_ddl_for_routine(entity: m.EntityMetadata):
+    """REBUILT entities (ROUTINE) get empty DDL."""
+    result = converter.convert(entity)
+    assert result.ddl == ""
+    assert result.success is True
+
+
+# =============================================================================
+# Property 9: Iceberg DDL round-trip for clean types (R6.1, R6.4, R6.6)
+# =============================================================================
+
+
+# Feature: bq-assess-lakehouse, Property 9: Iceberg DDL round-trip (clean types)
+@settings(max_examples=100)
+@given(entity=table_entity_clean_types())
+def test_p9_clean_types_produce_valid_ddl(entity: m.EntityMetadata):
+    """Tables with only clean types produce valid DDL with all columns present."""
+    result = converter.convert(entity)
+    assert result.success is True
+    assert result.ddl != ""
+    assert "CREATE TABLE" in result.ddl
+    assert entity.full_name in result.ddl
+    # Every column name appears in the DDL
+    for col in entity.columns:
+        assert col.name in result.ddl
+    # No lossy casts for clean-only tables
+    assert result.lossy_casts == []
+    # Nullability: REQUIRED → NOT NULL in DDL
+    for col in entity.columns:
+        if col.mode == "REQUIRED":
+            assert f"{col.name}" in result.ddl
+            # Find the column line and check NOT NULL
+            for line in result.ddl.split("\n"):
+                if col.name in line:
+                    assert "NOT NULL" in line
+                    break
+
+
+# =============================================================================
+# Property 10: Native nesting preservation (R6.2)
+# =============================================================================
+
+
+# Feature: bq-assess-lakehouse, Property 10: Native nesting preservation
+@settings(max_examples=100)
+@given(entity=table_entity_with_struct())
+def test_p10_nesting_preserved(entity: m.EntityMetadata):
+    """STRUCT/ARRAY columns use struct/list in DDL, no flattening or JSON-stringify."""
+    result = converter.convert(entity)
+    assert result.success is True
+    ddl = result.ddl
+
+    # Must contain struct<> syntax (native nesting)
+    assert "struct<" in ddl
+    # Must contain list<struct<>> for REPEATED STRUCT
+    assert "list<struct<" in ddl
+    # Must NOT contain SUPER (that's the old Redshift fallback)
+    assert "SUPER" not in ddl
+    # Must NOT contain flattened column names like "nested_x" or "nested_y"
+    assert "nested_x" not in ddl
+    assert "nested_y" not in ddl
+
+
+@st.composite
+def table_entity_with_required_nested(draw: st.DrawFn) -> m.EntityMetadata:
+    """Generate a TABLE with a STRUCT whose sub-fields have mixed REQUIRED/NULLABLE modes."""
+    n_inner = draw(st.integers(min_value=1, max_value=4))
+    inner_fields = []
+    for i in range(n_inner):
+        mode = draw(st.sampled_from(["NULLABLE", "REQUIRED"]))
+        inner_fields.append(
+            m.ColumnSchema(name=f"f_{i}", field_type="STRING", mode=mode, fields=[])
+        )
+    nesting = draw(st.sampled_from(["NULLABLE", "REPEATED"]))
+    struct_col = m.ColumnSchema(
+        name="nested", field_type="STRUCT", mode=nesting, fields=inner_fields,
+    )
+    ds = draw(_identifier)
+    tbl = draw(_identifier)
+    return m.EntityMetadata(
+        entity_id=tbl, dataset_id=ds, full_name=f"{ds}.{tbl}",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=10, num_bytes=100, columns=[struct_col],
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=None, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+
+
+# Feature: bq-assess-lakehouse, Property 10b: Nested-field nullability honored (R6.4)
+@settings(max_examples=100)
+@given(entity=table_entity_with_required_nested())
+def test_p10_nested_required_fields_marked_not_null(entity: m.EntityMetadata):
+    """Each REQUIRED sub-field of a STRUCT renders NOT NULL; NULLABLE ones do not (R6.4)."""
+    result = converter.convert(entity)
+    assert result.success is True
+    ddl = result.ddl
+    inner_fields = entity.columns[0].fields
+    for f in inner_fields:
+        if f.mode == "REQUIRED":
+            assert f"{f.name}: string NOT NULL" in ddl, (
+                f"REQUIRED nested field '{f.name}' missing NOT NULL in DDL: {ddl}"
+            )
+        else:
+            assert f"{f.name}: string NOT NULL" not in ddl, (
+                f"NULLABLE nested field '{f.name}' wrongly marked NOT NULL in DDL: {ddl}"
+            )
+
+
+# =============================================================================
+# Property 11: Lossy casts are never silent (R8.1, R8.2, R8.3, R8.4)
+# =============================================================================
+
+
+# Feature: bq-assess-lakehouse, Property 11: Lossy casts are never silent
+@settings(max_examples=100)
+@given(entity=table_entity_with_lossy_col())
+def test_p11_lossy_casts_never_silent(entity: m.EntityMetadata):
+    """Every lossy-type column produces a LossyCast warning, never maps silently."""
+    result = converter.convert(entity)
+    assert result.success is True
+
+    # Find lossy columns in the input
+    lossy_col_names = [
+        col.name for col in entity.columns
+        if col.field_type.upper() in LOSSY_TYPES
+    ]
+    assert len(lossy_col_names) > 0
+
+    # Every lossy column must have a corresponding LossyCast entry
+    lossy_cast_cols = [lc.column for lc in result.lossy_casts]
+    for col_name in lossy_col_names:
+        assert col_name in lossy_cast_cols, (
+            f"Column '{col_name}' is lossy but has no LossyCast warning"
+        )
+
+    # Each LossyCast has meaningful fields
+    for lc in result.lossy_casts:
+        assert lc.source_type != ""
+        assert lc.iceberg_type != ""
+        assert lc.loss_description != ""
+
+
+@settings(max_examples=50)
+@given(
+    unknown_type=st.from_regex(r"[A-Z]{4,10}", fullmatch=True).filter(
+        lambda t: t not in CLEAN_TYPE_MAP and t not in LOSSY_TYPES
+        and t not in ("STRUCT", "RECORD", "ARRAY")
+    )
+)
+def test_p11_unknown_type_is_lossy(unknown_type: str):
+    """Unknown types get a string fallback AND a lossy_cast warning (R8.4)."""
+    entity = m.EntityMetadata(
+        entity_id="t", dataset_id="d", full_name="d.t",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=1, num_bytes=1,
+        columns=[m.ColumnSchema(name="unk", field_type=unknown_type, mode="NULLABLE", fields=[])],
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=None, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+    result = converter.convert(entity)
+    assert result.success is True
+    assert len(result.lossy_casts) == 1
+    assert result.lossy_casts[0].column == "unk"
+    assert result.lossy_casts[0].iceberg_type == "string"
+    assert unknown_type in result.lossy_casts[0].loss_description
+
+
+# =============================================================================
+# Property 12: Partition mapping clean-vs-flagged (R7.1-R7.5, R9.2)
+# =============================================================================
+
+
+# Feature: bq-assess-lakehouse, Property 12: Partition mapping clean-vs-flagged
+@settings(max_examples=100)
+@given(
+    part_type=st.sampled_from(["DAY", "HOUR", "MONTH", "YEAR"]),
+    field_name=_identifier,
+)
+def test_p12_explicit_time_partition_is_clean(part_type: str, field_name: str):
+    """Explicit-field time partition → auto_derived=True, no decision flags."""
+    entity = m.EntityMetadata(
+        entity_id="t", dataset_id="d", full_name="d.t",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=1000,
+        columns=[m.ColumnSchema(name=field_name, field_type="TIMESTAMP", mode="NULLABLE", fields=[])],
+        time_partitioning=m.TimePartitionConfig(type=part_type, field=field_name),
+        range_partitioning=None, clustering_fields=None,
+        view_query=None, mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+    result = converter.convert(entity)
+    assert result.partition_mapping is not None
+    assert result.partition_mapping.auto_derived is True
+    assert result.partition_mapping.decision_flags == []
+    # Transform uses the correct function
+    expected_transform = f"{part_type.lower()}({field_name})"
+    assert expected_transform in result.partition_mapping.iceberg_transforms
+
+
+@settings(max_examples=50)
+@given(data=st.data())
+def test_p12_ingestion_time_partition_is_flagged(data):
+    """Ingestion-time partition (field=None) → auto_derived=False + decision flag."""
+    entity = m.EntityMetadata(
+        entity_id="t", dataset_id="d", full_name="d.t",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=1000,
+        columns=[m.ColumnSchema(name="ts", field_type="TIMESTAMP", mode="NULLABLE", fields=[])],
+        time_partitioning=m.TimePartitionConfig(type="DAY", field=None),
+        range_partitioning=None, clustering_fields=None,
+        view_query=None, mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+    result = converter.convert(entity)
+    assert result.partition_mapping is not None
+    assert result.partition_mapping.auto_derived is False
+    assert len(result.partition_mapping.decision_flags) > 0
+    assert any("ingestion" in f.lower() for f in result.partition_mapping.decision_flags)
+
+
+@settings(max_examples=50)
+@given(data=st.data())
+def test_p12_range_partition_is_flagged(data):
+    """Range partition → auto_derived=False + decision flag."""
+    entity = m.EntityMetadata(
+        entity_id="t", dataset_id="d", full_name="d.t",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=1000,
+        columns=[m.ColumnSchema(name="val", field_type="INT64", mode="NULLABLE", fields=[])],
+        time_partitioning=None,
+        range_partitioning=m.RangePartitionConfig(field="val", start=0, end=1000, interval=10),
+        clustering_fields=None,
+        view_query=None, mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+    result = converter.convert(entity)
+    assert result.partition_mapping is not None
+    assert result.partition_mapping.auto_derived is False
+    assert len(result.partition_mapping.decision_flags) > 0
+    assert any("range" in f.lower() for f in result.partition_mapping.decision_flags)
+
+
+@settings(max_examples=50)
+@given(fields=st.lists(_identifier, min_size=1, max_size=4, unique=True))
+def test_p12_clustering_becomes_sort_order(fields: list[str]):
+    """Clustering fields → sort order, auto_derived stays True (clean, R7.2)."""
+    columns = [
+        m.ColumnSchema(name=f, field_type="STRING", mode="NULLABLE", fields=[])
+        for f in fields
+    ]
+    entity = m.EntityMetadata(
+        entity_id="t", dataset_id="d", full_name="d.t",
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=1000, columns=columns,
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=fields,
+        view_query=None, mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime.now(tz=timezone.utc),
+    )
+    result = converter.convert(entity)
+    assert result.partition_mapping is not None
+    assert result.partition_mapping.sort_order == fields
+    assert result.partition_mapping.auto_derived is True

--- a/solution-architecture/clis/bq-assess/tests/property/test_cost_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_cost_properties.py
@@ -1,0 +1,162 @@
+# Feature: bq-assess-lakehouse, Property 22: Cost decoupling & range-without-data
+# Feature: bq-assess-lakehouse, Property 23: Cost internal consistency
+"""Property-based tests for the lakehouse Cost Estimator (issue 5.3 / 5.4).
+
+Realizes the design.md cost-comparison properties:
+
+- **P22** cost decoupling & range-without-data — Validates R18.1, R18.3, R18.4, R18.5, R18.6
+- **P23** cost internal consistency + provenance — Validates R18.2, R18.5, R18.7
+
+CRITICAL: these tests drive ``CostEstimator.estimate()`` over GENERATED INPUTS (entities +
+PricingDetection + SlotUtilization). They do NOT assert the conftest ``assessment()`` generator
+against itself — a CostComparison built by the generator already bakes in the P23 identities, so
+testing it would exercise zero production code. The whole point is to test the estimator.
+"""
+
+from __future__ import annotations
+
+import hypothesis.strategies as st
+
+from bq_assess.engine.redshift import cost_constants as k
+from hypothesis import given, settings
+
+from bq_assess.engine.redshift.cost import CostEstimator
+from bq_assess.models import (
+    BQPricingModel,
+    ConfidenceLevel,
+    CostComparison,
+    EntityPopulation,
+    EntityReport,
+    EntityType,
+    PricingDetection,
+    SlotUtilization,
+)
+
+_EDITIONS = ["STANDARD", "ENTERPRISE", "ENTERPRISE_PLUS"]
+_PLANS = ["FLEX", "MONTHLY", "ANNUAL", "THREE_YEAR"]
+
+
+@st.composite
+def _entities(draw):
+    n = draw(st.integers(min_value=0, max_value=8))
+    entities = []
+    for i in range(n):
+        size_gb = draw(st.floats(min_value=0.0, max_value=1e5, allow_nan=False, allow_infinity=False))
+        entities.append(EntityReport(
+            full_name=f"ds.t{i}", entity_type=EntityType.TABLE,
+            population=EntityPopulation.TABLE, rows=draw(st.integers(0, 10**9)),
+            size_gb=size_gb,
+            depends_on=[], effort=None, conversion=None, load_sync_dml=None,
+            complexity=None, rewrite_guidance=[], placement=None,
+        ))
+    return entities
+
+
+@st.composite
+def _pricing(draw):
+    model = draw(st.sampled_from(list(BQPricingModel)))
+    if model is BQPricingModel.CAPACITY:
+        base = draw(st.integers(0, 5000))
+        return PricingDetection(
+            model=model, confidence=ConfidenceLevel.HIGH, source_note="gen",
+            edition=draw(st.sampled_from(_EDITIONS)), baseline_slots=base,
+            max_slots=draw(st.integers(base, base + 5000)),
+            commitment_slots=draw(st.one_of(st.none(), st.integers(0, 5000))),
+            commitment_plan=draw(st.sampled_from(_PLANS)),
+        )
+    return PricingDetection(model=model, confidence=ConfidenceLevel.HIGH, source_note="gen")
+
+
+@st.composite
+def _slots_or_none(draw):
+    if draw(st.booleans()):
+        return None
+    return SlotUtilization(
+        avg_slots=draw(st.floats(0.0, 100.0, allow_nan=False)),
+        p50_slots=draw(st.floats(0.0, 100.0, allow_nan=False)),
+        p99_slots=draw(st.floats(0.0, 200.0, allow_nan=False)),
+        peak_slots=draw(st.floats(0.0, 500.0, allow_nan=False)),
+        active_hour_fraction=draw(st.floats(0.0, 1.0, allow_nan=False)),
+        total_slot_ms=draw(st.integers(0, 10**13)),
+        days_sampled=draw(st.integers(1, 60)),
+    )
+
+
+def _estimate(entities, pricing, slots, override=None, effort=10.0):
+    return CostEstimator(skip_live_pricing=True).estimate(entities, pricing, slots, override, effort)
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none())
+def test_p22_aws_is_storage_plus_compute_no_nodes(entities, pricing, slots) -> None:
+    """P22(a): AWS is exactly storage + compute, with zero node references anywhere (R18.1/R18.6)."""
+    r = _estimate(entities, pricing, slots)
+    assert isinstance(r, CostComparison)
+    assert len(r.aws_lines) >= 2
+    blob = " ".join(line.label + " " + line.source_note
+                    for line in r.aws_lines + r.bigquery_breakdown).lower()
+    for banned in ("node", "ra3", "xlplus", "provisioned", "deploymentadvisor"):
+        assert banned not in blob
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing())
+def test_p22_range_without_data(entities, pricing) -> None:
+    """P22(b): with no slots the compute line is a range (low<high) at LOW, never a point (R18.4)."""
+    r = _estimate(entities, pricing, slots=None)
+    compute = next(line for line in r.aws_lines if "compute" in line.label.lower())
+    assert compute.monthly is None
+    assert compute.monthly_low < compute.monthly_high
+    assert compute.confidence is ConfidenceLevel.LOW
+    assert r.compute_confidence is ConfidenceLevel.LOW
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none(),
+       effort=st.floats(0.0, 1000.0, allow_nan=False))
+def test_p22_breakeven_from_effort_not_count(entities, pricing, slots, effort) -> None:
+    """P22(d): migration_onetime tracks aggregate effort, independent of entity count (R18.5)."""
+    r = _estimate(entities, pricing, slots, effort=effort)
+    # Same effort, different entity count → same one-time cost.
+    r2 = _estimate(entities + list(entities), pricing, slots, effort=effort)
+    assert r.migration_onetime == r2.migration_onetime
+
+
+@settings(max_examples=300)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none())
+def test_p23_delta_and_annual_identities(entities, pricing, slots) -> None:
+    """P23: the bound-crossed delta + annual identities hold for every estimate (R18.5)."""
+    r = _estimate(entities, pricing, slots)
+    assert r.monthly_delta_low == r.bigquery_monthly - r.aws_monthly_high
+    assert r.monthly_delta_high == r.bigquery_monthly - r.aws_monthly_low
+    assert r.annual_savings_low == r.monthly_delta_low * 12
+    assert r.annual_savings_high == r.monthly_delta_high * 12
+    # bound ordering: low <= high (aws_low <= aws_high ⇒ delta_low <= delta_high)
+    assert r.monthly_delta_low <= r.monthly_delta_high
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none(),
+       override=st.floats(0.0, 1e6, allow_nan=False))
+def test_p23_override_sets_bigquery_monthly(entities, pricing, slots, override) -> None:
+    """P23: a supplied --bigquery-monthly-cost override sets bigquery_monthly exactly (R18.2)."""
+    r = _estimate(entities, pricing, slots, override=override)
+    assert r.bigquery_monthly == override
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none())
+def test_p23_every_line_has_source_note(entities, pricing, slots) -> None:
+    """P23 / R18.7: every emitted CostLine carries a non-empty source_note."""
+    r = _estimate(entities, pricing, slots)
+    for line in r.aws_lines + r.bigquery_breakdown:
+        assert line.source_note
+
+
+@settings(max_examples=200)
+@given(entities=_entities(), pricing=_pricing(), slots=_slots_or_none())
+def test_p22_breakeven_never_iff_no_savings(entities, pricing, slots) -> None:
+    """P22: break-even = BREAKEVEN_NEVER only when the matching delta is non-positive (R18.5)."""
+    r = _estimate(entities, pricing, slots)
+    assert (r.breakeven_months_low == k.BREAKEVEN_NEVER) == (r.monthly_delta_low <= 0)
+    assert (r.breakeven_months_high == k.BREAKEVEN_NEVER) == (r.monthly_delta_high <= 0)

--- a/solution-architecture/clis/bq-assess/tests/property/test_placement_relationships_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_placement_relationships_properties.py
@@ -1,0 +1,146 @@
+# Feature: bq-assess-lakehouse, Property 18: Placement rules
+# Feature: bq-assess-lakehouse, Property 19: Relationship inference & confidence; no distribution keys
+"""Property tests P18 (placement) and P19 (relationships).
+
+- **P18** — UDF→REDSHIFT (JS flagged); view/MV home ∈ {REDSHIFT, ICEBERG_CATALOG} with
+  non-empty signals and NOT a single blanket constant; Iceberg-MV → refresh_unverified.
+  Validates R14.1-R14.4.
+- **P19** — `_id` cols in >3 Tables → join keys; views w/ JOINs → ≥1 relationship; each
+  relationship has confidence+source; NO DISTKEY/SORTKEY recommendation anywhere.
+  Validates R15.1-R15.5.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess.core.relationships import RelationshipInferrer
+from bq_assess.engine.redshift.placement import PlacementAdvisor
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    RoutineMetadata,
+)
+
+_ID = st.from_regex(r"[a-z][a-z0-9_]{0,8}", fullmatch=True)
+
+
+def _table(dataset, name, columns):
+    return EntityMetadata(
+        entity_id=name, dataset_id=dataset, full_name=f"{dataset}.{name}",
+        entity_type=EntityType.TABLE, population=EntityPopulation.TABLE,
+        num_rows=1, num_bytes=1, columns=columns,
+        time_partitioning=None, range_partitioning=None,
+        clustering_fields=["created_at"], view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# P18: Placement rules — R14.1-R14.4
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    n_single=st.integers(min_value=1, max_value=5),
+    n_multi=st.integers(min_value=1, max_value=5),
+)
+def test_p18_placement_no_blanket_default(n_single, n_multi):
+    """View/MV home ∈ {REDSHIFT, ICEBERG_CATALOG}, signal-driven, NOT a blanket constant
+    (R14.2): single-dataset views → REDSHIFT (engine-local); multi-dataset views →
+    ICEBERG_CATALOG (open multi-engine). Across a mix, both homes appear."""
+    # Feature: bq-assess-lakehouse, Property 18: Placement rules
+    advisor = PlacementAdvisor()
+
+    def _view(i, deps):
+        return EntityMetadata(
+            entity_id=f"v{i}", dataset_id="ds0", full_name=f"ds0.v{i}",
+            entity_type=EntityType.VIEW, population=EntityPopulation.REBUILT,
+            num_rows=0, num_bytes=0,
+            columns=[ColumnSchema(name="c", field_type="INT64", mode="NULLABLE")],
+            time_partitioning=None, range_partitioning=None, clustering_fields=None,
+            view_query="SELECT c FROM ...", mview_query=None, routine=None,
+            depends_on=deps, last_modified=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+    homes = set()
+    for i in range(n_single):
+        rec = advisor.recommend(_view(("s", i), [f"ds0.t{i}"]), has_logs=False)
+        assert rec is not None and rec.home == "REDSHIFT"  # single-dataset → engine-local
+        assert rec.signals
+        homes.add(rec.home)
+    for i in range(n_multi):
+        rec = advisor.recommend(_view(("m", i), [f"ds{i}.a", f"ds{i+1}.b"]), has_logs=False)
+        assert rec is not None and rec.home == "ICEBERG_CATALOG"  # multi-dataset → open catalog
+        assert rec.signals
+        homes.add(rec.home)
+
+    # Both homes produced across the mix — not a blanket default (R14.2).
+    assert homes == {"REDSHIFT", "ICEBERG_CATALOG"}
+
+
+@settings(max_examples=50)
+@given(st.data())
+def test_p18_udf_always_redshift(data):
+    """Every UDF → REDSHIFT; a JavaScript UDF is flagged for Python/Lambda rewrite (R14.1)."""
+    # Feature: bq-assess-lakehouse, Property 18: Placement rules
+    lang = data.draw(st.sampled_from(["JAVASCRIPT", "SQL"]))
+    udf = EntityMetadata(
+        entity_id="fn", dataset_id="d", full_name="d.fn",
+        entity_type=EntityType.ROUTINE, population=EntityPopulation.REBUILT,
+        num_rows=0, num_bytes=0, columns=[],
+        time_partitioning=None, range_partitioning=None, clustering_fields=None,
+        view_query=None, mview_query=None,
+        routine=RoutineMetadata(name="fn", language=lang, arguments=[], body="x", routine_type="SCALAR_FUNCTION"),
+        depends_on=[], last_modified=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    rec = PlacementAdvisor().recommend(udf)
+    assert rec is not None and rec.home == "REDSHIFT"
+    if lang == "JAVASCRIPT":
+        assert any("javascript" in s.lower() or "lambda" in s.lower() or "python" in s.lower()
+                   for s in rec.signals), "JS UDF must be flagged for Python/Lambda rewrite"
+
+
+# ---------------------------------------------------------------------------
+# P19: Relationship inference & no distribution keys — R15.1-R15.5
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    id_col=_ID.map(lambda s: s + "_id"),
+    n_tables=st.integers(min_value=4, max_value=7),
+)
+def test_p19_id_columns_in_many_tables_are_join_keys(id_col, n_tables):
+    """An `_id` column appearing in >3 Tables appears in likely_join_keys (R15.1)."""
+    # Feature: bq-assess-lakehouse, Property 19: Relationship inference & confidence; no distribution keys
+    tables = [
+        _table("d", f"t{i}", [ColumnSchema(name=id_col, field_type="INT64", mode="NULLABLE")])
+        for i in range(n_tables)
+    ]
+    result = RelationshipInferrer().infer(tables)
+    assert id_col in result.likely_join_keys
+    # Every relationship carries a non-null confidence + source
+    for r in result.relationships:
+        assert r.confidence is not None
+        assert r.source
+
+
+@settings(max_examples=50)
+@given(st.data())
+def test_p19_no_distribution_key_recommendations(data):
+    """No output field SHALL contain a DISTKEY or SORTKEY recommendation (R15.5 — the
+    lakehouse pivot removed distribution keys; the Query Engine is Serverless over Iceberg)."""
+    # Feature: bq-assess-lakehouse, Property 19: Relationship inference & confidence; no distribution keys
+    n = data.draw(st.integers(min_value=1, max_value=5))
+    tables = [_table("d", f"t{i}", [ColumnSchema(name="x_id", field_type="INT64", mode="NULLABLE")]) for i in range(n)]
+    result = RelationshipInferrer().infer(tables)
+    # The result object must not expose distkey/sortkey recommendation fields.
+    forbidden = [f for f in vars(result) if "distkey" in f.lower() or "sortkey" in f.lower()]
+    assert not forbidden, f"R15.5 forbids distribution-key fields, found: {forbidden}"

--- a/solution-architecture/clis/bq-assess/tests/property/test_pricing_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_pricing_properties.py
@@ -1,0 +1,111 @@
+# Feature: bq-assess-lakehouse, Property 20: Pricing model honesty
+"""Property-based test for the Pricing Detector (issue 5.1 / 5.4).
+
+Realizes the design.md correctness property for pricing detection:
+
+- **P20** pricing model honesty — Validates R16.1, R16.2, R16.3, R16.4
+
+*For any* Source: a reachable/supplied reservation config → CAPACITY with recorded figures;
+an undeterminable Source → ON_DEMAND at LOW confidence (never silently assumed, never the bare
+UNKNOWN enum). The single property test the design test-map names is ``test_pricing_properties``.
+
+Inputs come from the ``pricing_jobs`` / ``reservation_config`` strategies (conftest). A tiny
+fake client returns the generated rows; the detector never touches a live BigQuery client here.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+
+from bq_assess.core.pricing import PricingDetector
+from bq_assess.models import BQPricingModel, ConfidenceLevel, PricingDetection
+from tests.conftest import pricing_jobs, reservation_config
+
+
+class _FakeClient:
+    """Returns canned JOBS rows for any query (no live BigQuery in property tests)."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def query(self, sql: str, *args, **kwargs):
+        rows = self._rows
+
+        class _Job:
+            def result(self_):
+                return iter(rows)
+
+        return _Job()
+
+
+def _detect(rows, reservation_config=None) -> PricingDetection:
+    return PricingDetector().detect(_FakeClient(rows), "proj", reservation_config)
+
+
+def _assert_universal_honesty(result: PricingDetection) -> None:
+    """Invariants that hold for EVERY detect() result, regardless of input (R16.3 / P20)."""
+    assert isinstance(result, PricingDetection)
+    # Never the bare UNKNOWN enum externally — undeterminable collapses to ON_DEMAND/LOW.
+    assert result.model is not BQPricingModel.UNKNOWN
+    assert result.model in (BQPricingModel.ON_DEMAND, BQPricingModel.CAPACITY)
+    assert isinstance(result.confidence, ConfidenceLevel)
+    # Provenance is always recorded (R18.7 / R19.2).
+    assert result.source_note
+    # Capacity figures appear only on a CAPACITY result.
+    if result.model is BQPricingModel.ON_DEMAND:
+        assert result.edition is None
+        assert result.baseline_slots is None
+        assert result.max_slots is None
+        assert result.commitment_slots is None
+        assert result.commitment_plan is None
+
+
+@settings(max_examples=200)
+@given(jobs=pricing_jobs(), cfg=reservation_config())
+def test_pricing_properties_config_supplied_is_capacity(jobs: list[dict], cfg: dict) -> None:
+    """P20 (config arm): a supplied --reservation-config → CAPACITY with the figures recorded
+    at HIGH confidence, regardless of what the jobs look like (R16.2)."""
+    result = _detect(jobs, reservation_config=cfg)
+    _assert_universal_honesty(result)
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.confidence is ConfidenceLevel.HIGH
+    assert result.edition == cfg["edition"]
+    assert result.baseline_slots == cfg["baseline_slots"]
+    assert result.max_slots == cfg["max_slots"]
+    assert result.commitment_slots == cfg["commitment_slots"]
+    assert result.commitment_plan == cfg["commitment_plan"]
+
+
+@settings(max_examples=200)
+@given(jobs=pricing_jobs())
+def test_pricing_properties_auto_detection_is_honest(jobs: list[dict]) -> None:
+    """P20 (auto arm, no config): the verdict honestly reflects the JOBS signal —
+    any non-null reservation_id (on a non-SCRIPT leaf) → CAPACITY; otherwise ON_DEMAND.
+    Undeterminable (no leaf signal) is ON_DEMAND at LOW, never UNKNOWN (R16.3)."""
+    result = _detect(jobs, reservation_config=None)
+    _assert_universal_honesty(result)
+
+    leaf = [j for j in jobs if j.get("statement_type") != "SCRIPT"]
+    any_capacity = any(j.get("reservation_id") is not None for j in leaf)
+
+    if any_capacity:
+        assert result.model is BQPricingModel.CAPACITY
+    elif not leaf:
+        # No usable leaf signal → undeterminable → ON_DEMAND at LOW with a prompt.
+        assert result.model is BQPricingModel.ON_DEMAND
+        assert result.confidence is ConfidenceLevel.LOW
+        assert "--reservation-config" in result.source_note
+    else:
+        assert result.model is BQPricingModel.ON_DEMAND
+
+
+@settings(max_examples=100)
+@given(jobs=pricing_jobs(), cfg=reservation_config())
+def test_detector_emits_no_node_concepts(jobs: list[dict], cfg: dict) -> None:
+    """Detector-boundary decoupling guard (supports P22, which the Cost tests validate):
+    the Pricing Detector classifies billing, not cluster shape — nothing it emits names a
+    Redshift node count/type."""
+    for result in (_detect(jobs), _detect(jobs, reservation_config=cfg)):
+        note = result.source_note.lower()
+        for term in ("node", "ra3", "dc2", "xlplus", "cluster"):
+            assert term not in note

--- a/solution-architecture/clis/bq-assess/tests/property/test_relationships_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_relationships_properties.py
@@ -1,0 +1,273 @@
+# Feature: phase1-assessment-tool, Property 10: Relationship inference from naming conventions and clustering
+# Feature: phase1-assessment-tool, Property 11: Relationship inference from view SQL
+# Feature: phase1-assessment-tool, Property 12: LOW confidence safe defaults
+"""Property tests for the RelationshipInferrer.
+
+Validates: Requirements 7.1, 7.2, 7.3, 7.4, 7.5
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, given, settings
+
+from bq_assess.models import (
+    EntityType,
+    EntityPopulation,
+    ColumnSchema,
+    ConfidenceLevel,
+    EntityMetadata,
+)
+from bq_assess.core.relationships import RelationshipInferrer
+
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,19}", fullmatch=True)
+
+
+@st.composite
+def tables_with_shared_id_column(draw: st.DrawFn) -> tuple[list[EntityMetadata], str]:
+    """Generate 4+ tables that all share a common ``_id`` column.
+
+    Each table has a unique ``full_name`` so the naming heuristic counts
+    them as distinct tables (the implementation uses a set of full_names).
+
+    Returns the table list and the shared column name.
+    """
+    # Pick a shared _id column name
+    prefix = draw(st.from_regex(r"[a-z][a-z0-9]{0,8}", fullmatch=True))
+    shared_col = f"{prefix}_id"
+
+    n_tables = draw(st.integers(min_value=4, max_value=7))
+    tables: list[EntityMetadata] = []
+
+    for i in range(n_tables):
+        # Use index-based naming to guarantee unique full_names
+        dataset_id = f"ds{i}"
+        table_id = f"tbl{i}"
+
+        # Always include the shared _id column
+        shared = ColumnSchema(name=shared_col, field_type="INT64", mode="NULLABLE", fields=[])
+
+        # Add 0-2 extra columns (non-_id to avoid accidental extra matches)
+        extra_cols = [
+            ColumnSchema(
+                name=f"col{i}_{j}_val",
+                field_type="STRING",
+                mode="NULLABLE",
+                fields=[],
+            )
+            for j in range(draw(st.integers(min_value=0, max_value=2)))
+        ]
+
+        clustering = draw(st.one_of(
+            st.none(),
+            st.lists(_identifier, min_size=1, max_size=3),
+        ))
+
+        tables.append(
+            EntityMetadata(
+                entity_id=table_id,
+                dataset_id=dataset_id,
+                full_name=f"{dataset_id}.{table_id}",
+                entity_type=EntityType.TABLE,
+                population=EntityPopulation.TABLE,
+                num_rows=0,
+                num_bytes=0,
+                columns=[shared] + extra_cols,
+                time_partitioning=None,
+                range_partitioning=None,
+                clustering_fields=clustering,
+                view_query=None,
+                mview_query=None,
+                routine=None,
+                depends_on=[],
+                last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+
+    return tables, shared_col
+
+
+@st.composite
+def view_definitions_with_joins(draw: st.DrawFn) -> dict[str, str]:
+    """Generate view definitions containing JOIN clauses with ON conditions."""
+    n_views = draw(st.integers(min_value=1, max_value=3))
+    views: dict[str, str] = {}
+
+    for _ in range(n_views):
+        view_name = draw(_identifier)
+        left_table = draw(_identifier)
+        right_table = draw(_identifier)
+        join_col = draw(_identifier)
+
+        sql = (
+            f"SELECT * FROM {left_table} "
+            f"JOIN {right_table} ON {left_table}.{join_col} = {right_table}.{join_col}"
+        )
+        views[view_name] = sql
+
+    return views
+
+
+@st.composite
+def tables_with_unique_columns(draw: st.DrawFn) -> list[EntityMetadata]:
+    """Generate tables with unique column names (no shared ``_id`` columns).
+
+    Each table gets columns that won't trigger the naming heuristic.
+    """
+    n_tables = draw(st.integers(min_value=1, max_value=5))
+    tables: list[EntityMetadata] = []
+
+    for i in range(n_tables):
+        dataset_id = draw(_identifier)
+        table_id = draw(_identifier)
+
+        # Use unique prefixes per table to avoid _id columns appearing in >3 tables
+        cols = [
+            ColumnSchema(
+                name=f"tbl{i}_col{j}_val",
+                field_type=draw(st.sampled_from(["STRING", "INT64", "FLOAT64", "BOOL", "TIMESTAMP"])),
+                mode="NULLABLE",
+                fields=[],
+            )
+            for j in range(draw(st.integers(min_value=1, max_value=4)))
+        ]
+
+        tables.append(
+            EntityMetadata(
+                entity_id=table_id,
+                dataset_id=dataset_id,
+                full_name=f"{dataset_id}.{table_id}",
+                entity_type=EntityType.TABLE,
+                population=EntityPopulation.TABLE,
+                num_rows=draw(st.integers(min_value=0, max_value=10**9)),
+                num_bytes=draw(st.integers(min_value=0, max_value=10**12)),
+                columns=cols,
+                time_partitioning=None,
+                range_partitioning=None,
+                clustering_fields=None,
+                view_query=None,
+                mview_query=None,
+                routine=None,
+                depends_on=[],
+                last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+
+    return tables
+
+
+# ---------------------------------------------------------------------------
+# Property 10: Relationship inference from naming conventions and clustering
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+@given(data=tables_with_shared_id_column())
+def test_naming_conventions_and_clustering(
+    data: tuple[list[EntityMetadata], str],
+) -> None:
+    """Property 10: Relationship inference from naming conventions and clustering.
+
+    **Validates: Requirements 7.1, 7.3, 7.4**
+
+    ``_id`` columns in >3 tables appear in ``likely_join_keys``.
+    Clustering keys appear in ``sort_order_hints``.
+    Each inferred relationship has a non-null confidence level.
+    """
+    # Feature: phase1-assessment-tool, Property 10: Relationship inference from naming conventions and clustering
+    tables, shared_col = data
+    inferrer = RelationshipInferrer()
+    result = inferrer.infer(tables)
+
+    # The shared _id column must appear in likely_join_keys
+    assert shared_col in result.likely_join_keys, (
+        f"Expected '{shared_col}' in likely_join_keys {result.likely_join_keys}"
+    )
+
+    # Clustering keys must appear in sort_order_hints (R7; not SORTKEY per R15.5)
+    for table in tables:
+        if table.clustering_fields:
+            assert table.full_name in result.sort_order_hints, (
+                f"Table {table.full_name} has clustering fields but is not in sort_order_hints"
+            )
+            assert result.sort_order_hints[table.full_name] == list(table.clustering_fields)
+
+    # Every inferred relationship must have a non-null confidence
+    for rel in result.relationships:
+        assert rel.confidence is not None
+        assert isinstance(rel.confidence, ConfidenceLevel)
+
+
+# ---------------------------------------------------------------------------
+# Property 11: Relationship inference from view SQL
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(views=view_definitions_with_joins())
+def test_view_sql_produces_relationships(views: dict[str, str]) -> None:
+    """Property 11: Relationship inference from view SQL.
+
+    **Validates: Requirements 7.2**
+
+    Views with JOINs produce at least one InferredRelationship
+    with source="view_definition".
+    """
+    # Feature: phase1-assessment-tool, Property 11: Relationship inference from view SQL
+    inferrer = RelationshipInferrer()
+    result = inferrer.infer(tables=[], view_definitions=views)
+
+    # At least one relationship should be inferred from the view definitions
+    assert len(result.relationships) >= 1, (
+        f"Expected at least 1 relationship from {len(views)} view(s), got 0"
+    )
+
+    # At least one relationship should have source="view_definition"
+    view_rels = [r for r in result.relationships if r.source == "view_definition"]
+    assert len(view_rels) >= 1, (
+        "Expected at least one relationship with source='view_definition'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 12: LOW confidence safe defaults
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(tables=tables_with_unique_columns())
+def test_low_confidence_safe_defaults(tables: list[EntityMetadata]) -> None:
+    """Property 12: LOW confidence safe defaults.
+
+    **Validates: Requirements 7.5**
+
+    LOW confidence → distkey=None (DISTSTYLE EVEN), sortkey=first timestamp column.
+    When no query analysis and no view definitions are provided, and the naming
+    heuristic doesn't trigger, confidence should be LOW.
+    """
+    # Feature: phase1-assessment-tool, Property 12: LOW confidence safe defaults
+    inferrer = RelationshipInferrer()
+    result = inferrer.infer(tables, query_analysis=None, view_definitions=None)
+
+    # With unique column names and no query analysis / views, confidence must be LOW
+    assert result.confidence == ConfidenceLevel.LOW, (
+        f"Expected LOW confidence, got {result.confidence}"
+    )
+
+    # No likely join keys should be detected (unique column names, no _id sharing)
+    assert result.likely_join_keys == [], (
+        f"Expected no likely_join_keys, got {result.likely_join_keys}"
+    )
+
+    # No relationships should be inferred
+    assert result.relationships == [], (
+        f"Expected no relationships, got {len(result.relationships)}"
+    )

--- a/solution-architecture/clis/bq-assess/tests/property/test_report_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_report_properties.py
@@ -1,0 +1,172 @@
+"""Phase 6 property tests for report writers (P24-P26).
+
+Validates: JSON/HTML round-trip, offline safety, credential filtering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+
+from hypothesis import given, settings
+
+from bq_assess.models import Assessment
+from bq_assess.report.html_writer import HTMLWriter
+from bq_assess.report.json_writer import JSONWriter
+
+from tests.conftest import assessment
+
+
+# ---------------------------------------------------------------------------
+# Credential patterns for P26
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate credential leakage
+_CREDENTIAL_PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA )?PRIVATE KEY-----"),
+    re.compile(r'"private_key"\s*:'),
+    re.compile(r'"client_email"\s*:\s*"[^"]+@[^"]+\.iam\.gserviceaccount\.com"'),
+    re.compile(r'"token"\s*:\s*"ya29\.[A-Za-z0-9_-]+'),
+    re.compile(r"AIza[0-9A-Za-z_-]{35}"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 Property Tests (P24-P26): normative Assessment model
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Property 24: JSON round-trip and populations (R19 — normative model)
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, deadline=None)
+@given(a=assessment())
+def test_p24_json_roundtrip_and_populations(a: Assessment) -> None:
+    """P24: JSON round-trip fidelity and population filtering.
+
+    For any Assessment: 3 files written, valid JSON, correct assessment_id,
+    effort has only TABLE, query has all, union of full_names = all entities.
+    """
+    out_dir = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out_dir)
+
+    # Exactly 3 files
+    assert len(paths) == 3
+
+    landing_path = [p for p in paths if "landing" in p][0]
+    effort_path = [p for p in paths if "effort" in p][0]
+    query_path = [p for p in paths if "query" in p][0]
+
+    # Valid JSON
+    with open(landing_path) as f:
+        landing = json.load(f)
+    with open(effort_path) as f:
+        effort = json.load(f)
+    with open(query_path) as f:
+        query = json.load(f)
+
+    # assessment_id matches
+    assert landing["assessment_id"] == a.assessment_id
+    assert effort["assessment_id"] == a.assessment_id
+    assert query["assessment_id"] == a.assessment_id
+
+    # Landing has required top-level keys
+    for key in ["generated_at", "project_id", "summary", "cost", "failures"]:
+        assert key in landing
+
+    # Effort file: only TABLE population
+    for e in effort["entities"]:
+        assert e["population"] == "TABLE"
+
+    # Query file: includes all entities
+    assert len(query["entities"]) == len(a.entities)
+
+    # Cross-reference: union of full_names
+    effort_names = {e["full_name"] for e in effort["entities"]}
+    query_names = {e["full_name"] for e in query["entities"]}
+    all_names = effort_names | query_names
+    expected_names = {e.full_name for e in a.entities}
+    assert all_names == expected_names
+
+
+# ---------------------------------------------------------------------------
+# Property 25: HTML offline and confidence banners (R20)
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, deadline=None)
+@given(a=assessment())
+def test_p25_html_offline_and_banners(a: Assessment) -> None:
+    """P25: HTML is offline-safe and confidence banners appear correctly.
+
+    For any Assessment: single HTML file with all tabs, no http/https URLs,
+    LOW-confidence banners appear when needed, no CSV produced.
+    """
+    out_dir = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out_dir)
+
+    assert len(paths) == 1
+    assert paths[0].endswith(".html")
+
+    with open(paths[0]) as f:
+        html = f.read()
+
+    # Offline (R20.7): no external ASSET references — scripts, stylesheets, images,
+    # fonts, imports. A blanket "http:// not in html" is wrong: customer DATA (rewrite
+    # guidance, SQL text, dataset names) may legitimately contain URL strings, and
+    # autoescaped text content is not a network dependency. Assert on the constructs
+    # that would actually make the browser fetch something.
+    for needle in (
+        'src="http', "src='http",              # <script>/<img>/<iframe> loads
+        'href="http', "href='http",            # <link rel=stylesheet> / external links
+        "url(http", "url('http", 'url("http',  # CSS url() fetches
+        "@import",                              # CSS imports
+        "<script src", "<link rel=",            # any non-inlined script/style at all
+    ):
+        assert needle not in html, f"external asset reference in HTML: {needle!r}"
+
+    # All tabs present
+    assert 'id="tab-landing"' in html
+    assert 'id="tab-effort"' in html
+    assert 'id="tab-query"' in html
+
+    # LOW compute_confidence → banner
+    if a.cost.compute_confidence.value == "LOW":
+        assert "Low Confidence Cost Estimate" in html
+
+    # LOW sql_surface_confidence → banner
+    if a.summary.sql_surface_confidence.value == "LOW":
+        assert "Low Confidence SQL Analysis" in html
+
+    # No CSV in output
+    files = os.listdir(out_dir)
+    assert not any(f.endswith(".csv") for f in files)
+
+
+# ---------------------------------------------------------------------------
+# Property 26: No credentials in output (R22.3 / R22.6 — normative model)
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, deadline=None)
+@given(a=assessment())
+def test_p26_no_credentials_in_output(a: Assessment) -> None:
+    """P26: No credentials leak into any output file (JSON or HTML).
+
+    Scans for service-account keys, client emails, and token patterns.
+    """
+    out_dir = tempfile.mkdtemp()
+    json_paths = JSONWriter().write(a, out_dir)
+    html_paths = HTMLWriter().write(a, out_dir)
+
+    for path in json_paths + html_paths:
+        with open(path) as f:
+            content = f.read()
+        for pattern in _CREDENTIAL_PATTERNS:
+            assert not pattern.search(content), (
+                f"Credential pattern {pattern.pattern!r} found in {path}"
+            )

--- a/solution-architecture/clis/bq-assess/tests/property/test_scanner_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_scanner_properties.py
@@ -1,0 +1,354 @@
+# Feature: bq-assess-lakehouse, Property 3: Dataset filter scoping
+# Feature: bq-assess-lakehouse, Property 4: Scanned metadata completeness
+# Feature: bq-assess-lakehouse, Property 5: Entity classification partitions the population
+# Feature: bq-assess-lakehouse, Property 7: Range partitioning is captured distinctly
+# Feature: bq-assess-lakehouse, Property 27: Scanner retry on transient errors
+# Feature: bq-assess-lakehouse, Property 28: Pipeline resilience
+"""Property-based tests for the scanner and entity classification (issue #8 / 1.3).
+
+Realizes the design.md correctness properties for Phase 1 ingestion:
+
+- **P3** dataset filter scoping            — Validates R3.4
+- **P4** scanned metadata completeness     — Validates R3.1, R3.2, R3.3
+- **P5** classification partition          — Validates R4.1, R4.2, R4.3
+- **P7** range partitioning captured       — Validates R3.8
+- **P27** scanner retry on transient errors — Validates R23.1
+- **P28** pipeline resilience              — Validates R23.2
+
+Each property is realized by exactly one Hypothesis test. Scanner tests drive a mocked
+BigQuery client; classification (P5) exercises the real ``core/classifier``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import hypothesis.strategies as st
+import pytest
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import bigquery
+from hypothesis import HealthCheck, assume, given, settings
+
+from bq_assess.core.classifier import classify_population
+from bq_assess.core.scanner import BigQueryScanner, _retry
+from bq_assess.models import EntityPopulation, EntityType
+
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,9}", fullmatch=True)
+
+
+# ---------------------------------------------------------------------------
+# Mock builders
+# ---------------------------------------------------------------------------
+
+
+def _make_scanner() -> BigQueryScanner:
+    scanner = BigQueryScanner(project_id="prop-project", use_adc=True)
+    scanner._client = MagicMock(spec=bigquery.Client)
+    scanner._client.list_routines.return_value = []
+    return scanner
+
+
+def _make_dataset_list_item(dataset_id: str):
+    item = MagicMock(spec=bigquery.dataset.DatasetListItem)
+    item.dataset_id = dataset_id
+    return item
+
+
+def _make_table_list_item(dataset_id: str, table_id: str):
+    item = MagicMock(spec=bigquery.table.TableListItem)
+    item.dataset_id = dataset_id
+    item.table_id = table_id
+    item.reference = MagicMock(spec=bigquery.TableReference)
+    return item
+
+
+def _make_schema_field(name: str, field_type: str = "STRING", mode: str = "NULLABLE"):
+    sf = MagicMock(spec=bigquery.SchemaField)
+    sf.name = name
+    sf.field_type = field_type
+    sf.mode = mode
+    sf.fields = []
+    return sf
+
+
+def _make_table(
+    dataset_id: str,
+    table_id: str,
+    *,
+    num_rows: int = 100,
+    num_bytes: int = 2048,
+    table_type: str = "TABLE",
+    range_partitioning=None,
+):
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = table_id
+    tbl.dataset_id = dataset_id
+    tbl.table_type = table_type
+    tbl.num_rows = num_rows
+    tbl.num_bytes = num_bytes
+    tbl.schema = [_make_schema_field("id", "INT64", "REQUIRED")]
+    tbl.time_partitioning = None
+    tbl.range_partitioning = range_partitioning
+    tbl.clustering_fields = None
+    tbl.view_query = None
+    tbl.mview_query = None
+    tbl.modified = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    return tbl
+
+
+def _make_range_partitioning(field: str, start: int, end: int, interval: int):
+    rng = MagicMock()
+    rng.start = start
+    rng.end = end
+    rng.interval = interval
+    rp = MagicMock()
+    rp.field = field
+    rp.range_ = rng
+    return rp
+
+
+# ---------------------------------------------------------------------------
+# P3: Dataset filter scoping  — Validates R3.4
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    all_datasets=st.lists(_identifier, min_size=1, max_size=8, unique=True),
+    filter_ratio=st.floats(min_value=0.1, max_value=1.0),
+)
+def test_p3_dataset_filter_scoping(all_datasets: list[str], filter_ratio: float):
+    """A non-empty filter yields only matching datasets; no filter yields all."""
+    scanner = _make_scanner()
+    client = scanner._client
+    client.list_datasets.return_value = [_make_dataset_list_item(d) for d in all_datasets]
+
+    table_items = {d: _make_table_list_item(d, f"t_{d}") for d in all_datasets}
+    table_objects = {id(tli.reference): _make_table(d, f"t_{d}") for d, tli in table_items.items()}
+    client.list_tables.side_effect = lambda ds: [table_items[ds]] if ds in table_items else []
+    client.get_table.side_effect = lambda ref: table_objects[id(ref)]
+
+    n_filter = max(1, int(len(all_datasets) * filter_ratio))
+    dataset_filter = all_datasets[:n_filter]
+
+    filtered = {e.dataset_id for e in scanner.scan(dataset_filter=dataset_filter)}
+    assert filtered == set(dataset_filter)
+
+    scanner.failures = []
+    all_scanned = {e.dataset_id for e in scanner.scan(dataset_filter=None)}
+    assert all_scanned == set(all_datasets)
+
+
+# ---------------------------------------------------------------------------
+# P4: Scanned metadata completeness  — Validates R3.1, R3.2, R3.3
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    dataset_id=_identifier,
+    table_id=_identifier,
+    num_rows=st.integers(min_value=0, max_value=10**9),
+    num_bytes=st.integers(min_value=0, max_value=10**12),
+)
+def test_p4_scanned_metadata_completeness(
+    dataset_id: str, table_id: str, num_rows: int, num_bytes: int
+):
+    """Required fields are non-null; partition/clustering/SQL fields are present (may be None)."""
+    scanner = _make_scanner()
+    client = scanner._client
+    client.list_datasets.return_value = [_make_dataset_list_item(dataset_id)]
+    client.list_tables.return_value = [_make_table_list_item(dataset_id, table_id)]
+    client.get_table.return_value = _make_table(
+        dataset_id, table_id, num_rows=num_rows, num_bytes=num_bytes
+    )
+
+    results = list(scanner.scan())
+    assert len(results) == 1
+    meta = results[0]
+
+    # Required fields non-null (design.md P4)
+    assert meta.entity_id is not None
+    assert meta.dataset_id is not None
+    assert meta.full_name is not None
+    assert meta.entity_type is not None
+    assert meta.population is not None
+    assert meta.num_bytes is not None
+    assert meta.columns is not None and len(meta.columns) > 0
+
+    # Partition/clustering/SQL fields present (attribute exists; value may be None)
+    for attr in (
+        "time_partitioning",
+        "range_partitioning",
+        "clustering_fields",
+        "view_query",
+        "mview_query",
+        "routine",
+        "last_modified",
+    ):
+        assert hasattr(meta, attr)
+
+
+# ---------------------------------------------------------------------------
+# P5: Entity classification partitions the population — Validates R4.1, R4.2, R4.3
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(entity_type=st.sampled_from(list(EntityType)))
+def test_p5_classification_partitions_population(entity_type: EntityType):
+    """population is TABLE iff type ∈ {TABLE, EXTERNAL}, else REBUILT — never both."""
+    population = classify_population(entity_type)
+    is_table_type = entity_type in (EntityType.TABLE, EntityType.EXTERNAL)
+
+    if is_table_type:
+        assert population is EntityPopulation.TABLE
+    else:
+        assert population is EntityPopulation.REBUILT
+
+    # Exactly one population — the mapping is a function (no entity is both).
+    assert population in (EntityPopulation.TABLE, EntityPopulation.REBUILT)
+    assert (population is EntityPopulation.TABLE) == is_table_type
+
+
+# ---------------------------------------------------------------------------
+# P7: Range partitioning is captured distinctly — Validates R3.8
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    dataset_id=_identifier,
+    table_id=_identifier,
+    field=_identifier,
+    start=st.integers(min_value=0, max_value=10**6),
+    span=st.integers(min_value=1, max_value=10**6),
+    interval=st.integers(min_value=1, max_value=10**5),
+)
+def test_p7_range_partitioning_captured(
+    dataset_id, table_id, field, start, span, interval
+):
+    """A range-partitioned table populates range_partitioning and is not unpartitioned."""
+    scanner = _make_scanner()
+    client = scanner._client
+    rp = _make_range_partitioning(field, start, start + span, interval)
+    table = _make_table(dataset_id, table_id, range_partitioning=rp)  # time_partitioning stays None
+
+    client.list_datasets.return_value = [_make_dataset_list_item(dataset_id)]
+    client.list_tables.return_value = [_make_table_list_item(dataset_id, table_id)]
+    client.get_table.return_value = table
+
+    meta = next(iter(scanner.scan()))
+
+    assert meta.range_partitioning is not None
+    assert meta.range_partitioning.field == field
+    assert meta.range_partitioning.start == start
+    assert meta.range_partitioning.end == start + span
+    assert meta.range_partitioning.interval == interval
+    # Distinct from time partitioning — not mistaken for unpartitioned (R3.8)
+    assert meta.time_partitioning is None
+    is_unpartitioned = (
+        meta.time_partitioning is None and meta.range_partitioning is None
+    )
+    assert not is_unpartitioned
+
+
+# ---------------------------------------------------------------------------
+# P27: Scanner retry on transient errors — Validates R23.1
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(
+    status_code=st.sampled_from([429, 500, 503]),
+    failures_before_success=st.integers(min_value=0, max_value=3),
+)
+@patch("bq_assess.core.scanner.time.sleep")
+def test_p27_retry_then_succeeds(mock_sleep, status_code, failures_before_success):
+    """Transient errors are retried with exponential backoff, at most 3 retries."""
+    err = GoogleAPICallError(f"transient {status_code}")
+    err.code = status_code
+
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+        if calls <= failures_before_success:
+            raise err
+        return "ok"
+
+    assert _retry(fn) == "ok"
+    assert calls == failures_before_success + 1
+    actual_delays = [c.args[0] for c in mock_sleep.call_args_list]
+    assert len(actual_delays) == failures_before_success
+    for i, actual in enumerate(actual_delays):
+        base = 1.0 * (2.0 ** i)
+        assert base * 0.5 <= actual <= base * 1.5
+
+
+@settings(max_examples=50)
+@given(status_code=st.sampled_from([429, 500, 503]))
+@patch("bq_assess.core.scanner.time.sleep")
+def test_p27_retry_caps_at_3_then_raises(mock_sleep, status_code):
+    """A persistently failing transient error raises after exactly 3 retries (4 attempts)."""
+    err = GoogleAPICallError(f"persistent {status_code}")
+    err.code = status_code
+
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+        raise err
+
+    with pytest.raises(GoogleAPICallError):
+        _retry(fn)
+    assert calls == 4  # 1 initial + 3 retries
+    assert mock_sleep.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# P28: Pipeline resilience — Validates R23.2
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    n_tables=st.integers(min_value=2, max_value=10),
+    k_failures=st.integers(min_value=1, max_value=9),
+)
+@patch("bq_assess.core.scanner.time.sleep")
+def test_p28_pipeline_resilience(mock_sleep, n_tables, k_failures):
+    """K of N entities fail → (N−K) results yielded and exactly K FailureRecords."""
+    assume(k_failures < n_tables)
+
+    scanner = _make_scanner()
+    client = scanner._client
+    client.list_datasets.return_value = [_make_dataset_list_item("ds")]
+
+    items = [_make_table_list_item("ds", f"t{i}") for i in range(n_tables)]
+    client.list_tables.return_value = items
+
+    fail_idx = set(range(k_failures))
+    err = GoogleAPICallError("permanent")
+    err.code = 400  # non-retryable → immediate per-entity failure
+    ref_to_idx = {id(it.reference): i for i, it in enumerate(items)}
+
+    def get_table(ref):
+        idx = ref_to_idx[id(ref)]
+        if idx in fail_idx:
+            raise err
+        return _make_table("ds", f"t{idx}")
+
+    client.get_table.side_effect = get_table
+
+    results = list(scanner.scan())
+
+    assert len(results) == n_tables - k_failures
+    assert len(scanner.failures) == k_failures
+    for fr in scanner.failures:
+        assert fr.entity_name is not None
+        assert fr.stage == "scan"
+        assert fr.error is not None

--- a/solution-architecture/clis/bq-assess/tests/property/test_scoring_anonymization_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_scoring_anonymization_properties.py
@@ -1,0 +1,170 @@
+# Feature: bq-assess-lakehouse, Property 13: Migration Effort is Tables-only and additive
+# Feature: bq-assess-lakehouse, Property 14: Query Complexity never fails on missing input
+# Feature: bq-assess-lakehouse, Property 17: Query text anonymization
+"""Property tests P13, P14, P17 — the scoring/anonymization gaps from the audit.
+
+- **P13** Migration Effort is Tables-only and additive — Validates R9.1-R9.5
+- **P14** Query Complexity never fails on missing input — Validates R11.5
+- **P17** Query text anonymization — Validates R10.4, R17.4, R22.4
+
+(P18 placement and P19 relationships are handled separately — they exposed real bugs.)
+"""
+
+from __future__ import annotations
+
+import re
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess.core.sql_surface import SQLSurfaceAnalyzer
+from bq_assess.models import (
+    ComplexityCategory,
+    ConfidenceLevel,
+    ConfidenceSource,
+    ConversionResult,
+    EffortCategory,
+    LossyCast,
+    PartitionMapping,
+)
+from bq_assess.scoring.complexity import ComplexityScorer
+from bq_assess.scoring.effort import EffortScorer
+
+from tests.conftest import entity_metadata
+
+
+# ---------------------------------------------------------------------------
+# P13: Migration Effort is Tables-only and additive — R9.1-R9.5
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _conversion_result(draw: st.DrawFn) -> ConversionResult:
+    """A successful ConversionResult with a random but known number of lossy casts
+    and an optional non-clean partition decision flag — the additive factors P13 checks."""
+    n_lossy = draw(st.integers(min_value=0, max_value=3))
+    lossy = [
+        LossyCast(column=f"c{i}", source_type="GEOGRAPHY", iceberg_type="binary",
+                  loss_description="no native geo")
+        for i in range(n_lossy)
+    ]
+    decision_flags: list[str] = []
+    if draw(st.booleans()):
+        decision_flags.append(
+            draw(st.sampled_from(["partition_decision_required", "sort_decision_required"]))
+        )
+    pm = PartitionMapping(
+        iceberg_transforms=[], sort_order=[], auto_derived=not decision_flags,
+        decision_flags=decision_flags,
+    )
+    return ConversionResult(
+        ddl="CREATE TABLE t (id long);",
+        partition_mapping=pm,
+        lossy_casts=lossy,
+        warnings=[],
+        success=True,
+    )
+
+
+@settings(max_examples=100)
+@given(entity=entity_metadata(), conversion=_conversion_result())
+def test_p13_effort_tables_only_and_additive(entity, conversion):
+    """Effort = sum of factor points; category follows AUTO=0/ASSISTED<=2/MANUAL>2;
+    flags match contributing factors. (REBUILT entities are not scored by EffortScorer —
+    the pipeline fixes their effort to None; see P-spec note.)"""
+    # Feature: bq-assess-lakehouse, Property 13: Migration Effort is Tables-only and additive
+    result = EffortScorer().score(entity, conversion)
+
+    # Additivity: score equals the documented sum of contributing factors.
+    expected = 0
+    size = entity.num_bytes or 0
+    if size >= 100 * 1024**3:
+        expected += 2
+    elif size >= 1024**3:
+        expected += 1
+    expected += len(conversion.lossy_casts)
+    # sync signal
+    sync = False
+    if entity.time_partitioning and (entity.time_partitioning.field or "").lower() in (
+        "_partitiontime", "updated_at", "modified_at", "ingestion_time"
+    ):
+        sync = True
+    if any((c.name or "").lower() in (
+        "_partitiontime", "updated_at", "modified_at", "ingestion_time"
+    ) for c in entity.columns):
+        sync = True
+    if sync:
+        expected += 1
+    expected += sum(
+        1 for f in conversion.partition_mapping.decision_flags
+        if f in ("partition_decision_required", "sort_decision_required")
+    )
+
+    assert result.score == expected, f"score {result.score} != additive sum {expected}"
+
+    # Category thresholds (AUTO=0, ASSISTED 1..2, MANUAL >2)
+    if result.score == 0:
+        assert result.category is EffortCategory.AUTO
+    elif result.score <= 2:
+        assert result.category is EffortCategory.ASSISTED
+    else:
+        assert result.category is EffortCategory.MANUAL
+
+    # Flags correspond to contributing factors (lossy flag present iff lossy casts)
+    assert ("lossy_casts" in result.flags) == (len(conversion.lossy_casts) > 0)
+
+
+# ---------------------------------------------------------------------------
+# P14: Query Complexity never fails on missing input — R11.5
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(entity=entity_metadata())
+def test_p14_complexity_never_fails_on_missing_input(entity):
+    """With no constructs and no logs, the scorer returns a LOW-confidence result with an
+    explicit 'no read workload visible' state — never raises, never omits the entity."""
+    # Feature: bq-assess-lakehouse, Property 14: Query Complexity never fails on missing input
+    result = ComplexityScorer().score(entity, constructs=[], relationships=None, has_logs=False)
+
+    assert result is not None
+    # No constructs → PORTABLE, score 0
+    assert result.category is ComplexityCategory.PORTABLE
+    assert result.score == 0
+
+    # If the entity also has no SQL surface, confidence must be LOW with an explicit state.
+    has_surface = bool(
+        entity.view_query or entity.mview_query or (entity.routine and entity.routine.body)
+    )
+    if not has_surface:
+        assert result.confidence is ConfidenceLevel.LOW
+        assert result.confidence_source is ConfidenceSource.SCHEMA_ONLY
+        assert "no sql surface" in result.reasoning.lower() or "no read workload" in result.reasoning.lower()
+
+
+# ---------------------------------------------------------------------------
+# P17: Query text anonymization — R10.4, R17.4, R22.4
+# ---------------------------------------------------------------------------
+
+# A SQL generator that always embeds a known string literal and a known numeric literal.
+@st.composite
+def _sql_with_literals(draw: st.DrawFn) -> tuple[str, str, str]:
+    str_val = draw(st.text(alphabet=st.characters(whitelist_categories=("L",)), min_size=3, max_size=12))
+    num_val = str(draw(st.integers(min_value=1000, max_value=999999)))
+    sql = f"SELECT * FROM t WHERE name = '{str_val}' AND amount = {num_val}"
+    return sql, str_val, num_val
+
+
+@settings(max_examples=100)
+@given(payload=_sql_with_literals())
+def test_p17_anonymization_removes_all_literals(payload):
+    """After anonymization, no original string or numeric literal value remains."""
+    # Feature: bq-assess-lakehouse, Property 17: Query text anonymization
+    sql, str_val, num_val = payload
+    out = SQLSurfaceAnalyzer().anonymize(sql)
+
+    # The original quoted string value must be gone.
+    assert f"'{str_val}'" not in out
+    assert str_val not in out.replace("?", "")  # value not lurking unquoted either
+    # The original numeric literal must be gone.
+    assert not re.search(rf"(?<!\d){re.escape(num_val)}(?!\d)", out)

--- a/solution-architecture/clis/bq-assess/tests/property/test_strategies_smoke.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_strategies_smoke.py
@@ -1,0 +1,146 @@
+# Feature: bq-assess-lakehouse, issue #4: conftest strategy contract checks
+"""Contract tests for the issue-#4 normative-model Hypothesis strategies.
+
+Prove the shared strategies in ``conftest`` generate structurally valid instances of the
+normative model (Phase 0.5 checkpoint), and pin the invariants later phases' property tests
+rely on (population↔type, Tables-only effort axis, slot-job shape, construct pairing).
+"""
+
+from __future__ import annotations
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bq_assess import models as m
+from tests.conftest import (
+    PRICING_EDITIONS,
+    assessment,
+    entity_metadata,
+    pricing_jobs,
+    reservation_config,
+    slot_jobs,
+    sql_with_constructs,
+)
+
+
+@settings(max_examples=50)
+@given(e=entity_metadata())
+def test_entity_metadata_population_matches_type(e: m.EntityMetadata) -> None:
+    assert isinstance(e, m.EntityMetadata)
+    expected = (
+        m.EntityPopulation.TABLE
+        if e.entity_type in (m.EntityType.TABLE, m.EntityType.EXTERNAL)
+        else m.EntityPopulation.REBUILT
+    )
+    assert e.population is expected
+    # Required fields non-null
+    assert e.entity_id and e.dataset_id and e.full_name
+    assert e.columns
+    # REBUILT carries 0 rows; routines/views carry their payloads when applicable
+    if e.population is m.EntityPopulation.REBUILT:
+        assert e.num_rows == 0
+    if e.entity_type is m.EntityType.ROUTINE:
+        assert e.routine is not None
+
+
+@settings(max_examples=50)
+@given(jobs=slot_jobs())
+def test_slot_jobs_shape(jobs: list[dict]) -> None:
+    assert len(jobs) >= 1
+    for j in jobs:
+        base_keys = {"total_slot_ms", "total_bytes_processed", "creation_time"}
+        # The billed column mirrors real data: present-and-normal (>= processed,
+        # 10 MiB minimums), present-and-zero (cache hits / reservation-served), or
+        # ABSENT (old exports) — the contract must cover all three so consumers'
+        # fallback branches are reachable by property tests.
+        assert set(j) in (base_keys, base_keys | {"total_bytes_billed"})
+        assert j["total_slot_ms"] >= 0
+        assert j["total_bytes_processed"] >= 0
+        if "total_bytes_billed" in j:
+            assert j["total_bytes_billed"] == 0 or (
+                j["total_bytes_billed"] >= j["total_bytes_processed"])
+
+
+@settings(max_examples=50)
+@given(jobs=pricing_jobs())
+def test_pricing_jobs_carry_detection_signal(jobs: list[dict]) -> None:
+    """pricing_jobs() rows carry the detector's signal columns on top of slot_jobs()."""
+    for j in jobs:
+        # Superset of slot_jobs() keys plus the three V5 detection columns.
+        assert set(j) == {
+            "total_slot_ms", "total_bytes_processed", "total_bytes_billed",
+            "creation_time", "reservation_id", "edition", "statement_type",
+        }
+        # billed is 0 (cache hit) or >= processed (10 MiB minimums)
+        assert j["total_bytes_billed"] == 0 or (
+            j["total_bytes_billed"] >= j["total_bytes_processed"])
+        # reservation_id is the on-demand-vs-capacity signal: NULL or a path string.
+        assert j["reservation_id"] is None or isinstance(j["reservation_id"], str)
+        # edition is set iff the job ran on capacity (non-null reservation_id).
+        if j["reservation_id"] is None:
+            assert j["edition"] is None
+        else:
+            assert j["edition"] in PRICING_EDITIONS
+        # SCRIPT parents are NULL-reservation by design (the trap the detector guards).
+        if j["statement_type"] == "SCRIPT":
+            assert j["reservation_id"] is None
+
+
+@settings(max_examples=25)
+@given(data=st.data())
+def test_pricing_jobs_force_arms(data: st.DataObject) -> None:
+    """The `force` arms pin a deterministic billing/shape for targeted tests."""
+    ondemand = data.draw(pricing_jobs(force="ondemand"))
+    assert ondemand and all(j["reservation_id"] is None for j in ondemand)
+    assert all(j["statement_type"] != "SCRIPT" for j in ondemand)
+
+    capacity = data.draw(pricing_jobs(force="capacity"))
+    assert capacity and all(j["reservation_id"] is not None for j in capacity)
+    assert all(j["edition"] in PRICING_EDITIONS for j in capacity)
+
+    scripts = data.draw(pricing_jobs(force="all_script"))
+    assert scripts and all(j["statement_type"] == "SCRIPT" for j in scripts)
+    assert all(j["reservation_id"] is None for j in scripts)
+
+    assert data.draw(pricing_jobs(force="empty")) == []
+
+
+@settings(max_examples=50)
+@given(cfg=reservation_config())
+def test_reservation_config_shape(cfg: dict) -> None:
+    """A --reservation-config dict carries edition + the four slot/commitment figures."""
+    assert set(cfg) == {
+        "edition", "baseline_slots", "max_slots", "commitment_slots", "commitment_plan",
+    }
+    assert cfg["edition"] in PRICING_EDITIONS
+    assert 0 <= cfg["baseline_slots"] <= cfg["max_slots"]
+    assert cfg["commitment_slots"] >= 0
+    assert isinstance(cfg["commitment_plan"], str)
+
+
+@settings(max_examples=50)
+@given(pair=sql_with_constructs())
+def test_sql_with_constructs_pairs_sql_and_classes(pair: tuple[str, list[str]]) -> None:
+    sql, classes = pair
+    assert classes
+    assert isinstance(sql, str) and sql
+    # Every named class contributed a non-empty snippet to the SQL
+    assert len(set(classes)) == len(classes)
+
+
+@settings(max_examples=50)
+@given(a=assessment())
+def test_assessment_summary_consistent(a: m.Assessment) -> None:
+    assert isinstance(a, m.Assessment)
+    assert a.summary.total_entities == len(a.entities)
+    tables = [e for e in a.entities if e.population is m.EntityPopulation.TABLE]
+    assert a.summary.total_tables == len(tables)
+    # Effort axis present iff Table
+    for e in a.entities:
+        if e.population is m.EntityPopulation.REBUILT:
+            assert e.effort is None
+            assert e.conversion is None
+        else:
+            assert e.effort is not None
+    # Effort counts agree with entities
+    assert sum(a.summary.effort_counts.values()) == len(tables)

--- a/solution-architecture/clis/bq-assess/tests/property/test_workload_properties.py
+++ b/solution-architecture/clis/bq-assess/tests/property/test_workload_properties.py
@@ -1,0 +1,70 @@
+# Feature: bq-assess-lakehouse, Property 21: Slot utilization curve
+"""Property-based test for the Workload Analyzer (issue 5.2 / 5.4).
+
+Realizes the design.md correctness property for slot/workload analysis:
+
+- **P21** slot utilization curve — Validates R17.1, R17.2
+
+*For any* non-empty job set, ``SlotUtilization`` exposes avg/P50/P99/peak and an active-hour
+fraction in ``[0, 1]`` derived from ``total_slot_ms`` and ``creation_time``. Inputs come from
+the ``slot_jobs()`` strategy (conftest); a fake client returns the generated rows.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+
+from bq_assess.core.workload import WorkloadAnalyzer
+from bq_assess.models import SlotUtilization
+from tests.conftest import slot_jobs
+
+
+class _FakeClient:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def query(self, sql: str, *args, **kwargs):
+        rows = self._rows
+
+        class _Job:
+            def result(self_):
+                return iter(rows)
+
+        return _Job()
+
+
+@settings(max_examples=200)
+@given(jobs=slot_jobs())
+def test_p21_slot_utilization_curve_invariants(jobs: list[dict]) -> None:
+    """P21: for any non-empty job set the curve is well-defined and bounded."""
+    result, raw_jobs = WorkloadAnalyzer().analyze_from_api(_FakeClient(jobs), "proj")
+
+    # slot_jobs() always carries a usable creation_time, so a non-empty set never degrades.
+    assert isinstance(result, SlotUtilization)
+
+    # The active-hour fraction is a genuine fraction.
+    assert 0.0 <= result.active_hour_fraction <= 1.0
+
+    # Curve ordering invariant (avg is intentionally NOT constrained — bursty loads break it).
+    assert result.p50_slots <= result.p99_slots <= result.peak_slots
+
+    # total_slot_ms is the verbatim sum of inputs; all curve metrics are non-negative.
+    assert result.total_slot_ms == sum(j["total_slot_ms"] for j in jobs)
+    assert result.avg_slots >= 0.0
+    assert result.peak_slots >= 0.0
+    assert result.days_sampled >= 1
+
+    # Hourly buckets returned for metadata export: every input job is counted, and the
+    # bucket list never exceeds the job count (aggregation only merges, never invents).
+    assert result.total_queries == len(jobs)
+    assert 1 <= len(raw_jobs) <= len(jobs)
+    assert all("hour_bucket" in b for b in raw_jobs)
+
+
+@settings(max_examples=100)
+@given(jobs=slot_jobs(min_size=0, max_size=0))
+def test_p21_empty_returns_none(jobs: list[dict]) -> None:
+    """No jobs → (None, []) (the no-data sentinel that trips the LOW-confidence cost range, R18.4)."""
+    slots, raw = WorkloadAnalyzer().analyze_from_api(_FakeClient(jobs), "proj")
+    assert slots is None
+    assert raw == []

--- a/solution-architecture/clis/bq-assess/tests/unit/__init__.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# unit tests package

--- a/solution-architecture/clis/bq-assess/tests/unit/test_analyzer.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_analyzer.py
@@ -1,0 +1,264 @@
+"""Unit tests for the QueryAnalyzer.
+
+Validates: Requirements 9.4, 9.5
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bq_assess.core.analyzer import AnalyzerError, QueryAnalyzer
+
+
+@pytest.fixture
+def analyzer() -> QueryAnalyzer:
+    return QueryAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# Helper to write a query log JSON file
+# ---------------------------------------------------------------------------
+
+def _write_query_log(tmp_path, queries: list[str]):
+    """Write a list of SQL strings as a JSON query log file and return the path."""
+    path = tmp_path / "queries.json"
+    entries = [{"query": q} for q in queries]
+    with open(path, "w") as f:
+        json.dump(entries, f)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Query log parsing — table_query_counts
+# ---------------------------------------------------------------------------
+
+class TestQueryLogParsing:
+    """Test query log parsing with known query patterns."""
+
+    def test_simple_select_extracts_table(self, analyzer: QueryAnalyzer, tmp_path):
+        path = _write_query_log(tmp_path, ["SELECT * FROM ds.orders"])
+        result = analyzer.analyze_from_file(path)
+
+        assert "ds.orders" in result.table_query_counts
+        assert result.table_query_counts["ds.orders"] == 1
+
+    def test_join_extracts_both_tables(self, analyzer: QueryAnalyzer, tmp_path):
+        sql = (
+            "SELECT * FROM ds.orders o "
+            "JOIN ds.customers c ON o.customer_id = c.customer_id"
+        )
+        path = _write_query_log(tmp_path, [sql])
+        result = analyzer.analyze_from_file(path)
+
+        assert "ds.orders" in result.table_query_counts
+        assert "ds.customers" in result.table_query_counts
+
+    def test_join_extracts_join_patterns(self, analyzer: QueryAnalyzer, tmp_path):
+        sql = (
+            "SELECT * FROM ds.orders o "
+            "JOIN ds.customers c ON o.customer_id = c.customer_id"
+        )
+        path = _write_query_log(tmp_path, [sql])
+        result = analyzer.analyze_from_file(path)
+
+        assert len(result.join_patterns) > 0
+        # Flatten all join patterns to check for the expected join
+        all_patterns = [
+            jp for patterns in result.join_patterns.values() for jp in patterns
+        ]
+        assert any(jp.join_column == "customer_id" for jp in all_patterns)
+
+    def test_where_extracts_columns(self, analyzer: QueryAnalyzer, tmp_path):
+        sql = "SELECT * FROM ds.orders WHERE o.status = 'active'"
+        path = _write_query_log(tmp_path, [sql])
+        result = analyzer.analyze_from_file(path)
+
+        assert len(result.where_columns) > 0
+        # The WHERE clause references o.status
+        all_cols = [
+            col for cols in result.where_columns.values() for col in cols
+        ]
+        assert "status" in all_cols
+
+    def test_multiple_queries_accumulate_counts(self, analyzer: QueryAnalyzer, tmp_path):
+        queries = [
+            "SELECT * FROM ds.orders",
+            "SELECT * FROM ds.orders WHERE o.id = 1",
+            "SELECT * FROM ds.customers",
+        ]
+        path = _write_query_log(tmp_path, queries)
+        result = analyzer.analyze_from_file(path)
+
+        assert result.table_query_counts["ds.orders"] == 2
+        assert result.table_query_counts["ds.customers"] == 1
+
+    def test_result_is_anonymized(self, analyzer: QueryAnalyzer, tmp_path):
+        path = _write_query_log(tmp_path, ["SELECT * FROM ds.orders"])
+        result = analyzer.analyze_from_file(path)
+
+        assert result.anonymized is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Anonymization
+# ---------------------------------------------------------------------------
+
+class TestAnonymization:
+    """Test anonymization with specific SQL strings."""
+
+    def test_string_literal_replaced(self, analyzer: QueryAnalyzer):
+        sql = "SELECT * FROM t WHERE name = 'John' AND age = 25"
+        result = analyzer.anonymize_query(sql)
+
+        assert "'John'" not in result
+        assert "'?'" in result
+
+    def test_numeric_literal_replaced(self, analyzer: QueryAnalyzer):
+        sql = "SELECT * FROM t WHERE name = 'John' AND age = 25"
+        result = analyzer.anonymize_query(sql)
+
+        # 25 after = should be replaced with ?
+        assert "= 25" not in result
+        assert "= ?" in result
+
+    def test_preserves_table_and_column_names(self, analyzer: QueryAnalyzer):
+        sql = "SELECT col1 FROM table1"
+        result = analyzer.anonymize_query(sql)
+
+        assert "col1" in result
+        assert "table1" in result
+        # No changes expected — no literals to anonymize
+        assert result == sql
+
+    def test_multiple_string_literals(self, analyzer: QueryAnalyzer):
+        sql = "SELECT * FROM t WHERE city = 'NYC' OR city = 'LA'"
+        result = analyzer.anonymize_query(sql)
+
+        assert "'NYC'" not in result
+        assert "'LA'" not in result
+        assert result.count("'?'") == 2
+
+    def test_float_literal_replaced(self, analyzer: QueryAnalyzer):
+        sql = "SELECT * FROM t WHERE price > 19.99"
+        result = analyzer.anonymize_query(sql)
+
+        assert "19.99" not in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Hub table detection
+# ---------------------------------------------------------------------------
+
+class TestHubTableDetection:
+    """Test hub table detection (tables with >5 distinct join partners)."""
+
+    def test_hub_table_detected(self, analyzer: QueryAnalyzer, tmp_path):
+        # Create queries where ds.hub joins with 6 different tables
+        queries = []
+        for i in range(6):
+            queries.append(
+                f"SELECT * FROM ds.hub h "
+                f"JOIN ds.table{i} t ON h.id = t.id"
+            )
+        path = _write_query_log(tmp_path, queries)
+        result = analyzer.analyze_from_file(path)
+
+        assert "ds.hub" in result.hub_tables
+
+    def test_non_hub_table_excluded(self, analyzer: QueryAnalyzer, tmp_path):
+        # Only 3 join partners — should NOT be a hub table
+        queries = []
+        for i in range(3):
+            queries.append(
+                f"SELECT * FROM ds.small h "
+                f"JOIN ds.partner{i} t ON h.id = t.id"
+            )
+        path = _write_query_log(tmp_path, queries)
+        result = analyzer.analyze_from_file(path)
+
+        assert "ds.small" not in result.hub_tables
+
+
+# ---------------------------------------------------------------------------
+# 4. Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    """Test error conditions raise AnalyzerError."""
+
+    def test_file_not_found_raises(self, analyzer: QueryAnalyzer):
+        with pytest.raises(AnalyzerError, match="not found"):
+            analyzer.analyze_from_file("/nonexistent/path/queries.json")
+
+    def test_invalid_json_raises(self, analyzer: QueryAnalyzer, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("this is not json {{{", encoding="utf-8")
+
+        with pytest.raises(AnalyzerError, match="Failed to parse"):
+            analyzer.analyze_from_file(str(path))
+
+    def test_empty_query_list_returns_empty(self, analyzer: QueryAnalyzer, tmp_path):
+        path = _write_query_log(tmp_path, [])
+        result = analyzer.analyze_from_file(path)
+
+        assert result.table_query_counts == {}
+        assert result.join_patterns == {}
+        assert result.where_columns == {}
+        assert result.hub_tables == []
+        assert result.anonymized is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Workload metrics from file
+# ---------------------------------------------------------------------------
+
+class TestWorkloadMetricsFromFile:
+    """Test workload metric extraction from JSON query logs."""
+
+    def test_workload_metrics_extracted(self, analyzer: QueryAnalyzer, tmp_path):
+        """When bytes/timestamps are present, workload metrics are populated."""
+        entries = [
+            {
+                "query": "SELECT * FROM ds.orders",
+                "total_bytes_processed": 1000000,
+                "creation_time": "2025-01-15T10:00:00+00:00",
+            },
+            {
+                "query": "SELECT * FROM ds.users",
+                "total_bytes_processed": 2000000,
+                "creation_time": "2025-01-15T11:00:00+00:00",
+            },
+        ]
+        path = tmp_path / "queries.json"
+        path.write_text(json.dumps(entries), encoding="utf-8")
+
+        result = analyzer.analyze_from_file(str(path))
+
+        assert result.workload_metrics is not None
+        assert result.workload_metrics.total_queries == 2
+        assert result.workload_metrics.total_bytes_processed == 3000000
+        assert result.workload_metrics.distinct_query_hours == 2
+
+    def test_workload_metrics_without_timestamps(self, analyzer: QueryAnalyzer, tmp_path):
+        """Metrics work even when no timestamps are provided."""
+        entries = [
+            {"query": "SELECT 1", "total_bytes_processed": 500},
+        ]
+        path = tmp_path / "queries.json"
+        path.write_text(json.dumps(entries), encoding="utf-8")
+
+        result = analyzer.analyze_from_file(str(path))
+
+        assert result.workload_metrics is not None
+        assert result.workload_metrics.total_queries == 1
+        assert result.workload_metrics.peak_hourly_queries == 0
+
+    def test_no_workload_metrics_for_bare_queries(self, analyzer: QueryAnalyzer, tmp_path):
+        """Standard query log format (query only) still returns workload metrics."""
+        path = _write_query_log(tmp_path, ["SELECT 1"])
+        result = analyzer.analyze_from_file(path)
+        # bytes_processed_list will have [0], so workload is still computed
+        assert result.workload_metrics is not None
+        assert result.workload_metrics.total_bytes_processed == 0

--- a/solution-architecture/clis/bq-assess/tests/unit/test_bundle.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_bundle.py
@@ -1,0 +1,450 @@
+# Feature: collector/report split (2026-07-08 design)
+"""Unit + property tests for the bundle package.
+
+Covers:
+- Write → load round-trip losslessness (entities incl. physical_bytes + nested STRUCTs,
+  workload, pricing, rates, failures, queries) — the anti-drift guarantee's foundation.
+- Strict manifest enforcement: schema-version mismatch refusal, checksum-tamper refusal,
+  missing-required-file refusal, optional-file clean degrade.
+- Zip ingestion: .zip == extracted directory, including a nested top-level folder.
+- Disclaimer embedded in the manifest.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bq_assess.bundle import Bundle, BundleLoader, BundleWriter, SCHEMA_VERSION
+from bq_assess.bundle.loader import BundleError
+from bq_assess.bundle.models import QueryRecord
+from bq_assess.core.disclaimer import FULL_DISCLAIMER
+from bq_assess.models import (
+    BQPricingModel,
+    ConfidenceLevel,
+    FailureRecord,
+    PricingDetection,
+    SlotUtilization,
+)
+from tests.conftest import entity_metadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(entities, **overrides) -> Bundle:
+    defaults = dict(
+        project_id="test-project",
+        bq_location="australia-southeast1",
+        aws_region="ap-southeast-2",
+        entities=entities,
+        failures=[FailureRecord(entity_name="ds.broken", stage="scan", error="403")],
+        workload=SlotUtilization(
+            avg_slots=10.0, p50_slots=8.0, p99_slots=40.0, peak_slots=55.0,
+            active_hour_fraction=0.4, total_slot_ms=86_400_000, days_sampled=14,
+            total_bytes_processed=5 * 10**12, total_bytes_billed=4 * 10**12,
+            has_billed_bytes=True, total_queries=1200, lookback_days=30,
+        ),
+        pricing=PricingDetection(
+            model=BQPricingModel.ON_DEMAND,
+            confidence=ConfidenceLevel.HIGH,
+            source_note="JOBS reservation_id NULL on all jobs (2026-07-08)",
+        ),
+        rates={"aws": {"rpu_hour": 0.45}, "gcp": {}, "is_live": True,
+               "staleness_warning": "", "aws_region": "ap-southeast-2",
+               "bq_location": "australia-southeast1"},
+        queries=[
+            QueryRecord(
+                query="SELECT a FROM ds.t WHERE x = '?'",
+                total_slot_ms=1234, total_bytes_processed=10**9,
+                total_bytes_billed=10**9, statement_type="SELECT",
+                creation_time="2026-07-01T10:00:00+00:00",
+            ),
+            QueryRecord(
+                query="SELECT b FROM ds.u LIMIT ?",
+                total_slot_ms=99, total_bytes_processed=0,
+                total_bytes_billed=None, statement_type="SELECT",
+                creation_time=None,
+            ),
+        ],
+        storage_basis="measured",
+        collector_version="0.3.0",
+        created_at="2026-07-08T12:00:00+00:00",
+    )
+    defaults.update(overrides)
+    return Bundle(**defaults)
+
+
+def _entities_equal(a, b) -> bool:
+    """Structural equality via dataclasses.asdict (nested columns included)."""
+    return dataclasses.asdict(a) == dataclasses.asdict(b)
+
+
+def _zip_bundle(src_dir: str, zip_path: Path, *, prefix: str = "") -> None:
+    """Zip a bundle dir's files under an arc prefix — THE zip-builder for these tests."""
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for p in Path(src_dir).rglob("*"):
+            if p.is_file():
+                zf.write(p, prefix + p.name)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip (property test over generated entities)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @settings(max_examples=25, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+    @given(entities=st.lists(entity_metadata(), min_size=1, max_size=6))
+    def test_entities_round_trip_lossless(self, entities) -> None:
+        """write → load preserves every entity field, incl. nested STRUCT columns,
+        both partitionings, routines, and physical_bytes."""
+        import tempfile
+        for i, e in enumerate(entities):
+            # Deduplicate full_names (strategy may collide) and populate physical_bytes
+            e.full_name = f"{e.dataset_id}.{e.entity_id}_{i}"
+            e.entity_id = f"{e.entity_id}_{i}"
+            if e.num_bytes:
+                e.physical_bytes = e.num_bytes // 2
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = _make_bundle(entities)
+            bundle_dir = BundleWriter().write(bundle, tmp)
+            loaded = BundleLoader().load(bundle_dir)
+
+        assert len(loaded.entities) == len(entities)
+        # Loader emits tables first, then routines — compare as maps by full_name.
+        by_name = {e.full_name: e for e in loaded.entities}
+        for original in entities:
+            assert original.full_name in by_name, f"{original.full_name} lost in round-trip"
+            assert _entities_equal(original, by_name[original.full_name])
+
+    def test_full_bundle_round_trip(self, tmp_path) -> None:
+        """Workload, pricing, rates, failures, queries, and manifest scalars survive."""
+        entities = []
+        bundle = _make_bundle(entities)
+        bundle_dir = BundleWriter().write(bundle, str(tmp_path))
+        loaded = BundleLoader().load(bundle_dir)
+
+        assert loaded.project_id == bundle.project_id
+        assert loaded.bq_location == bundle.bq_location
+        assert loaded.aws_region == bundle.aws_region
+        assert loaded.storage_basis == "measured"
+        assert loaded.collector_version == "0.3.0"
+        assert dataclasses.asdict(loaded.workload) == dataclasses.asdict(bundle.workload)
+        assert dataclasses.asdict(loaded.pricing) == dataclasses.asdict(bundle.pricing)
+        assert loaded.rates == bundle.rates
+        assert [dataclasses.asdict(f) for f in loaded.failures] == [
+            dataclasses.asdict(f) for f in bundle.failures
+        ]
+        assert [dataclasses.asdict(q) for q in loaded.queries] == [
+            dataclasses.asdict(q) for q in bundle.queries
+        ]
+
+    def test_none_workload_pricing_rates_round_trip(self, tmp_path) -> None:
+        """A degraded collection (no workload/pricing/rates/queries) loads cleanly."""
+        bundle = _make_bundle([], workload=None, pricing=None, rates=None,
+                              queries=None, failures=[])
+        bundle_dir = BundleWriter().write(bundle, str(tmp_path))
+        loaded = BundleLoader().load(bundle_dir)
+
+        assert loaded.workload is None
+        assert loaded.pricing is None
+        assert loaded.rates is None
+        assert loaded.queries is None
+        assert loaded.failures == []
+
+    def test_billed_key_absence_means_unavailable(self, tmp_path) -> None:
+        """queries.jsonl omits total_bytes_billed when None — absent key must load
+        back as None, never 0 (billed-unavailable semantics)."""
+        bundle = _make_bundle([])
+        bundle_dir = BundleWriter().write(bundle, str(tmp_path))
+
+        lines = (Path(bundle_dir) / "queries.jsonl").read_text().strip().split("\n")
+        rows = [json.loads(line) for line in lines]
+        assert "total_bytes_billed" in rows[0]
+        assert "total_bytes_billed" not in rows[1]
+
+        loaded = BundleLoader().load(bundle_dir)
+        assert loaded.queries[0].total_bytes_billed == 10**9
+        assert loaded.queries[1].total_bytes_billed is None
+
+
+# ---------------------------------------------------------------------------
+# Manifest enforcement (strict)
+# ---------------------------------------------------------------------------
+
+
+class TestManifestEnforcement:
+    def test_schema_version_mismatch_refused(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        manifest_path = Path(bundle_dir) / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["schema_version"] = SCHEMA_VERSION + 1
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BundleError, match="schema version mismatch"):
+            BundleLoader().load(bundle_dir)
+
+    def test_tampered_file_refused(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        tables = Path(bundle_dir) / "tables.json"
+        tables.write_text('[{"full_name": "evil.injected", "entity_type": "TABLE"}]')
+
+        with pytest.raises(BundleError, match="Checksum mismatch for tables.json"):
+            BundleLoader().load(bundle_dir)
+
+    def test_missing_required_file_refused(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        (Path(bundle_dir) / "workload.json").unlink()
+
+        with pytest.raises(BundleError, match="workload.json"):
+            BundleLoader().load(bundle_dir)
+
+    def test_manifest_listed_but_missing_queries_refused(self, tmp_path) -> None:
+        """queries.jsonl listed in manifest but absent on disk → REFUSED. The writer
+        only lists it when written, so listed-but-missing is always truncation or
+        tampering — silently degrading was the 2026-07-08 review's finding 6."""
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        (Path(bundle_dir) / "queries.jsonl").unlink()
+
+        with pytest.raises(BundleError, match="queries.jsonl"):
+            BundleLoader().load(bundle_dir)
+
+    def test_queries_absent_from_manifest_loads_cleanly(self, tmp_path) -> None:
+        """A bundle collected with --exclude-query-text (no queries.jsonl written,
+        none listed in the manifest) loads with queries=None."""
+        bundle_dir = BundleWriter().write(_make_bundle([], queries=None), str(tmp_path))
+
+        loaded = BundleLoader().load(bundle_dir)
+        assert loaded.queries is None
+
+    def test_partial_workload_json_raises_bundle_error(self, tmp_path) -> None:
+        """A workload.json missing required SlotUtilization fields (hand-edited,
+        re-checksummed) must fail as BundleError, not a raw TypeError."""
+        import json as _json
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        wl_path = Path(bundle_dir) / "workload.json"
+        wl_path.write_text('{"p50_slots": 1.0}')
+        # Re-checksum so the manifest gate passes and deserialization is reached
+        manifest_path = Path(bundle_dir) / "manifest.json"
+        manifest = _json.loads(manifest_path.read_text())
+        from bq_assess.bundle.models import sha256_file
+        manifest["files"]["workload.json"] = sha256_file(wl_path)
+        manifest_path.write_text(_json.dumps(manifest))
+
+        with pytest.raises(BundleError, match="workload.json"):
+            BundleLoader().load(bundle_dir)
+
+    def test_missing_manifest_refused(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        (Path(bundle_dir) / "manifest.json").unlink()
+
+        with pytest.raises(BundleError, match="manifest.json not found"):
+            BundleLoader().load(bundle_dir)
+
+    def test_nonexistent_path_refused(self) -> None:
+        with pytest.raises(BundleError, match="not found"):
+            BundleLoader().load("/nonexistent/bundle")
+
+    def test_manifest_carries_disclaimer(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path))
+        manifest = json.loads((Path(bundle_dir) / "manifest.json").read_text())
+        assert manifest["disclaimer"] == FULL_DISCLAIMER
+        assert manifest["schema_version"] == SCHEMA_VERSION
+        assert manifest["bq_location"] == "australia-southeast1"
+        assert manifest["aws_region"] == "ap-southeast-2"
+
+
+# ---------------------------------------------------------------------------
+# Zip ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestZipIngestion:
+    def test_zip_equals_directory(self, tmp_path) -> None:
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path / "out"))
+        zip_path = tmp_path / "bundle.zip"
+        _zip_bundle(bundle_dir, zip_path)
+
+        from_dir = BundleLoader().load(bundle_dir)
+        from_zip = BundleLoader().load(str(zip_path))
+
+        assert dataclasses.asdict(from_zip.workload) == dataclasses.asdict(from_dir.workload)
+        assert from_zip.project_id == from_dir.project_id
+        assert from_zip.rates == from_dir.rates
+        assert len(from_zip.entities) == len(from_dir.entities)
+
+    def test_zip_with_nested_folder(self, tmp_path) -> None:
+        """Customers zip the folder itself: bundle.zip containing bundle/…"""
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path / "out"))
+        zip_path = tmp_path / "nested.zip"
+        _zip_bundle(bundle_dir, zip_path, prefix="bundle/")
+
+        loaded = BundleLoader().load(str(zip_path))
+        assert loaded.project_id == "test-project"
+
+    def test_not_a_zip_refused(self, tmp_path) -> None:
+        bogus = tmp_path / "bogus.zip"
+        bogus.write_text("this is not a zip")
+        with pytest.raises(BundleError, match="Not a valid zip"):
+            BundleLoader().load(str(bogus))
+
+    def test_zip_without_manifest_refused(self, tmp_path) -> None:
+        src = tmp_path / "empty"
+        src.mkdir()
+        (src / "readme.txt").write_text("no bundle here")
+        zip_path = tmp_path / "nomanifest.zip"
+        _zip_bundle(str(src), zip_path)
+
+        with pytest.raises(BundleError, match="No manifest.json found"):
+            BundleLoader().load(str(zip_path))
+
+    def test_tampered_zip_refused(self, tmp_path) -> None:
+        """Tampering inside the zip is caught by the same checksum gate."""
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path / "out"))
+        # Tamper before zipping
+        (Path(bundle_dir) / "pricing.json").write_text('{"model": "CAPACITY"}')
+        zip_path = tmp_path / "tampered.zip"
+        _zip_bundle(bundle_dir, zip_path)
+
+        with pytest.raises(BundleError, match="Checksum mismatch"):
+            BundleLoader().load(str(zip_path))
+
+
+# ---------------------------------------------------------------------------
+# Cleanup guard: zip extraction shouldn't leak the temp dir on load failure
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_one(self) -> None:
+        """Bump SCHEMA_VERSION when the bundle shape changes — this test is the
+        tripwire reminding you the loader/writer must stay compatible."""
+        assert SCHEMA_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# Review fixes (2026-07-08 code review of the collector/report split)
+# ---------------------------------------------------------------------------
+
+
+class TestZipDepthAndCleanup:
+    def test_zip_two_levels_deep_loads(self, tmp_path) -> None:
+        """`zip -r bundle.zip bundle-out/bundle` stores entries two levels deep —
+        the documented customer command must load (review fix 4)."""
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path / "out"))
+        zip_path = tmp_path / "deep.zip"
+        _zip_bundle(bundle_dir, zip_path, prefix="bundle-out/bundle/")
+
+        loaded = BundleLoader().load(str(zip_path))
+        assert loaded.project_id == "test-project"
+
+    def test_zip_temp_dir_cleaned_up(self, tmp_path, monkeypatch) -> None:
+        """Zip extraction temp dirs are removed after load — success AND error
+        paths (review fix 9)."""
+        import tempfile as _tempfile
+        created: list[str] = []
+        real_mkdtemp = _tempfile.mkdtemp
+
+        def tracking_mkdtemp(*args, **kwargs):
+            d = real_mkdtemp(*args, **kwargs)
+            created.append(d)
+            return d
+
+        monkeypatch.setattr(_tempfile, "mkdtemp", tracking_mkdtemp)
+
+        bundle_dir = BundleWriter().write(_make_bundle([]), str(tmp_path / "out"))
+        zip_path = tmp_path / "b.zip"
+        _zip_bundle(bundle_dir, zip_path, prefix="bundle/")
+
+        BundleLoader().load(str(zip_path))
+        assert created and not Path(created[-1]).exists(), "temp dir leaked on success"
+
+        # Error path: tampered zip must also clean up
+        (Path(bundle_dir) / "pricing.json").write_text('{"model": "CAPACITY"}')
+        bad_zip = tmp_path / "bad.zip"
+        _zip_bundle(bundle_dir, bad_zip, prefix="bundle/")
+        with pytest.raises(BundleError):
+            BundleLoader().load(str(bad_zip))
+        assert not Path(created[-1]).exists(), "temp dir leaked on error path"
+
+
+class TestQueryLogFormatConsistency:
+    """Review fix 6: _queries_from_file must accept every format
+    WorkloadAnalyzer.analyze_from_file accepts (JSON array AND JSONL)."""
+
+    _ENTRIES = [
+        {"query": "SELECT a FROM ds.t WHERE x = 'secret'", "total_slot_ms": 100,
+         "total_bytes_processed": 10, "creation_time": "2026-07-01T10:00:00+00:00"},
+        {"query": "SELECT b FROM ds.u LIMIT 5", "total_slot_ms": 50,
+         "total_bytes_processed": 5, "creation_time": "2026-07-01T11:00:00+00:00"},
+    ]
+
+    def test_jsonl_file_yields_statements(self, tmp_path) -> None:
+        from bq_assess.collector import _queries_from_file
+        path = tmp_path / "logs.jsonl"
+        path.write_text("\n".join(json.dumps(e) for e in self._ENTRIES))
+
+        records = _queries_from_file(str(path))
+        assert len(records) == 2
+        # Anonymization applied before anything else sees the text
+        assert "secret" not in records[0].query
+
+    def test_json_array_file_yields_statements(self, tmp_path) -> None:
+        from bq_assess.collector import _queries_from_file
+        path = tmp_path / "logs.json"
+        path.write_text(json.dumps(self._ENTRIES))
+
+        records = _queries_from_file(str(path))
+        assert len(records) == 2
+
+
+class TestTruncationProof:
+    """Review round-2 fix 2: truncation is proven from the RAW row count —
+    empty-text rows must not defeat the boundary check."""
+
+    def _rows(self, n, empties=0):
+        rows = [
+            {"query": f"SELECT {i}", "total_slot_ms": n - i,
+             "total_bytes_processed": 1, "total_bytes_billed": 1,
+             "missing_billed_jobs": 0, "statement_type": "SELECT",
+             "creation_time": None}
+            for i in range(n - empties)
+        ]
+        rows += [{"query": "", "total_slot_ms": 0} for _ in range(empties)]
+        return rows
+
+    def test_truncated_flag_from_raw_rows_despite_empty_text(self, monkeypatch) -> None:
+        from bq_assess import collector as coll
+        from bq_assess.core.jobs_query import QUERIES_EXPORT_LIMIT
+
+        # limit+1 raw rows returned, one with empty text: records == LIMIT exactly,
+        # but truncation must STILL be flagged (the old len(records) check missed it).
+        monkeypatch.setattr(
+            coll, "read_jobs_queries",
+            lambda *a, **k: self._rows(QUERIES_EXPORT_LIMIT + 1, empties=1),
+        )
+        records, truncated = coll._queries_from_api(None, "p", 30, "US")
+        assert truncated is True
+        assert len(records) == QUERIES_EXPORT_LIMIT
+
+    def test_not_truncated_at_exact_limit(self, monkeypatch) -> None:
+        from bq_assess import collector as coll
+        from bq_assess.core.jobs_query import QUERIES_EXPORT_LIMIT
+
+        monkeypatch.setattr(
+            coll, "read_jobs_queries",
+            lambda *a, **k: self._rows(QUERIES_EXPORT_LIMIT),
+        )
+        records, truncated = coll._queries_from_api(None, "p", 30, "US")
+        assert truncated is False
+        assert len(records) == QUERIES_EXPORT_LIMIT

--- a/solution-architecture/clis/bq-assess/tests/unit/test_cache.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_cache.py
@@ -1,0 +1,335 @@
+"""Unit tests for MetadataCache (SQLite EntityMetadata storage) — R5.1, R5.2, R5.3.
+
+The P8 round-trip Hypothesis property is owned by issue #10 (1.5); these unit tests pin
+store/load on known entities (tables, nested structs, both partitionings, views, routines)
+and the has_cache / overwrite behavior for issue #9 (1.4).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from bq_assess.core.cache import MetadataCache
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    RangePartitionConfig,
+    RoutineMetadata,
+    TimePartitionConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _simple_table(entity_id: str = "users", dataset_id: str = "analytics") -> EntityMetadata:
+    """A plain table — no partitioning, no clustering."""
+    return EntityMetadata(
+        entity_id=entity_id,
+        dataset_id=dataset_id,
+        full_name=f"{dataset_id}.{entity_id}",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=1000,
+        num_bytes=50000,
+        columns=[
+            ColumnSchema(name="id", field_type="INT64", mode="REQUIRED", fields=[]),
+            ColumnSchema(name="name", field_type="STRING", mode="NULLABLE", fields=[]),
+        ],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _nested_struct_table() -> EntityMetadata:
+    """Table with nested STRUCT columns + clean time partitioning (recursive serialization)."""
+    return EntityMetadata(
+        entity_id="events",
+        dataset_id="tracking",
+        full_name="tracking.events",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=5_000_000,
+        num_bytes=2_000_000_000,
+        columns=[
+            ColumnSchema(name="event_id", field_type="STRING", mode="REQUIRED", fields=[]),
+            ColumnSchema(
+                name="payload",
+                field_type="STRUCT",
+                mode="NULLABLE",
+                fields=[
+                    ColumnSchema(name="action", field_type="STRING", mode="NULLABLE", fields=[]),
+                    ColumnSchema(
+                        name="context",
+                        field_type="STRUCT",
+                        mode="NULLABLE",
+                        fields=[
+                            ColumnSchema(name="page", field_type="STRING", mode="NULLABLE", fields=[]),
+                            ColumnSchema(name="referrer", field_type="STRING", mode="NULLABLE", fields=[]),
+                        ],
+                    ),
+                ],
+            ),
+            ColumnSchema(name="tags", field_type="ARRAY", mode="REPEATED", fields=[]),
+        ],
+        time_partitioning=TimePartitionConfig(type="DAY", field="created_at"),
+        range_partitioning=None,
+        clustering_fields=["event_id", "payload"],
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2025, 1, 10, 8, 30, 0, tzinfo=timezone.utc),
+    )
+
+
+def _range_partitioned_table() -> EntityMetadata:
+    """Table with range partitioning (R3.8) — distinct from time partitioning."""
+    return EntityMetadata(
+        entity_id="orders",
+        dataset_id="sales",
+        full_name="sales.orders",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=100_000_000,
+        num_bytes=80_000_000_000,
+        columns=[
+            ColumnSchema(name="order_id", field_type="INT64", mode="REQUIRED", fields=[]),
+            ColumnSchema(name="customer_id", field_type="INT64", mode="REQUIRED", fields=[]),
+        ],
+        time_partitioning=None,
+        range_partitioning=RangePartitionConfig(field="customer_id", start=0, end=1000, interval=10),
+        clustering_fields=["customer_id"],
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2025, 3, 20, 16, 45, 0, tzinfo=timezone.utc),
+    )
+
+
+def _view_entity() -> EntityMetadata:
+    """A VIEW (REBUILT population) carrying view_query + dependency links."""
+    return EntityMetadata(
+        entity_id="active_users",
+        dataset_id="analytics",
+        full_name="analytics.active_users",
+        entity_type=EntityType.VIEW,
+        population=EntityPopulation.REBUILT,
+        num_rows=0,
+        num_bytes=0,
+        columns=[ColumnSchema(name="id", field_type="INT64", mode="NULLABLE", fields=[])],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query="SELECT id FROM analytics.users WHERE active",
+        mview_query=None,
+        routine=None,
+        depends_on=["analytics.users"],
+        last_modified=datetime(2025, 2, 1, 0, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _routine_entity() -> EntityMetadata:
+    """A ROUTINE (REBUILT population) carrying RoutineMetadata."""
+    return EntityMetadata(
+        entity_id="to_upper",
+        dataset_id="udfs",
+        full_name="udfs.to_upper",
+        entity_type=EntityType.ROUTINE,
+        population=EntityPopulation.REBUILT,
+        num_rows=0,
+        num_bytes=0,
+        columns=[],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=RoutineMetadata(
+            name="to_upper",
+            language="JAVASCRIPT",
+            arguments=["s"],
+            body="return s.toUpperCase();",
+            routine_type="SCALAR_FUNCTION",
+        ),
+        depends_on=[],
+        last_modified=datetime(2025, 4, 1, 0, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _assert_entity_equal(original: EntityMetadata, loaded: EntityMetadata) -> None:
+    assert loaded.entity_id == original.entity_id
+    assert loaded.dataset_id == original.dataset_id
+    assert loaded.full_name == original.full_name
+    assert loaded.entity_type == original.entity_type
+    assert loaded.population == original.population
+    assert loaded.num_rows == original.num_rows
+    assert loaded.num_bytes == original.num_bytes
+    assert loaded.last_modified == original.last_modified
+    assert loaded.clustering_fields == original.clustering_fields
+    assert loaded.view_query == original.view_query
+    assert loaded.mview_query == original.mview_query
+    assert loaded.depends_on == original.depends_on
+
+    if original.time_partitioning is None:
+        assert loaded.time_partitioning is None
+    else:
+        assert loaded.time_partitioning is not None
+        assert loaded.time_partitioning.type == original.time_partitioning.type
+        assert loaded.time_partitioning.field == original.time_partitioning.field
+
+    if original.range_partitioning is None:
+        assert loaded.range_partitioning is None
+    else:
+        assert loaded.range_partitioning is not None
+        assert loaded.range_partitioning.field == original.range_partitioning.field
+        assert loaded.range_partitioning.start == original.range_partitioning.start
+        assert loaded.range_partitioning.end == original.range_partitioning.end
+        assert loaded.range_partitioning.interval == original.range_partitioning.interval
+
+    if original.routine is None:
+        assert loaded.routine is None
+    else:
+        assert loaded.routine is not None
+        assert loaded.routine.name == original.routine.name
+        assert loaded.routine.language == original.routine.language
+        assert loaded.routine.arguments == original.routine.arguments
+        assert loaded.routine.body == original.routine.body
+        assert loaded.routine.routine_type == original.routine.routine_type
+
+    _assert_columns_equal(original.columns, loaded.columns)
+
+
+def _assert_columns_equal(original: list[ColumnSchema], loaded: list[ColumnSchema]) -> None:
+    assert len(loaded) == len(original)
+    for orig, back in zip(original, loaded):
+        assert back.name == orig.name
+        assert back.field_type == orig.field_type
+        assert back.mode == orig.mode
+        _assert_columns_equal(orig.fields, back.fields)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreAndLoad:
+    """store/load with known entities — R5.1."""
+
+    def test_simple_table(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        e = _simple_table()
+        cache.store("my-project", [e])
+        loaded = cache.load("my-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(e, loaded[0])
+
+    def test_nested_struct(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        e = _nested_struct_table()
+        cache.store("struct-project", [e])
+        loaded = cache.load("struct-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(e, loaded[0])
+        # nesting preserved
+        payload = loaded[0].columns[1]
+        assert payload.field_type == "STRUCT"
+        assert payload.fields[1].name == "context"
+        assert payload.fields[1].fields[0].name == "page"
+
+    def test_range_partitioned(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        e = _range_partitioned_table()
+        cache.store("range-project", [e])
+        loaded = cache.load("range-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(e, loaded[0])
+        assert loaded[0].range_partitioning is not None
+        assert loaded[0].time_partitioning is None
+
+    def test_view_entity(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        e = _view_entity()
+        cache.store("view-project", [e])
+        loaded = cache.load("view-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(e, loaded[0])
+        assert loaded[0].population is EntityPopulation.REBUILT
+        assert loaded[0].view_query is not None
+        assert loaded[0].depends_on == ["analytics.users"]
+
+    def test_routine_entity(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        e = _routine_entity()
+        cache.store("routine-project", [e])
+        loaded = cache.load("routine-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(e, loaded[0])
+        assert loaded[0].routine is not None
+        assert loaded[0].routine.language == "JAVASCRIPT"
+
+    def test_multiple_entities(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        entities = [
+            _simple_table(),
+            _nested_struct_table(),
+            _range_partitioned_table(),
+            _view_entity(),
+            _routine_entity(),
+        ]
+        cache.store("multi-project", entities)
+        loaded = cache.load("multi-project")
+        assert loaded is not None and len(loaded) == 5
+
+        key = lambda e: (e.dataset_id, e.entity_id)  # noqa: E731
+        for orig, back in zip(sorted(entities, key=key), sorted(loaded, key=key)):
+            _assert_entity_equal(orig, back)
+
+
+class TestHasCache:
+    """has_cache / load-miss behavior — R5.2."""
+
+    def test_has_cache_false_for_unknown(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        assert cache.has_cache("unknown-project") is False
+
+    def test_load_none_for_unknown(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        assert cache.load("unknown-project") is None
+
+    def test_has_cache_true_after_store(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        cache.store("my-project", [_simple_table()])
+        assert cache.has_cache("my-project") is True
+
+
+class TestOverwriteBehavior:
+    """Re-storing replaces previous data — R5.1."""
+
+    def test_second_store_replaces_first(self, tmp_path) -> None:
+        cache = MetadataCache(db_path=os.path.join(str(tmp_path), "cache.db"))
+        first = [
+            _simple_table(entity_id="old_a", dataset_id="ds1"),
+            _simple_table(entity_id="old_b", dataset_id="ds1"),
+        ]
+        cache.store("overwrite-project", first)
+        assert len(cache.load("overwrite-project")) == 2
+
+        second = [_range_partitioned_table()]
+        cache.store("overwrite-project", second)
+        loaded = cache.load("overwrite-project")
+        assert loaded is not None and len(loaded) == 1
+        _assert_entity_equal(second[0], loaded[0])
+        assert {e.entity_id for e in loaded} == {"orders"}

--- a/solution-architecture/clis/bq-assess/tests/unit/test_classifier.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_classifier.py
@@ -1,0 +1,67 @@
+"""Unit tests for the entity classifier — EntityType → EntityPopulation (R4.1-R4.3).
+
+The P5 Hypothesis property (classification partitions the population) is owned by issue #8;
+these unit tests pin the explicit mapping, totality, and disjointness for issue #7 (1.2).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bq_assess.core.classifier import (
+    classify_population,
+    is_table_population,
+)
+from bq_assess.models import EntityPopulation, EntityType
+
+
+class TestClassifyPopulation:
+    @pytest.mark.parametrize(
+        ("entity_type", "expected"),
+        [
+            (EntityType.TABLE, EntityPopulation.TABLE),
+            (EntityType.EXTERNAL, EntityPopulation.TABLE),
+            (EntityType.VIEW, EntityPopulation.REBUILT),
+            (EntityType.MATERIALIZED_VIEW, EntityPopulation.REBUILT),
+            (EntityType.ROUTINE, EntityPopulation.REBUILT),
+        ],
+    )
+    def test_explicit_mapping(self, entity_type, expected):
+        assert classify_population(entity_type) is expected
+
+    def test_mapping_is_total(self):
+        """Every EntityType maps to a population (no member left unclassified)."""
+        for et in EntityType:
+            result = classify_population(et)
+            assert isinstance(result, EntityPopulation)
+
+    def test_mapping_is_disjoint(self):
+        """TABLE and REBUILT populations do not overlap across the type set."""
+        table_types = {et for et in EntityType if classify_population(et) is EntityPopulation.TABLE}
+        rebuilt_types = {et for et in EntityType if classify_population(et) is EntityPopulation.REBUILT}
+        assert table_types.isdisjoint(rebuilt_types)
+        # Union covers every EntityType (total partition)
+        assert table_types | rebuilt_types == set(EntityType)
+
+    def test_table_population_membership(self):
+        assert table_types_only() == {EntityType.TABLE, EntityType.EXTERNAL}
+
+    def test_invalid_input_raises(self):
+        with pytest.raises(TypeError):
+            classify_population("TABLE")  # not an EntityType
+
+
+class TestIsTablePopulation:
+    def test_true_for_table_and_external(self):
+        assert is_table_population(EntityType.TABLE)
+        assert is_table_population(EntityType.EXTERNAL)
+
+    def test_false_for_rebuilt_types(self):
+        assert not is_table_population(EntityType.VIEW)
+        assert not is_table_population(EntityType.MATERIALIZED_VIEW)
+        assert not is_table_population(EntityType.ROUTINE)
+
+
+def table_types_only() -> set[EntityType]:
+    """Helper: the set of EntityTypes classified into the TABLE population."""
+    return {et for et in EntityType if is_table_population(et)}

--- a/solution-architecture/clis/bq-assess/tests/unit/test_cli.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_cli.py
@@ -1,0 +1,412 @@
+# Feature: bq-assess-lakehouse, Phase 7: CLI rewrite (R1)
+"""Unit tests for cli.py — arg parsing, config, validation (R1).
+
+Tests cover:
+- R1.1: Missing --gcp-project rejected
+- R1.2: Missing credential mode (--credentials XOR --use-adc) rejected
+- R1.3: --redshift-type removed (not accepted)
+- R1.4: csv format rejected
+- R1.5: --reservation-config in help
+- R1.6-16: Config loading, merging, precedence
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bq_assess.cli import _load_config, _merge_config, _interactive_prompts, main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FULL_CONFIG_YAML = """\
+gcp:
+  project_id: my-gcp-project
+  credentials: /path/to/sa.json
+  use_adc: false
+  datasets:
+    - analytics
+    - marketing
+
+query_logs:
+  enabled: true
+  file: /tmp/logs.json
+  days: 7
+
+cost:
+  bigquery_monthly: 5000.0
+  reservation_config: /path/to/res.yaml
+
+options:
+  output: output_dir/
+  format:
+    - json
+    - html
+"""
+
+_MINIMAL_CONFIG_YAML = """\
+gcp:
+  project_id: minimal-project
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: _load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    """Test YAML config file loading (R1.6-11)."""
+
+    def test_load_full_config(self, tmp_path: object) -> None:
+        """Load a YAML file with all config sections and verify the flat dict (R1.6)."""
+        config_file = os.path.join(str(tmp_path), "config.yaml")
+        with open(config_file, "w") as f:
+            f.write(_FULL_CONFIG_YAML)
+
+        result = _load_config(config_file)
+
+        assert result["gcp_project"] == "my-gcp-project"
+        assert result["credentials"] == "/path/to/sa.json"
+        assert result["use_adc"] is False
+        assert result["datasets"] == "analytics,marketing"
+        assert result["include_query_logs"] is True
+        assert result["query_logs"] == "/tmp/logs.json"  # nosec B108 - asserting CLI arg passthrough, no file created
+        assert result["query_log_days"] == 7
+        assert result["bigquery_monthly_cost"] == 5000.0
+        assert result["reservation_config"] == "/path/to/res.yaml"
+        assert result["output"] == "output_dir/"
+        assert result["format"] == "json,html"
+
+    def test_load_minimal_config(self, tmp_path: object) -> None:
+        """Load a config with only gcp.project_id set (R1.7)."""
+        config_file = os.path.join(str(tmp_path), "config.yaml")
+        with open(config_file, "w") as f:
+            f.write(_MINIMAL_CONFIG_YAML)
+
+        result = _load_config(config_file)
+
+        assert result["gcp_project"] == "minimal-project"
+        assert "credentials" not in result
+        assert "use_adc" not in result
+
+    def test_reservation_config_parsed(self, tmp_path: object) -> None:
+        """_load_config parses cost.reservation_config correctly (R1.8)."""
+        config_file = os.path.join(str(tmp_path), "config.yaml")
+        with open(config_file, "w") as f:
+            f.write("cost:\n  reservation_config: /path/to/res.json\n")
+
+        result = _load_config(config_file)
+        assert result["reservation_config"] == "/path/to/res.json"
+
+    def test_missing_file_exits(self, tmp_path: object) -> None:
+        """Loading a non-existent config file should sys.exit(1) (R1.10)."""
+        with pytest.raises(SystemExit) as exc_info:
+            _load_config(os.path.join(str(tmp_path), "nonexistent.yaml"))
+        assert exc_info.value.code == 1
+
+    def test_invalid_yaml_exits(self, tmp_path: object) -> None:
+        """Loading an invalid YAML file should sys.exit(1) (R1.11)."""
+        config_file = os.path.join(str(tmp_path), "bad.yaml")
+        with open(config_file, "w") as f:
+            f.write(":\n  - :\n  bad: [unterminated")
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_config(config_file)
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: _merge_config
+# ---------------------------------------------------------------------------
+
+
+class TestMergeConfig:
+    """Test CLI/config merging (R1.12-16)."""
+
+    def test_cli_overrides_config(self) -> None:
+        """CLI params override config file values for the same key (R1.12)."""
+        config_values = {"gcp_project": "config-project", "output": "config-out/"}
+        cli_params = {"gcp_project": "cli-project"}
+
+        merged = _merge_config(cli_params, config_values)
+
+        assert merged["gcp_project"] == "cli-project"
+        assert merged["output"] == "config-out/"
+
+    def test_config_only_keys_preserved(self) -> None:
+        """Keys present only in config are preserved in the merged result (R1.16)."""
+        config_values = {"output": "dir/", "bigquery_monthly_cost": 3000.0}
+        cli_params = {"gcp_project": "my-proj"}
+
+        merged = _merge_config(cli_params, config_values)
+
+        assert merged["gcp_project"] == "my-proj"
+        assert merged["output"] == "dir/"
+        assert merged["bigquery_monthly_cost"] == 3000.0
+
+    def test_none_cli_values_do_not_override(self) -> None:
+        """None CLI values should not override config values (R1.14)."""
+        config_values = {"gcp_project": "config-project"}
+        cli_params = {"gcp_project": None}
+
+        merged = _merge_config(cli_params, config_values)
+
+        assert merged["gcp_project"] == "config-project"
+
+    def test_empty_config_returns_cli_params(self) -> None:
+        """When config is empty, merged result equals CLI params (non-None) (R1.15)."""
+        cli_params = {"gcp_project": "proj", "use_adc": True}
+
+        merged = _merge_config(cli_params, {})
+
+        assert merged["gcp_project"] == "proj"
+        assert merged["use_adc"] is True
+
+    def test_config_value_used_when_cli_none(self) -> None:
+        """When CLI doesn't provide a value, config value is used (R1.13)."""
+        config_values = {"gcp_project": "config-proj", "output": "config-dir"}
+        cli_params = {}
+
+        merged = _merge_config(cli_params, config_values)
+
+        assert merged["gcp_project"] == "config-proj"
+        assert merged["output"] == "config-dir"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Click command argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestClickCommand:
+    """Test Click CLI argument parsing with CliRunner (R1.1-5).
+
+    The pipeline seam is now collect() + analyze_and_report() (collector/report
+    split) — tests patch both where they used to patch _run_pipeline.
+    """
+
+    def test_gcp_project_and_use_adc_accepted(self) -> None:
+        """--gcp-project and --use-adc are accepted as valid options."""
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect, \
+             patch("bq_assess.cli.analyze_and_report") as mock_report:
+            result = runner.invoke(main, [
+                "--gcp-project", "test-project",
+                "--use-adc",
+            ])
+            # Pipeline should be called (we mock it to avoid real BQ calls)
+            assert mock_collect.called
+            assert mock_report.called
+            assert result.exit_code == 0
+
+    def test_gcp_project_with_credentials_accepted(self) -> None:
+        """--gcp-project with --credentials is accepted."""
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect, \
+             patch("bq_assess.cli.analyze_and_report") as mock_report:
+            result = runner.invoke(main, [
+                "--gcp-project", "test-project",
+                "--credentials", "/path/to/creds.json",
+            ])
+            assert mock_collect.called
+            assert mock_report.called
+            assert result.exit_code == 0
+
+    def test_assess_subcommand_equivalent_to_bare(self) -> None:
+        """`bq-assess assess …` parses identically to bare `bq-assess …`."""
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect, \
+             patch("bq_assess.cli.analyze_and_report") as mock_report:
+            result = runner.invoke(main, [
+                "assess",
+                "--gcp-project", "test-project",
+                "--use-adc",
+            ])
+            assert mock_collect.called
+            assert mock_report.called
+            assert result.exit_code == 0
+
+    def test_missing_gcp_project_shows_error(self) -> None:
+        """Missing --gcp-project (without --interactive) should exit with code 1 (R1.1)."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--use-adc"])
+        assert result.exit_code == 1
+        assert "gcp-project" in result.output.lower() or "required" in result.output.lower()
+
+    def test_missing_credentials_shows_error(self) -> None:
+        """Missing both --credentials and --use-adc should exit with code 1 (R1.2)."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--gcp-project", "test-project"])
+        assert result.exit_code == 1
+        assert "credentials" in result.output.lower() or "use-adc" in result.output.lower()
+
+    def test_redshift_type_not_accepted(self) -> None:
+        """CLI rejects --redshift-type option (removed in Phase 7, R1.3)."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--gcp-project", "p", "--use-adc", "--redshift-type", "ra3.xlplus"])
+        # Click should reject the unknown option
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower() or "redshift-type" in result.output.lower()
+
+    def test_csv_format_rejected(self) -> None:
+        """CLI rejects csv format (not implemented, R20.8)."""
+        runner = CliRunner()
+        # Format validation runs before collect() — mock collect to prevent BQ calls.
+        with patch("bq_assess.cli.collect") as mock_collect:
+            result = runner.invoke(main, ["--gcp-project", "p", "--use-adc", "--format", "csv"])
+            assert result.exit_code != 0, "csv format must be rejected with non-zero exit"
+            assert "not supported" in result.output.lower() or "csv" in result.output.lower()
+            assert not mock_collect.called, "collect must not run when the format is invalid"
+
+    def test_help_shows_reservation_config(self) -> None:
+        """assess help includes --reservation-config option (R1.5). Options live on
+        the subcommand only (group options were silently dropped — review fix 5)."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["assess", "--help"])
+        assert result.exit_code == 0
+        assert "--reservation-config" in result.output
+
+    def test_options_before_subcommand_error_not_silently_dropped(self) -> None:
+        """`bq-assess --gcp-project p assess` must ERROR clearly, not parse the
+        options at group level and silently discard them (review fix 5)."""
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect:
+            result = runner.invoke(main, ["--gcp-project", "p", "--use-adc", "assess"])
+            assert result.exit_code != 0
+            assert not mock_collect.called
+
+    def test_config_file_option(self, tmp_path: object) -> None:
+        """--config loads values from a YAML file."""
+        config_file = os.path.join(str(tmp_path), "config.yaml")
+        with open(config_file, "w") as f:
+            f.write("gcp:\n  project_id: config-proj\n  use_adc: true\n")
+
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect, \
+             patch("bq_assess.cli.analyze_and_report"):
+            result = runner.invoke(main, ["--config", config_file])
+            assert mock_collect.called
+            # Verify the pipeline received the config values
+            call_params = mock_collect.call_args[0][0]
+            assert call_params["gcp_project"] == "config-proj"
+            assert call_params["use_adc"] is True
+            assert result.exit_code == 0
+
+    def test_cli_overrides_config_file(self, tmp_path: object) -> None:
+        """CLI args override config file values."""
+        config_file = os.path.join(str(tmp_path), "config.yaml")
+        with open(config_file, "w") as f:
+            f.write("gcp:\n  project_id: config-proj\n  use_adc: true\n")
+
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect") as mock_collect, \
+             patch("bq_assess.cli.analyze_and_report"):
+            result = runner.invoke(main, [
+                "--config", config_file,
+                "--gcp-project", "cli-proj",
+                "--use-adc",
+            ])
+            assert mock_collect.called
+            call_params = mock_collect.call_args[0][0]
+            assert call_params["gcp_project"] == "cli-proj"
+            assert result.exit_code == 0
+
+    def test_pipeline_exception_exits_with_code_1(self) -> None:
+        """If the pipeline raises an exception, CLI exits with code 1."""
+        runner = CliRunner()
+        with patch("bq_assess.cli.collect", side_effect=RuntimeError("boom")):
+            result = runner.invoke(main, [
+                "--gcp-project", "test-project",
+                "--use-adc",
+            ])
+            assert result.exit_code == 1
+            assert "fatal" in result.output.lower() or "boom" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _interactive_prompts (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestInteractivePrompts:
+    """Test interactive mode prompts with mocked Rich prompts."""
+
+    @patch("bq_assess.cli.Prompt.ask")
+    @patch("bq_assess.cli.Confirm.ask")
+    def test_fills_missing_gcp_project(self, mock_confirm, mock_prompt) -> None:
+        """Interactive mode prompts for gcp_project when missing."""
+        mock_prompt.side_effect = lambda *a, **kw: {
+            "GCP Project ID": "prompted-project",
+            "Authentication method": "adc",
+            "Datasets to scan (comma-separated, or empty for all)": "",
+            "Path to exported query logs JSON (or empty for API)": "",
+            "Query log lookback window in days (1-90)": "30",
+            "Monthly BigQuery cost override (or empty to calculate)": "",
+            "Output directory": "reports/",
+            "Output formats (json,html)": "json,html",
+        }.get(a[0], "")
+        mock_confirm.return_value = False
+
+        params: dict = {}
+        result = _interactive_prompts(params)
+
+        assert result["gcp_project"] == "prompted-project"
+        assert result["use_adc"] is True
+
+    @patch("bq_assess.cli.Prompt.ask")
+    @patch("bq_assess.cli.Confirm.ask")
+    def test_preserves_existing_values(self, mock_confirm, mock_prompt) -> None:
+        """Interactive mode does not overwrite already-set values."""
+        mock_prompt.side_effect = lambda *a, **kw: {
+            "Datasets to scan (comma-separated, or empty for all)": "",
+            "Path to exported query logs JSON (or empty for API)": "",
+            "Query log lookback window in days (1-90)": "30",
+            "Monthly BigQuery cost override (or empty to calculate)": "",
+            "Output directory": "reports/",
+            "Output formats (json,html)": "json,html",
+        }.get(a[0], "")
+        mock_confirm.return_value = False
+
+        params = {"gcp_project": "already-set", "use_adc": True}
+        result = _interactive_prompts(params)
+
+        assert result["gcp_project"] == "already-set"
+
+    @patch("bq_assess.cli.Prompt.ask")
+    @patch("bq_assess.cli.Confirm.ask")
+    def test_credentials_path_prompt(self, mock_confirm, mock_prompt) -> None:
+        """Interactive mode prompts for credentials path when 'credentials' is chosen."""
+        call_count = 0
+
+        def prompt_side_effect(*args, **kwargs):
+            nonlocal call_count
+            prompt_text = args[0] if args else ""
+            call_count += 1
+            responses = {
+                "GCP Project ID": "my-proj",
+                "Authentication method": "credentials",
+                "Path to service account JSON": "/path/to/sa.json",
+                "Datasets to scan (comma-separated, or empty for all)": "",
+                "Path to exported query logs JSON (or empty for API)": "",
+                "Query log lookback window in days (1-90)": "30",
+                "Monthly BigQuery cost override (or empty to calculate)": "",
+                "Output directory": "reports/",
+                "Output formats (json,html)": "json,html",
+            }
+            return responses.get(prompt_text, "")
+
+        mock_prompt.side_effect = prompt_side_effect
+        mock_confirm.return_value = False
+
+        params: dict = {}
+        result = _interactive_prompts(params)
+
+        assert result["gcp_project"] == "my-proj"
+        assert result["credentials"] == "/path/to/sa.json"

--- a/solution-architecture/clis/bq-assess/tests/unit/test_complexity_scorer.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_complexity_scorer.py
@@ -1,0 +1,104 @@
+"""Unit tests for scoring/complexity.py — Query Complexity scorer (R11)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    ComplexityCategory,
+    ConfidenceLevel,
+    ConfidenceSource,
+    DetectedConstruct,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+)
+from bq_assess.scoring.complexity import ComplexityScorer
+
+
+def _entity(entity_type=EntityType.VIEW, view_query="SELECT 1"):
+    return EntityMetadata(
+        entity_id="v1",
+        dataset_id="ds",
+        full_name="ds.v1",
+        entity_type=entity_type,
+        population=EntityPopulation.REBUILT if entity_type != EntityType.TABLE else EntityPopulation.TABLE,
+        num_rows=0,
+        num_bytes=0,
+        columns=[],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=view_query if entity_type == EntityType.VIEW else None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _construct(cls: str) -> DetectedConstruct:
+    return DetectedConstruct(construct_class=cls, snippet="...", description="test")
+
+
+class TestComplexityScorer:
+    def test_no_constructs_no_surface_portable_low(self):
+        scorer = ComplexityScorer()
+        e = _entity(entity_type=EntityType.TABLE, view_query=None)
+        e.view_query = None
+        result = scorer.score(e, constructs=[], has_logs=False)
+        assert result.category == ComplexityCategory.PORTABLE
+        assert result.confidence == ConfidenceLevel.LOW
+
+    def test_no_constructs_with_surface_portable_medium(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[], has_logs=False)
+        assert result.category == ComplexityCategory.PORTABLE
+        assert result.confidence == ConfidenceLevel.MEDIUM
+
+    def test_js_udf_is_rewrite(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[_construct("JS_UDF")])
+        assert result.category == ComplexityCategory.REWRITE
+        assert result.score >= 4
+
+    def test_unnest_is_adapt(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[_construct("UNNEST")])
+        assert result.category == ComplexityCategory.ADAPT
+        assert "UNNEST" in result.flags
+
+    def test_array_fn_is_adapt(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[_construct("ARRAY_FN")])
+        assert result.category == ComplexityCategory.ADAPT
+
+    def test_struct_nav_one_point(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[_construct("STRUCT_NAV")])
+        assert result.score == 1
+        assert result.category == ComplexityCategory.ADAPT
+
+    def test_function_drift_one_per(self):
+        scorer = ComplexityScorer()
+        constructs = [_construct("FUNCTION_DRIFT"), _construct("FUNCTION_DRIFT")]
+        result = scorer.score(_entity(), constructs=constructs)
+        assert result.score == 2
+
+    def test_combined_high_score_is_rewrite(self):
+        scorer = ComplexityScorer()
+        constructs = [_construct("UNNEST"), _construct("ARRAY_FN"), _construct("STRUCT_NAV")]
+        result = scorer.score(_entity(), constructs=constructs)
+        # 2 + 2 + 1 = 5 → REWRITE
+        assert result.category == ComplexityCategory.REWRITE
+
+    def test_has_logs_gives_high_confidence(self):
+        scorer = ComplexityScorer()
+        result = scorer.score(_entity(), constructs=[], has_logs=True)
+        assert result.confidence == ConfidenceLevel.HIGH
+        assert result.confidence_source == ConfidenceSource.QUERY_LOGS
+
+    def test_constructs_included_in_result(self):
+        scorer = ComplexityScorer()
+        c = [_construct("UNNEST")]
+        result = scorer.score(_entity(), constructs=c)
+        assert result.constructs == c

--- a/solution-architecture/clis/bq-assess/tests/unit/test_cost.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_cost.py
@@ -1,0 +1,864 @@
+# Feature: bq-assess-lakehouse, issue 5.3: CostEstimator (R18)
+"""Unit tests for the lakehouse Cost Estimator (BigQuery vs AWS run-rate comparison).
+
+Drives ``CostEstimator.estimate()`` (R18): AWS = S3 Tables storage (V2) + Serverless RPU
+compute (V1) via the slot→RPU bridge (V3), no node sizing (R18.6); BQ priced per the detected
+model (R16.4); ``--bigquery-monthly-cost`` override wins (R18.2); compute is a point at MED/HIGH
+with slots else a LOW-confidence range (R18.3/R18.4); every CostLine carries a dated source_note
+and every constant is overridable (R18.7).
+
+Inputs unique to this signature (PricingDetection, SlotUtilization) have no conftest strategy
+yet (owed by 5.1/5.2 — they were TDD'd with ad-hoc inputs); built here as local helpers.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from bq_assess.core import pricing_constants as v4
+from bq_assess.engine.redshift import cost_constants as k
+from bq_assess.engine.redshift.cost import CostEstimator
+from bq_assess.models import (
+    BQPricingModel,
+    ConfidenceLevel,
+    CostComparison,
+    EntityPopulation,
+    EntityType,
+    PricingDetection,
+    SlotUtilization,
+)
+
+# --- input helpers (local; PricingDetection/SlotUtilization have no conftest strategy yet) ----
+
+
+def ondemand_pricing() -> PricingDetection:
+    return PricingDetection(
+        model=BQPricingModel.ON_DEMAND, confidence=ConfidenceLevel.HIGH,
+        source_note="on-demand (test)",
+    )
+
+
+def capacity_pricing(edition="ENTERPRISE", baseline_slots=100, max_slots=200,
+                     commitment_slots=100, commitment_plan="ANNUAL") -> PricingDetection:
+    return PricingDetection(
+        model=BQPricingModel.CAPACITY, confidence=ConfidenceLevel.HIGH,
+        source_note="capacity (test)", edition=edition, baseline_slots=baseline_slots,
+        max_slots=max_slots, commitment_slots=commitment_slots, commitment_plan=commitment_plan,
+    )
+
+
+def slot_util(*, total_slot_ms=730 * 3_600_000, days_sampled=14, avg=1.0, peak=2.0) -> SlotUtilization:
+    return SlotUtilization(
+        avg_slots=avg, p50_slots=avg, p99_slots=peak, peak_slots=peak,
+        active_hour_fraction=0.5, total_slot_ms=total_slot_ms, days_sampled=days_sampled,
+    )
+
+
+def entity(size_gb=100.0, name="ds.t1"):
+    """A minimal EntityReport carrying the size the cost model reads."""
+    from bq_assess.models import EntityReport
+    return EntityReport(
+        full_name=name, entity_type=EntityType.TABLE, population=EntityPopulation.TABLE,
+        rows=1000, size_gb=size_gb, depends_on=[], effort=None, conversion=None,
+        load_sync_dml=None, complexity=None, rewrite_guidance=[], placement=None,
+    )
+
+
+def _estimate(entities=None, *, pricing=None, slots=None, override=None, effort=10.0):
+    return CostEstimator(skip_live_pricing=True).estimate(
+        entities if entities is not None else [entity()],
+        pricing or ondemand_pricing(),
+        slots,
+        override,
+        effort,
+    )
+
+
+# --- Phase A: signature + structure ---------------------------------------------------
+
+def test_estimate_signature_matches_contract() -> None:
+    """estimate() params match design.md exactly; entities/effort_total unannotated.
+
+    ``location`` (keyword-only, default None) was added by the 2026-07-02 region-cascade
+    amendment — see SCRUM_NOTES § Signature amendment 2026-07-02. Default None preserves
+    the pre-amendment behavior for existing positional callers.
+    ``storage_basis`` (keyword-only, default "assumed") was added by the 2026-07-08
+    physical-bytes storage sizing feature (Task 4).
+    """
+    sig = inspect.signature(CostEstimator.estimate)
+    params = list(sig.parameters)
+    assert params == ["self", "entities", "pricing", "slots", "bq_monthly_override",
+                      "effort_total", "location", "storage_basis"]
+    assert sig.parameters["location"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["location"].default is None
+    assert sig.parameters["storage_basis"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["storage_basis"].default == "assumed"
+
+
+def test_returns_costcomparison() -> None:
+    """estimate() returns a fully-populated CostComparison."""
+    result = _estimate()
+    assert isinstance(result, CostComparison)
+    assert isinstance(result.bq_pricing_model, BQPricingModel)
+    assert isinstance(result.compute_confidence, ConfidenceLevel)
+
+
+def _aws(line_label, result):
+    return next(line for line in result.aws_lines if line_label in line.label)
+
+
+def test_aws_has_storage_and_compute_line() -> None:
+    """AWS run-rate = storage line + compute line, both always present (R18.1)."""
+    r = _estimate(slots=slot_util())
+    labels = " ".join(line.label for line in r.aws_lines)
+    assert "storage" in labels.lower()
+    assert "compute" in labels.lower()
+    assert len(r.aws_lines) >= 2
+
+
+def test_aws_total_sums_all_lines_point_case() -> None:
+    """With slots (point compute), aws bounds equal the sum of all line points (R18.1)."""
+    r = _estimate(slots=slot_util())
+    total = sum(line.monthly for line in r.aws_lines)
+    assert r.aws_monthly_low == r.aws_monthly_high          # point case: bounds equal
+    assert round(r.aws_monthly_low, 4) == round(total, 4)
+
+
+# --- Phase B: compute switch (slots present → point MED/HIGH; absent → range LOW) -----
+
+def test_compute_point_when_slots_present() -> None:
+    """R18.3: with slots the compute line is a point at MED/HIGH, never LOW."""
+    r = _estimate(slots=slot_util(days_sampled=14))
+    compute = _aws("compute", r)
+    assert compute.monthly is not None
+    assert compute.monthly_low is None and compute.monthly_high is None
+    assert compute.confidence in (ConfidenceLevel.MEDIUM, ConfidenceLevel.HIGH)
+    assert r.compute_confidence is compute.confidence
+
+
+def test_compute_high_confidence_when_week_plus_sampled() -> None:
+    """>=7 days sampled → HIGH; <7 → MEDIUM (R18.3 / D7); never LOW with slots."""
+    assert _estimate(slots=slot_util(days_sampled=7)).compute_confidence is ConfidenceLevel.HIGH
+    assert _estimate(slots=slot_util(days_sampled=3)).compute_confidence is ConfidenceLevel.MEDIUM
+
+
+def test_compute_range_when_slots_absent() -> None:
+    """R18.4: no slots → compute is a range (low < high) at LOW, never a point."""
+    r = _estimate(slots=None)
+    compute = _aws("compute", r)
+    assert compute.monthly is None                          # strictly not a point
+    assert compute.monthly_low < compute.monthly_high
+    assert compute.confidence is ConfidenceLevel.LOW
+    assert r.compute_confidence is ConfidenceLevel.LOW
+
+
+def test_aws_bounds_spread_when_compute_is_range() -> None:
+    """The range branch must spread aws bounds via the compute low/high fallback (audit G3)."""
+    r = _estimate(slots=None)
+    assert r.aws_monthly_low < r.aws_monthly_high
+
+
+def test_zero_slot_ms_workload_yields_range_not_confident_zero() -> None:
+    """A SlotUtilization with total_slot_ms==0 carries no compute signal → LOW range, not a
+    confident $0 point (review #5/#12). All-cached/metadata jobs produce this."""
+    r = _estimate(slots=slot_util(total_slot_ms=0, days_sampled=14))
+    compute = _aws("compute", r)
+    assert compute.monthly is None                 # NOT a confident $0.00 point
+    assert compute.monthly_low < compute.monthly_high
+    assert r.compute_confidence is ConfidenceLevel.LOW
+
+
+def test_compute_range_labels_estimate() -> None:
+    """R18.4 / R20.6: the range source_note marks it an estimate + suggests query logs."""
+    note = _aws("compute", _estimate(slots=None)).source_note.lower()
+    assert "estimate" in note
+    assert "query log" in note
+
+
+def test_compute_depends_on_slot_ms_not_active_day_count() -> None:
+    """Compute tracks total_slot_ms over the lookback window, NOT days_sampled (active days).
+    Scaling by active-day count over-extrapolates a sparse workload (review #2)."""
+    sparse = _estimate(slots=slot_util(total_slot_ms=365 * 3_600_000, days_sampled=3))
+    dense = _estimate(slots=slot_util(total_slot_ms=365 * 3_600_000, days_sampled=30))
+    # Same slot-ms over the same window → same monthly compute regardless of how many distinct
+    # days saw activity (the old code inflated `sparse` 10× by dividing by days_sampled).
+    assert _aws("compute", sparse).monthly == _aws("compute", dense).monthly
+    # And the figure is the honest slot-hours × V3 ratio × rate (rounded to 4 dp).
+    assert _aws("compute", dense).monthly == round(
+        365 * k.V3_SLOT_TO_RPU_RATIO * k.V1_RPU_HOUR_USD, 4)
+
+
+# --- Phase C: BigQuery pricing paths --------------------------------------------------
+
+def test_ondemand_prices_storage_plus_bytes_scanned() -> None:
+    """R18.2a: on-demand BQ = storage line + bytes-scanned line; scanned cites $/TiB."""
+    r = _estimate(pricing=ondemand_pricing(), slots=slot_util())
+    labels = [line.label.lower() for line in r.bigquery_breakdown]
+    assert any("storage" in x for x in labels)
+    assert any("scan" in x for x in labels)
+    scan_line = next(line for line in r.bigquery_breakdown if "scan" in line.label.lower())
+    assert str(v4.V4_ONDEMAND_USD_PER_TIB) in scan_line.source_note
+
+
+def test_bq_breakdown_sums_to_bigquery_monthly() -> None:
+    """The BQ breakdown lines explain (sum to) bigquery_monthly (audit G17)."""
+    r = _estimate(pricing=ondemand_pricing(), slots=slot_util())
+    total = sum(line.monthly for line in r.bigquery_breakdown)
+    assert round(total, 4) == round(r.bigquery_monthly, 4)
+
+
+def test_capacity_prices_from_reservation_figures() -> None:
+    """R18.2b: capacity priced from edition × plan-rate × slots × 730; no on-demand line."""
+    pricing = capacity_pricing(edition="ENTERPRISE", commitment_slots=100, commitment_plan="ANNUAL")
+    r = _estimate(pricing=pricing)
+    rate = v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]["commit_1yr"]   # ANNUAL → commit_1yr
+    assert round(r.bigquery_monthly, 4) == round(100 * rate * k.HOURS_PER_MONTH, 4)
+    assert not any("scan" in line.label.lower() for line in r.bigquery_breakdown)
+
+
+def test_capacity_plan_maps_to_rate_key() -> None:
+    """commitment_plan vocabulary maps to V4 rate keys; FLEX/MONTHLY → payg (audit G7)."""
+    ent = v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]
+    for plan, key in [("ANNUAL", "commit_1yr"), ("THREE_YEAR", "commit_3yr"),
+                      ("MONTHLY", "payg"), ("FLEX", "payg")]:
+        r = _estimate(pricing=capacity_pricing(commitment_slots=10, commitment_plan=plan))
+        assert round(r.bigquery_monthly, 4) == round(10 * ent[key] * k.HOURS_PER_MONTH, 4)
+
+
+def test_capacity_slot_basis_falls_back_commitment_then_baseline_then_max() -> None:
+    """D5 precedence: commitment_slots → baseline_slots → max_slots."""
+    ent_rate = v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]["commit_1yr"]
+    # commitment present and positive → used
+    r1 = _estimate(pricing=capacity_pricing(commitment_slots=50, baseline_slots=10, max_slots=200))
+    assert round(r1.bigquery_monthly, 4) == round(50 * ent_rate * k.HOURS_PER_MONTH, 4)
+    # commitment None → baseline used
+    r2 = _estimate(pricing=capacity_pricing(commitment_slots=None, baseline_slots=10, max_slots=200))
+    assert round(r2.bigquery_monthly, 4) == round(10 * ent_rate * k.HOURS_PER_MONTH, 4)
+    # commitment + baseline None → max used
+    r3 = _estimate(pricing=capacity_pricing(commitment_slots=None, baseline_slots=None, max_slots=200))
+    assert round(r3.bigquery_monthly, 4) == round(200 * ent_rate * k.HOURS_PER_MONTH, 4)
+
+
+def test_commitment_slots_zero_falls_through_to_baseline() -> None:
+    """commitment_slots=0 means 'no commitment purchased' — must NOT shadow a valid baseline.
+    Regression guard for _first_positive (round-2 review fix #1)."""
+    ent_rate = v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]["commit_1yr"]
+    r = _estimate(pricing=capacity_pricing(commitment_slots=0, baseline_slots=100, max_slots=200))
+    assert round(r.bigquery_monthly, 4) == round(100 * ent_rate * k.HOURS_PER_MONTH, 4)
+
+
+def test_standard_edition_commitment_priced_at_payg_not_commit() -> None:
+    """STANDARD has no true slot commitments (V4): a STANDARD+ANNUAL config is priced at PAYG,
+    flagged, NOT at the commit_1yr rate at HIGH confidence (review #6/#11)."""
+    pricing = capacity_pricing(edition="STANDARD", commitment_slots=100, commitment_plan="ANNUAL")
+    r = _estimate(pricing=pricing)
+    payg = v4.V4_EDITION_SLOT_HOUR_USD["STANDARD"]["payg"]
+    assert round(r.bigquery_monthly, 4) == round(100 * payg * k.HOURS_PER_MONTH, 4)
+    line = r.bigquery_breakdown[0]
+    assert "no true slot commitments" in line.source_note.lower() or "payg" in line.source_note.lower()
+
+
+def test_unknown_edition_priced_as_enterprise_fallback_low_conf() -> None:
+    """An unrecognized edition is priced at ENTERPRISE rates as a labelled LOW-confidence
+    fallback, not silently (review #9)."""
+    pricing = capacity_pricing(edition="GALACTIC", commitment_slots=100, commitment_plan="ANNUAL")
+    r = _estimate(pricing=pricing)
+    assert r.bigquery_monthly > 0
+    line = r.bigquery_breakdown[0]
+    assert line.confidence is ConfidenceLevel.LOW
+    assert "galactic" in line.source_note.lower()
+
+
+def test_zero_rate_override_not_replaced_by_payg(monkeypatch) -> None:
+    """A 0.0 rate override is a legitimate value (credit/promo) — not swallowed by `or payg` (#7)."""
+    rates = dict(v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"])
+    rates["commit_1yr"] = 0.0
+    monkeypatch.setitem(v4.V4_EDITION_SLOT_HOUR_USD, "ENTERPRISE", rates)
+    r = _estimate(pricing=capacity_pricing(edition="ENTERPRISE", commitment_slots=100,
+                                           commitment_plan="ANNUAL"))
+    assert r.bigquery_monthly == 0.0      # priced at the 0.0 override, not payg
+
+
+def test_malformed_capacity_config_does_not_raise() -> None:
+    """A string commitment_slots degrades to 0 rather than crashing str×float (review #8/#16)."""
+    pricing = capacity_pricing(commitment_slots="oops", baseline_slots=None, max_slots=None)
+    r = _estimate(pricing=pricing)
+    assert isinstance(r.bigquery_monthly, float)   # no TypeError
+
+
+def test_capacity_never_falls_back_to_ondemand() -> None:
+    """R16.4: a CAPACITY model with no figures is still capacity-priced, never on-demand."""
+    pricing = capacity_pricing(commitment_slots=None, baseline_slots=None, max_slots=None)
+    r = _estimate(pricing=pricing)
+    assert r.bq_pricing_model is BQPricingModel.CAPACITY
+    assert not any("scan" in line.label.lower() for line in r.bigquery_breakdown)
+    assert not any(str(v4.V4_ONDEMAND_USD_PER_TIB) in line.source_note for line in r.bigquery_breakdown)
+
+
+def test_bq_pricing_model_equals_detected_model() -> None:
+    """R16.4 / R19.2: bq_pricing_model == pricing.model exactly, for all three models."""
+    for model, pricing in [
+        (BQPricingModel.ON_DEMAND, ondemand_pricing()),
+        (BQPricingModel.CAPACITY, capacity_pricing()),
+        (BQPricingModel.UNKNOWN, PricingDetection(
+            model=BQPricingModel.UNKNOWN, confidence=ConfidenceLevel.LOW, source_note="?")),
+    ]:
+        assert _estimate(pricing=pricing).bq_pricing_model is model
+
+
+def test_override_takes_precedence() -> None:
+    """R18.2c: --bigquery-monthly-cost wins regardless of model."""
+    r = _estimate(pricing=capacity_pricing(), override=4242.0)
+    assert r.bigquery_monthly == 4242.0
+
+
+# --- Phase D: deltas / annual / break-even (R18.5, bound cross) -----------------------
+
+def test_delta_and_annual_identities() -> None:
+    """R18.5 / P23: bound-crossed delta + annual = delta × 12."""
+    r = _estimate(slots=slot_util())
+    assert r.monthly_delta_low == r.bigquery_monthly - r.aws_monthly_high
+    assert r.monthly_delta_high == r.bigquery_monthly - r.aws_monthly_low
+    assert r.annual_savings_low == r.monthly_delta_low * 12
+    assert r.annual_savings_high == r.monthly_delta_high * 12
+
+
+def test_breakeven_from_effort_not_table_count() -> None:
+    """R18.5 / R9.2: migration_onetime tracks aggregate Effort, not entity count."""
+    low_effort = _estimate(effort=10.0)
+    high_effort = _estimate(effort=100.0)
+    assert high_effort.migration_onetime > low_effort.migration_onetime
+    # Vary entity count, hold effort → one-time cost unchanged.
+    few = _estimate([entity()], effort=50.0)
+    many = _estimate([entity(name=f"ds.t{i}") for i in range(50)], effort=50.0)
+    assert few.migration_onetime == many.migration_onetime
+
+
+def test_breakeven_never_when_no_savings() -> None:
+    """D6: AWS ≥ BQ (delta ≤ 0) → break-even = BREAKEVEN_NEVER (JSON-safe sentinel)."""
+    # Make BQ tiny so AWS dwarfs it → negative delta.
+    r = _estimate(slots=None, override=0.0)
+    assert r.monthly_delta_high <= 0
+    assert r.breakeven_months_low == k.BREAKEVEN_NEVER
+    assert r.breakeven_months_high == k.BREAKEVEN_NEVER
+
+
+def test_breakeven_mixed_when_bounds_straddle_zero() -> None:
+    """When the savings range straddles zero, low break-even = BREAKEVEN_NEVER, high is finite."""
+    # Tune override so bigquery sits between aws_low and aws_high.
+    probe = _estimate(slots=None)
+    mid = (probe.aws_monthly_low + probe.aws_monthly_high) / 2
+    r = _estimate(slots=None, override=mid)
+    assert r.monthly_delta_low < 0 < r.monthly_delta_high
+    assert r.breakeven_months_low == k.BREAKEVEN_NEVER
+    assert 0 < r.breakeven_months_high < k.BREAKEVEN_NEVER
+
+
+def test_breakeven_never_is_json_serializable() -> None:
+    """BREAKEVEN_NEVER must be finite so it serializes to JSON (RFC 7159).
+    Regression guard: math.inf would pass equality tests but crash json.dumps."""
+    import json
+    import math
+    r = _estimate(slots=None, override=0.0)
+    assert r.breakeven_months_low == k.BREAKEVEN_NEVER
+    assert math.isfinite(r.breakeven_months_low)
+    assert math.isfinite(r.breakeven_months_high)
+    json.dumps([r.breakeven_months_low, r.breakeven_months_high])  # ValueError if inf/nan
+
+
+def test_negative_savings_not_clamped() -> None:
+    """Negative deltas/annual are reported as negative, not clamped to 0 (audit G13)."""
+    r = _estimate(slots=None, override=0.0)
+    assert r.monthly_delta_low < 0
+    assert r.annual_savings_low < 0
+
+
+def test_zero_entities_no_crash() -> None:
+    """Empty project → zero storage, both AWS lines still present, no divide-by-zero (audit G9)."""
+    r = _estimate([], slots=None)
+    assert isinstance(r, CostComparison)
+    assert len(r.aws_lines) >= 2
+
+
+# --- Phase E: decoupling & no node sizing (R18.6) -------------------------------------
+
+def test_compute_not_sized_by_stored_bytes() -> None:
+    """R18.6: compute is a function of slots only — identical when only storage scales."""
+    small = _estimate([entity(size_gb=1.0)], slots=slot_util())
+    large = _estimate([entity(size_gb=10_000.0)], slots=slot_util())
+    assert _aws("compute", small).monthly == _aws("compute", large).monthly
+    assert _aws("storage", small).monthly < _aws("storage", large).monthly   # storage does scale
+
+
+def test_no_node_strings_anywhere() -> None:
+    """R18.6: no node/RA3/provisioned/advisor leakage in any label or source_note."""
+    for slots in (slot_util(), None):
+        for pricing in (ondemand_pricing(), capacity_pricing()):
+            r = _estimate(pricing=pricing, slots=slots)
+            blob = " ".join(
+                line.label + " " + line.source_note
+                for line in r.aws_lines + r.bigquery_breakdown
+            ).lower()
+            for banned in ("node", "ra3", "xlplus", "4xlarge", "16xlarge", "provisioned",
+                           "deploymentadvisor", "redshift_type"):
+                assert banned not in blob
+
+
+def test_costcomparison_has_no_node_fields() -> None:
+    """R18.6: the dataclass exposes no node/type/advisor field (regression vs legacy)."""
+    import dataclasses
+    names = {f.name for f in dataclasses.fields(CostComparison)}
+    for banned in ("node", "node_type", "redshift_type", "deployment", "advisor"):
+        assert banned not in names
+
+
+# --- Phase F: provenance + overridability (R18.7) -------------------------------------
+
+def test_every_costline_has_dated_source_note() -> None:
+    """R18.7: every line carries a non-empty source_note containing a date token."""
+    for slots in (slot_util(), None):
+        for pricing in (ondemand_pricing(), capacity_pricing()):
+            r = _estimate(pricing=pricing, slots=slots)
+            for line in r.aws_lines + r.bigquery_breakdown:
+                assert line.source_note
+                assert "2026-" in line.source_note          # V1/V2 (2026-06-15) or V4 (2026-06-11)
+
+
+def test_overriding_v1_changes_compute(monkeypatch) -> None:
+    """R18.7: V1 RPU rate is overridable, not hardcoded — compute line moves."""
+    base = _aws("compute", _estimate(slots=slot_util())).monthly
+    monkeypatch.setattr(k, "V1_RPU_HOUR_USD", k.V1_RPU_HOUR_USD * 2)
+    assert _aws("compute", _estimate(slots=slot_util())).monthly > base
+
+
+def test_overriding_v3_ratio_changes_compute(monkeypatch) -> None:
+    """R18.7 / D4: the V3 slot→RPU ratio is the one tunable; compute scales with it."""
+    base = _aws("compute", _estimate(slots=slot_util())).monthly
+    monkeypatch.setattr(k, "V3_SLOT_TO_RPU_RATIO", k.V3_SLOT_TO_RPU_RATIO * 3)
+    assert _aws("compute", _estimate(slots=slot_util())).monthly == pytest.approx(base * 3, rel=1e-3)
+
+
+def test_overriding_v2_changes_storage(monkeypatch) -> None:
+    """R18.7: V2 S3 Tables storage rate is overridable (audit G11)."""
+    base = _aws("storage", _estimate()).monthly
+    monkeypatch.setattr(k, "V2_S3_TABLES_USD_PER_GB_MONTH_TIER1", k.V2_S3_TABLES_USD_PER_GB_MONTH_TIER1 * 2)
+    assert _aws("storage", _estimate()).monthly > base
+
+
+def test_overriding_v4_changes_bq(monkeypatch) -> None:
+    """R18.7: V4 BQ on-demand rate is overridable — BQ scanned line moves (audit G11)."""
+    # Large entity so monthly scan exceeds the 1 TiB free tier and the rate actually bites.
+    big = [entity(size_gb=500_000.0)]
+    base = _estimate(big, pricing=ondemand_pricing(), slots=slot_util()).bigquery_monthly
+    monkeypatch.setattr(v4, "V4_ONDEMAND_USD_PER_TIB", v4.V4_ONDEMAND_USD_PER_TIB * 5)
+    assert _estimate(big, pricing=ondemand_pricing(), slots=slot_util()).bigquery_monthly > base
+
+
+def test_v3_source_note_labels_assumption() -> None:
+    """R18.7 / R20.6: the compute source_note flags V3 as a LOW-confidence assumption."""
+    note = _aws("compute", _estimate(slots=slot_util())).source_note.lower()
+    assert "assumption" in note
+
+
+# --- Multi-scenario fixes: storage basis + money formatting ---------------------------
+# These cover two bugs found reviewing the multi-scenario engine against a live run:
+#   1. provisioned scenarios billed RMS storage instead of the shared S3 Tables basis
+#   2. sub-dollar totals rendered as "$0/month" in the recommendation prose
+from bq_assess.engine.redshift.cost import _fmt_usd  # noqa: E402
+
+
+def _scenarios(result):
+    return result.aws_scenarios
+
+
+def test_provisioned_storage_uses_s3_tables_not_rms() -> None:
+    """All scenarios — serverless AND provisioned — share the S3 Tables storage basis.
+
+    Data lives in S3 Tables (decoupled lakehouse) and is queried via external tables, so the
+    storage line must NOT change with the query engine. Provisioned must not bill RMS.
+    """
+    result = _estimate(slots=slot_util())
+    prov = [s for s in _scenarios(result) if s.category.startswith("PROVISIONED")]
+    assert prov, "expected provisioned scenarios when slot data is present"
+    for s in prov:
+        storage_lines = [ln for ln in s.lines if "storage" in ln.label.lower()]
+        assert storage_lines, f"{s.label} has no storage line"
+        for ln in storage_lines:
+            assert "S3 Tables" in ln.label
+            blob = (ln.label + " " + ln.source_note).lower()
+            assert "managed storage" not in blob
+            assert "ra3" not in blob
+
+
+def test_storage_value_identical_across_all_scenarios() -> None:
+    """Storage cost must not vary by engine — same bytes, same S3 Tables basis everywhere."""
+    result = _estimate(slots=slot_util())
+    storage_vals = []
+    for s in _scenarios(result):
+        ln = next(x for x in s.lines if "storage" in x.label.lower())
+        storage_vals.append(round(ln.monthly, 6))
+    assert len(set(storage_vals)) == 1, f"storage differs across scenarios: {storage_vals}"
+
+
+def test_fmt_usd_does_not_round_subdollar_to_zero() -> None:
+    """Sub-dollar amounts keep cents; $1+ are comma-grouped whole dollars."""
+    assert _fmt_usd(0.1151) == "$0.12"
+    assert _fmt_usd(0.0) == "$0.00"
+    assert _fmt_usd(0.9) == "$0.90"
+    assert _fmt_usd(1.0) == "$1"
+    assert _fmt_usd(893.23) == "$893"
+    assert _fmt_usd(43210.0) == "$43,210"
+    assert _fmt_usd(-0.10) == "-$0.10"
+
+
+def test_recommendation_prose_never_says_zero_dollars_for_real_cost() -> None:
+    """A sub-dollar serverless workload must not be described as '$0/month'."""
+    result = _estimate(
+        [entity(size_gb=0.03)],
+        slots=slot_util(total_slot_ms=7_000_000, days_sampled=30, avg=0.003, peak=0.03),
+    )
+    rec = result.recommendation
+    assert rec is not None
+    assert "$0/month" not in rec.reasoning
+
+
+# --- Region cascade (2026-07-02): price both clouds in the Source's geography ----------
+# Root cause of the Montu underestimate: an australia-southeast1 Source was priced at US
+# multi-region rates ($6.25/TiB vs Sydney's $8.125). These tests pin the cascade.
+
+@pytest.fixture()
+def _restore_region_constants():
+    """Snapshot/restore the module constants the region cascade mutates."""
+    v4_snap = {n: getattr(v4, n) for n in (
+        "V4_ONDEMAND_USD_PER_TIB", "V4_STORAGE_ACTIVE_LOGICAL_USD_PER_GIB_MONTH",
+        "V4_STORAGE_LONGTERM_LOGICAL_USD_PER_GIB_MONTH",
+        "V4_STORAGE_ACTIVE_PHYSICAL_USD_PER_GIB_MONTH",
+        "V4_STORAGE_LONGTERM_PHYSICAL_USD_PER_GIB_MONTH",
+        "V4_EDITION_SLOT_HOUR_USD", "V4_EDITION_RESOURCE_CUD_SLOT_HOUR_USD",
+        "V4_PRICING_REGION", "V4_REGION_SCOPE",
+    )}
+    k_snap = {n: getattr(k, n) for n in (
+        "V1_RPU_HOUR_USD", "V1_SERVERLESS_1YR_RPU_HOUR_USD", "V1_SERVERLESS_3YR_RPU_HOUR_USD",
+        "V2_S3_TABLES_USD_PER_GB_MONTH_TIER1", "V2_S3_TABLES_USD_PER_GB_MONTH_TIER2",
+        "V2_S3_TABLES_USD_PER_GB_MONTH_TIER3", "V6_MANAGED_STORAGE_USD_PER_GB_MONTH",
+        "AWS_PRICING_REGION", "AWS_REGION_SCOPE",
+    )}
+    import copy
+    node_snap = (copy.deepcopy(k.V7_RG_NODE_TYPES), copy.deepcopy(k.V6_RA3_NODE_TYPES))
+    yield
+    for n, val in v4_snap.items():
+        setattr(v4, n, val)
+    for n, val in k_snap.items():
+        setattr(k, n, val)
+    k.V7_RG_NODE_TYPES.update(node_snap[0])
+    k.V6_RA3_NODE_TYPES.update(node_snap[1])
+
+
+def _estimate_at(location, **kwargs):
+    return CostEstimator(skip_live_pricing=True).estimate(
+        kwargs.pop("entities", [entity()]),
+        kwargs.pop("pricing", None) or ondemand_pricing(),
+        kwargs.pop("slots", None),
+        None, 10.0, location=location,
+    )
+
+
+def test_sydney_source_priced_at_sydney_rates(_restore_region_constants) -> None:
+    """An australia-southeast1 Source uses $8.125/TiB, not the US $6.25 (Montu bug)."""
+    r = _estimate_at("australia-southeast1", slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "8.125" in scan.source_note
+    assert r.bq_pricing_region == "australia-southeast1"
+    assert r.aws_pricing_region == "ap-southeast-2"
+
+
+def test_sydney_costs_more_than_us_for_same_workload(_restore_region_constants) -> None:
+    """Same workload, Sydney region → strictly higher BQ estimate than US."""
+    big = [entity(size_gb=500_000.0)]
+    slots = slot_util()
+    us = _estimate_at("US", entities=big, slots=slots).bigquery_monthly
+    syd = _estimate_at("australia-southeast1", entities=big, slots=slots).bigquery_monthly
+    assert syd > us
+
+
+def test_aws_side_repriced_with_bq_region(_restore_region_constants) -> None:
+    """The AWS comparison uses the mapped region's rates (Sydney RPU $0.419, not $0.375)."""
+    r = _estimate_at("australia-southeast1", slots=slot_util())
+    compute = next(ln for ln in r.aws_lines if "compute" in ln.label.lower())
+    assert "0.419" in compute.source_note
+
+
+def test_unknown_location_falls_back_to_us_with_caveat(_restore_region_constants) -> None:
+    """An unmapped location prices at US rates and carries a scope-note caveat."""
+    r = _estimate_at("mars-north1", slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "6.25" in scan.source_note
+    assert any("mars-north1" in n for n in r.scope_notes)
+
+
+def test_no_location_preserves_module_constants(_restore_region_constants, monkeypatch) -> None:
+    """location=None (legacy callers/tests) must not re-point overridden constants (R18.7)."""
+    monkeypatch.setattr(v4, "V4_ONDEMAND_USD_PER_TIB", 99.0)
+    r = _estimate(pricing=ondemand_pricing(), slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "99.0" in scan.source_note
+
+
+def test_scope_notes_disclose_unmodeled_skus(_restore_region_constants) -> None:
+    """The estimate must disclose that streaming/Storage API SKUs are out of scope."""
+    r = _estimate_at("US", slots=slot_util())
+    joined = " ".join(r.scope_notes).lower()
+    assert "storage read/write api" in joined
+    assert "streaming" in joined
+
+
+def test_billed_bytes_preferred_over_processed(_restore_region_constants) -> None:
+    """Scan cost bills on total_bytes_billed (10 MiB minimums) when available."""
+    processed = 10 * (1024 ** 4)
+    billed = 15 * (1024 ** 4)   # small-query minimums push billed above processed
+    s = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.5, total_slot_ms=730 * 3_600_000, days_sampled=14,
+        total_bytes_processed=processed, total_bytes_billed=billed,
+        has_billed_bytes=True, total_queries=100,
+    )
+    s_proc_only = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.5, total_slot_ms=730 * 3_600_000, days_sampled=14,
+        total_bytes_processed=processed, total_bytes_billed=0, total_queries=100,
+    )
+    with_billed = _estimate_at("US", slots=s)
+    with_processed = _estimate_at("US", slots=s_proc_only)
+    assert with_billed.bigquery_monthly > with_processed.bigquery_monthly
+    scan = next(ln for ln in with_billed.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "billed" in scan.source_note
+    fallback = next(ln for ln in with_processed.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "billed unavailable" in fallback.source_note
+
+
+def test_degraded_window_never_prices_on_partial_billed_sum(_restore_region_constants) -> None:
+    """A degraded window (has_billed_bytes=False) prices on processed bytes even when a
+    POSITIVE partial billed sum is present — pricing on the partial sum would silently
+    exclude the NULL-billed jobs' volume (2026-07-08 review: the `or billed > 0` clause
+    defeated workload.py's degradation policy)."""
+    processed = 10 * (1024 ** 4)
+    partial_billed = 8 * (1024 ** 4)   # 2 of 10 jobs NULL-billed: sum covers only 8
+    s = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.5, total_slot_ms=730 * 3_600_000, days_sampled=14,
+        total_bytes_processed=processed, total_bytes_billed=partial_billed,
+        has_billed_bytes=False, total_queries=10, lookback_days=14,
+    )
+    result = _estimate_at("US", slots=s)
+    scan = next(ln for ln in result.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "billed unavailable" in scan.source_note   # processed fallback, labelled
+    # Priced on the 10 TiB processed overestimate, not the 8 TiB partial sum.
+    assert f"{processed / (1024**4):,.2f} TiB" in scan.source_note
+
+
+# --- Review fixes (2026-07-03): cascade ordering, projection window, billed-zero -------
+
+def test_cascade_does_not_clobber_live_rates(_restore_region_constants, monkeypatch) -> None:
+    """CLI ordering: cascade applied in Stage 9b, live rates layered on top — estimate()
+    passing the SAME location must not re-apply the hardcoded table over the live rates."""
+    v4.apply_bq_region("australia-southeast1")
+    k.apply_aws_region("ap-southeast-2")
+    # Live refresh drifts the rates (simulating apply_live_rates)
+    monkeypatch.setattr(v4, "V4_ONDEMAND_USD_PER_TIB", 9.99)
+    monkeypatch.setattr(k, "V1_RPU_HOUR_USD", 0.5)
+    r = _estimate_at("australia-southeast1", slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "9.99" in scan.source_note      # live rate survived
+    compute = next(ln for ln in r.aws_lines if "compute" in ln.label.lower())
+    assert "0.5" in compute.source_note
+
+
+def test_unknown_region_resets_to_us_not_previous(_restore_region_constants) -> None:
+    """An unknown location after a regional estimate must reset to US rates, not keep
+    the previous region's (the 'priced at US rates' caveat must be true)."""
+    _estimate_at("australia-southeast1", slots=slot_util())
+    r = _estimate_at("mars-north1", slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "6.25" in scan.source_note and "8.125" not in scan.source_note
+    assert r.bq_pricing_region == "us"
+
+
+def test_us_central1_has_verified_rates_no_scary_caveat(_restore_region_constants) -> None:
+    """us-central1 (the most common single US region) is in the verified table — no
+    unknown-region caveat, storage at its regional rate."""
+    r = _estimate_at("us-central1", slots=slot_util())
+    assert not any("No verified rate table" in n for n in r.scope_notes)
+    storage = next(ln for ln in r.bigquery_breakdown if "storage" in ln.label.lower())
+    assert "0.023" in storage.source_note
+
+
+def test_scan_projected_over_calendar_window_not_active_days(_restore_region_constants) -> None:
+    """A batch workload active 4 of 30 days projects over the 30-day window (~1×), not
+    the 4 active days (7.5× inflation)."""
+    ten_tib = 10 * (1024 ** 4)
+    s = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.1, total_slot_ms=4 * 3_600_000, days_sampled=4,
+        total_bytes_processed=ten_tib, total_bytes_billed=ten_tib,
+        has_billed_bytes=True, total_queries=40, lookback_days=30,
+    )
+    r = _estimate_at("US", slots=s)
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert scan.monthly == pytest.approx(10 * 6.25, rel=0.05)   # ~10 TiB/mo, not ~75
+
+
+def test_billed_zero_window_is_zero_scan_not_fallback(_restore_region_constants) -> None:
+    """A window that carried the billed column with a genuine zero (all-cached /
+    reservation-served) bills $0 scan — no fallback to processed bytes."""
+    s = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.5, total_slot_ms=730 * 3_600_000, days_sampled=14,
+        total_bytes_processed=5 * (1024 ** 4), total_bytes_billed=0,
+        has_billed_bytes=True, total_queries=100, lookback_days=14,
+    )
+    r = _estimate_at("US", slots=s)
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert scan.monthly == 0
+    assert "billed unavailable" not in scan.source_note
+
+
+def test_workload_profile_scan_volume_matches_cost_basis(_restore_region_constants) -> None:
+    """The recommendation's monthly_scanned_tb quotes the same (billed) basis and window
+    as the BigQuery cost line — the report must not contradict itself."""
+    processed, billed = 10 * (1024 ** 4), 15 * (1024 ** 4)
+    s = SlotUtilization(
+        avg_slots=1.0, p50_slots=1.0, p99_slots=2.0, peak_slots=2.0,
+        active_hour_fraction=0.5, total_slot_ms=730 * 3_600_000, days_sampled=30,
+        total_bytes_processed=processed, total_bytes_billed=billed,
+        has_billed_bytes=True, total_queries=1000, lookback_days=30,
+    )
+    r = _estimate_at("US", slots=s)
+    wp = r.recommendation.workload_profile
+    assert wp.monthly_scanned_tb == pytest.approx((billed / 30 * 30.0) / (1024 ** 4), rel=1e-6)
+
+
+def test_edition_commitments_use_catalog_factors(_restore_region_constants) -> None:
+    """Regional edition commitments follow the catalog's ×0.8/×0.6 SKU factors (Sydney
+    ENTERPRISE 1yr $0.0648 = 0.081×0.8, verified), not a fabricated ×0.9/×0.8."""
+    v4.apply_bq_region("australia-southeast1")
+    assert v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]["commit_1yr"] == pytest.approx(0.0648)
+    assert v4.V4_EDITION_SLOT_HOUR_USD["ENTERPRISE"]["commit_3yr"] == pytest.approx(0.0486)
+
+
+# --- Round-2 review fixes (2026-07-04) --------------------------------------------------
+
+def test_live_rates_survive_for_region_outside_hardcoded_table(_restore_region_constants) -> None:
+    """A live catalog lookup for a region NOT in V4_REGIONAL_RATES stamps the region tag;
+    estimate() must then keep those rates instead of resetting to hardcoded US."""
+    from bq_assess.core.price_lookup import GCPRates, PricingRates, apply_live_rates
+    live = PricingRates(bq_location="asia-east1", aws_region="us-east-1")
+    live.gcp = GCPRates(ondemand_usd_per_tib=6.75, storage_active_logical_usd_per_gib=0.023,
+                        fetched_at="2026-07-04", source="GCP Cloud Billing Catalog API (asia-east1)")
+    apply_live_rates(live)
+    assert v4.V4_PRICING_REGION == "asia-east1"
+
+    r = _estimate_at("asia-east1", slots=slot_util())
+    scan = next(ln for ln in r.bigquery_breakdown if "scanned" in ln.label.lower())
+    assert "6.75" in scan.source_note                      # live rate survived the cascade
+    assert r.bq_pricing_region == "asia-east1"
+    assert not any("No verified rate table" in n for n in r.scope_notes)
+
+
+def test_hardcoded_fallback_source_does_not_stamp_freshness(_restore_region_constants) -> None:
+    """The GCP fallback's source reads 'hardcoded (verified …)' — apply_live_rates must not
+    treat it as live (no date stamp, no region tag update)."""
+    from bq_assess.core.price_lookup import GCPRates, PricingRates, apply_live_rates
+    before_date, before_region = v4.V4_CONFIRMED_DATE, v4.V4_PRICING_REGION
+    fallback = PricingRates(bq_location="australia-southeast1")
+    fallback.gcp = GCPRates(ondemand_usd_per_tib=6.25, fetched_at="2026-06-24",
+                            source="hardcoded (verified 2026-06-24)")
+    apply_live_rates(fallback)
+    assert v4.V4_CONFIRMED_DATE == before_date
+    assert v4.V4_PRICING_REGION == before_region
+
+
+def test_default_edition_commitments_match_catalog_factors() -> None:
+    """The module-default edition table (location=None path) must carry the same catalog
+    x0.8/x0.6 commitment factors apply_bq_region derives — not the fabricated x0.9/x0.8."""
+    for edition, rates in v4.V4_EDITION_SLOT_HOUR_USD.items():
+        assert rates["commit_1yr"] == pytest.approx(rates["payg"] * 0.8), edition
+        assert rates["commit_3yr"] == pytest.approx(rates["payg"] * 0.6), edition
+
+
+def test_reused_estimator_refreshes_per_region_pair(_restore_region_constants, monkeypatch) -> None:
+    """A reused CostEstimator must attempt a live refresh for EACH region pair, not once."""
+    calls: list[tuple[str, str]] = []
+
+    class _FakeLookup:
+        def __init__(self, aws_region="us-east-1", bq_location="us", use_cache=True):
+            calls.append((bq_location, aws_region))
+        def fetch(self, gcp_client=None):
+            raise RuntimeError("no network in tests")
+
+    import bq_assess.core.price_lookup as pl
+    monkeypatch.setattr(pl, "PriceLookup", _FakeLookup)
+    est = CostEstimator(skip_live_pricing=False)
+    est.estimate([entity()], ondemand_pricing(), slot_util(), None, 10.0, location="US")
+    est.estimate([entity()], ondemand_pricing(), slot_util(), None, 10.0,
+                 location="australia-southeast1")
+    est.estimate([entity()], ondemand_pricing(), slot_util(), None, 10.0, location="US")
+    assert ("us", "us-east-1") in calls
+    assert ("australia-southeast1", "ap-southeast-2") in calls
+    assert len(calls) == 2       # third call = repeat pair, no re-fetch
+
+
+# --- Physical bytes storage sizing (Task 4) ---------------------------------------------------
+
+def test_s3_storage_line_uses_physical_bytes_when_measured():
+    """S3 storage line uses physical_bytes when measured=True, HIGH confidence."""
+    entities = [entity(size_gb=100.0, name=f"ds.t{i}") for i in range(3)]
+    for e in entities:
+        e.num_bytes = int(e.size_gb * (1024 ** 3))
+        e.physical_bytes = round(e.num_bytes * 0.4)  # ~2.5× compression
+
+    est = CostEstimator(skip_live_pricing=True)
+    result = est.estimate(entities, ondemand_pricing(), slot_util(), None, 10.0,
+                          storage_basis="measured")
+    storage = _aws("storage", result)
+
+    assert storage.confidence == ConfidenceLevel.HIGH
+    total_physical = sum(e.physical_bytes for e in entities)
+    expected_gb = total_physical * k.GB_PER_BYTE
+    assert expected_gb > 0
+    assert "TABLE_STORAGE" in storage.source_note
+    assert str(k.ASSUMED_PHYSICAL_RATIO) not in storage.source_note
+
+
+def test_s3_storage_line_drops_to_medium_confidence_when_fallback():
+    """S3 storage line uses MEDIUM confidence when basis=assumed (0.75× fallback)."""
+    entities = [entity(size_gb=100.0, name=f"ds.t{i}") for i in range(3)]
+    for e in entities:
+        e.num_bytes = int(e.size_gb * (1024 ** 3))
+        e.physical_bytes = round(e.num_bytes * k.ASSUMED_PHYSICAL_RATIO)
+
+    est = CostEstimator(skip_live_pricing=True)
+    result = est.estimate(entities, ondemand_pricing(), slot_util(), None, 10.0,
+                          storage_basis="assumed")
+    storage = _aws("storage", result)
+
+    assert storage.confidence == ConfidenceLevel.MEDIUM
+    assert str(k.ASSUMED_PHYSICAL_RATIO) in storage.source_note
+    assert "TABLE_STORAGE unavailable" in storage.source_note
+
+
+def test_s3_storage_line_mixed_basis():
+    """S3 storage line uses MEDIUM confidence for mixed basis."""
+    entities = [entity(size_gb=100.0, name=f"ds.t{i}") for i in range(3)]
+    for e in entities:
+        e.num_bytes = int(e.size_gb * (1024 ** 3))
+        e.physical_bytes = round(e.num_bytes * k.ASSUMED_PHYSICAL_RATIO)
+
+    est = CostEstimator(skip_live_pricing=True)
+    result = est.estimate(entities, ondemand_pricing(), slot_util(), None, 10.0,
+                          storage_basis="mixed")
+    storage = _aws("storage", result)
+
+    assert storage.confidence == ConfidenceLevel.MEDIUM
+    assert "mixed" in storage.source_note

--- a/solution-architecture/clis/bq-assess/tests/unit/test_effort_scorer.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_effort_scorer.py
@@ -1,0 +1,141 @@
+"""Unit tests for scoring/effort.py — Migration Effort scorer (R9)."""
+from __future__ import annotations
+
+from bq_assess.models import (
+    ConversionResult,
+    EffortCategory,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    ConfidenceLevel,
+    LossyCast,
+    PartitionMapping,
+)
+from bq_assess.scoring.effort import EffortScorer
+
+
+def _entity(num_bytes: int = 100_000, entity_type=EntityType.TABLE, columns=None):
+    from datetime import datetime, timezone
+    return EntityMetadata(
+        entity_id="t1",
+        dataset_id="ds",
+        full_name="ds.t1",
+        entity_type=entity_type,
+        population=EntityPopulation.TABLE,
+        num_rows=1000,
+        num_bytes=num_bytes,
+        columns=columns or [],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _conversion(lossy_casts=None, decision_flags=None):
+    pm = None
+    if decision_flags:
+        pm = PartitionMapping(
+            iceberg_transforms=[],
+            sort_order=[],
+            auto_derived=False,
+            decision_flags=decision_flags,
+        )
+    return ConversionResult(
+        ddl="CREATE TABLE ds.t1 (id bigint);",
+        partition_mapping=pm,
+        lossy_casts=lossy_casts or [],
+        warnings=[],
+        success=True,
+    )
+
+
+class TestEffortScorer:
+    def test_small_clean_table_is_auto(self):
+        scorer = EffortScorer()
+        result = scorer.score(_entity(num_bytes=500_000_000), _conversion())
+        assert result.category == EffortCategory.AUTO
+        assert result.score == 0
+
+    def test_large_table_gets_volume_point(self):
+        scorer = EffortScorer()
+        # 50 GB
+        result = scorer.score(_entity(num_bytes=50 * 1024**3), _conversion())
+        assert result.score >= 1
+        assert "data_volume_large" in result.flags
+
+    def test_huge_table_gets_two_volume_points(self):
+        scorer = EffortScorer()
+        # 200 GB
+        result = scorer.score(_entity(num_bytes=200 * 1024**3), _conversion())
+        assert result.score >= 2
+        assert "data_volume_huge" in result.flags
+
+    def test_lossy_casts_add_points(self):
+        scorer = EffortScorer()
+        lossy = [
+            LossyCast(column="c1", source_type="TIME", iceberg_type="STRING", loss_description="no TIME"),
+            LossyCast(column="c2", source_type="JSON", iceberg_type="STRING", loss_description="no JSON"),
+        ]
+        result = scorer.score(_entity(), _conversion(lossy_casts=lossy))
+        assert result.score >= 2
+        assert "lossy_casts" in result.flags
+
+    def test_partition_decision_adds_point(self):
+        scorer = EffortScorer()
+        result = scorer.score(_entity(), _conversion(decision_flags=["partition_decision_required"]))
+        assert result.score >= 1
+        assert "partition_decision_required" in result.flags
+
+    def test_sort_decision_adds_point(self):
+        scorer = EffortScorer()
+        result = scorer.score(_entity(), _conversion(decision_flags=["sort_decision_required"]))
+        assert result.score >= 1
+        assert "sort_decision_required" in result.flags
+
+    def test_sync_need_adds_point(self):
+        from bq_assess.models import TimePartitionConfig
+        e = _entity()
+        e.time_partitioning = TimePartitionConfig(field="_PARTITIONTIME", type="DAY")
+        scorer = EffortScorer()
+        result = scorer.score(e, _conversion())
+        assert "ongoing_sync" in result.flags
+
+    def test_combined_factors_manual(self):
+        from bq_assess.models import TimePartitionConfig
+        scorer = EffortScorer()
+        e = _entity(num_bytes=200 * 1024**3)
+        e.time_partitioning = TimePartitionConfig(field="_PARTITIONTIME", type="DAY")
+        lossy = [LossyCast(column="c", source_type="TIME", iceberg_type="STRING", loss_description="x")]
+        result = scorer.score(e, _conversion(lossy_casts=lossy, decision_flags=["partition_decision_required"]))
+        assert result.category == EffortCategory.MANUAL
+        assert result.score >= 3
+
+    def test_confidence_high_when_num_bytes_known(self):
+        scorer = EffortScorer()
+        result = scorer.score(_entity(num_bytes=0), _conversion())
+        assert result.confidence == ConfidenceLevel.HIGH
+
+    def test_confidence_low_when_num_bytes_none(self):
+        scorer = EffortScorer()
+        e = _entity()
+        e.num_bytes = None
+        result = scorer.score(e, _conversion())
+        assert result.confidence == ConfidenceLevel.LOW
+
+    def test_failed_conversion_is_manual(self):
+        scorer = EffortScorer()
+        failed = ConversionResult(ddl="", partition_mapping=None, lossy_casts=[], warnings=["error"], success=False)
+        result = scorer.score(_entity(), failed)
+        assert result.category == EffortCategory.MANUAL
+
+    def test_sync_column_name_adds_point(self):
+        from bq_assess.models import ColumnSchema
+        e = _entity(columns=[ColumnSchema(name="updated_at", field_type="TIMESTAMP", mode="NULLABLE")])
+        scorer = EffortScorer()
+        result = scorer.score(e, _conversion())
+        assert "ongoing_sync" in result.flags

--- a/solution-architecture/clis/bq-assess/tests/unit/test_html_writer.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_html_writer.py
@@ -1,0 +1,285 @@
+"""Unit tests for report/html_writer.py — single combined HTML report (R20)."""
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    Assessment,
+    AssessmentSummary,
+    BQPricingModel,
+    ConfidenceLevel,
+    ConfidenceSource,
+    ComplexityCategory,
+    ComplexityResult,
+    ConversionResult,
+    CostComparison,
+    CostLine,
+    EffortCategory,
+    EffortResult,
+    EntityPopulation,
+    EntityReport,
+    EntityType,
+)
+from bq_assess.report.html_writer import HTMLWriter
+
+
+def _known_assessment(
+    compute_confidence=ConfidenceLevel.HIGH, sql_confidence=ConfidenceLevel.HIGH
+):
+    entities = [
+        EntityReport(
+            full_name="ds.orders",
+            entity_type=EntityType.TABLE,
+            population=EntityPopulation.TABLE,
+            rows=1_000_000,
+            size_gb=42.5,
+            depends_on=[],
+            effort=EffortResult(
+                category=EffortCategory.ASSISTED,
+                score=45,
+                flags=["time_partitioning"],
+                reasoning="partitioned",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            conversion=ConversionResult(
+                ddl="CREATE TABLE ds.orders (id long);",
+                partition_mapping=None,
+                lossy_casts=[],
+                warnings=[],
+                success=True,
+            ),
+            load_sync_dml="COPY INTO ds.orders FROM 's3://bucket'",
+            complexity=ComplexityResult(
+                category=ComplexityCategory.ADAPT,
+                score=60,
+                constructs=[],
+                flags=["UNNEST"],
+                reasoning="uses UNNEST",
+                confidence=ConfidenceLevel.MEDIUM,
+                confidence_source=ConfidenceSource.QUERY_LOGS,
+            ),
+            rewrite_guidance=["Replace UNNEST"],
+            placement=None,
+        ),
+        EntityReport(
+            full_name="ds.view1",
+            entity_type=EntityType.VIEW,
+            population=EntityPopulation.REBUILT,
+            rows=0,
+            size_gb=0.0,
+            depends_on=["ds.orders"],
+            effort=None,
+            conversion=None,
+            load_sync_dml=None,
+            complexity=ComplexityResult(
+                category=ComplexityCategory.REWRITE,
+                score=80,
+                constructs=[],
+                flags=["JS_UDF"],
+                reasoning="JS",
+                confidence=ConfidenceLevel.LOW,
+                confidence_source=ConfidenceSource.VIEW_DEFINITION,
+            ),
+            rewrite_guidance=["Rewrite JS UDF"],
+            placement=None,
+        ),
+    ]
+    return Assessment(
+        assessment_id="assess-20260617-abc123",
+        generated_at=datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc),
+        project_id="my-project",
+        summary=AssessmentSummary(
+            total_entities=2,
+            total_tables=1,
+            total_size_gb=42.5,
+            effort_counts={"AUTO": 0, "ASSISTED": 1, "MANUAL": 0},
+            complexity_counts={"PORTABLE": 0, "ADAPT": 1, "REWRITE": 1},
+            sql_surface_confidence=sql_confidence,
+        ),
+        cost=CostComparison(
+            bq_pricing_model=BQPricingModel.CAPACITY,
+            bigquery_monthly=105000.0,
+            bigquery_breakdown=[
+                CostLine(
+                    label="BQ cap",
+                    monthly=105000.0,
+                    monthly_low=None,
+                    monthly_high=None,
+                    confidence=ConfidenceLevel.HIGH,
+                    source_note="V4",
+                )
+            ],
+            aws_lines=[
+                CostLine(
+                    label="S3",
+                    monthly=50.0,
+                    monthly_low=None,
+                    monthly_high=None,
+                    confidence=ConfidenceLevel.HIGH,
+                    source_note="V2",
+                )
+            ],
+            aws_monthly_low=26250.0,
+            aws_monthly_high=26250.0,
+            monthly_delta_low=78750.0,
+            monthly_delta_high=78750.0,
+            annual_savings_low=945000.0,
+            annual_savings_high=945000.0,
+            migration_onetime=15000.0,
+            breakeven_months_low=0.19,
+            breakeven_months_high=0.19,
+            compute_confidence=compute_confidence,
+        ),
+        entities=entities,
+        failures=[],
+    )
+
+
+def test_html_renders_single_file():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    assert len(paths) == 1
+    assert paths[0].endswith(".html")
+    assert os.path.exists(paths[0])
+    assert os.path.basename(paths[0]) == "my-project-assessment.html"
+
+
+def test_html_contains_all_tabs():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    with open(paths[0]) as f:
+        html = f.read()
+    assert 'id="tab-landing"' in html
+    assert 'id="tab-effort"' in html
+    assert 'id="tab-query"' in html
+
+
+def test_html_offline_no_external_urls():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    with open(paths[0]) as f:
+        html = f.read()
+    assert "http://" not in html
+    assert "https://" not in html
+
+
+def test_html_low_confidence_banner_compute():
+    a = _known_assessment(compute_confidence=ConfidenceLevel.LOW)
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    with open(paths[0]) as f:
+        html = f.read()
+    assert "Low Confidence Cost Estimate" in html
+
+
+def test_html_low_confidence_banner_sql_surface():
+    a = _known_assessment(sql_confidence=ConfidenceLevel.LOW)
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    with open(paths[0]) as f:
+        html = f.read()
+    assert "Low Confidence SQL Analysis" in html
+
+
+def test_html_no_csv_emitted():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    HTMLWriter().write(a, out)
+    files = os.listdir(out)
+    assert not any(f.endswith(".csv") for f in files)
+
+
+def test_html_mobile_viewport():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out)
+    with open(paths[0]) as f:
+        html = f.read()
+    assert 'name="viewport"' in html
+    assert "@media (max-width: 768px)" in html
+
+
+def test_html_storage_basis_measured():
+    """When storage_basis='measured', template receives correct basis."""
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out, storage_basis="measured")
+    with open(paths[0]) as f:
+        html = f.read()
+    # The template's conditional text for measured storage
+    assert "measured physical bytes" in html.lower()
+
+
+def test_html_storage_basis_assumed():
+    """When storage_basis='assumed' (default), template interpolates physical_ratio."""
+    from bq_assess.engine.redshift import cost_constants as k
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(a, out, storage_basis="assumed")
+    with open(paths[0]) as f:
+        html = f.read()
+    # The template's conditional text for assumed storage — should have interpolated ratio
+    assert str(k.ASSUMED_PHYSICAL_RATIO) in html
+
+
+def _render_html(assessment) -> str:
+    out = tempfile.mkdtemp()
+    paths = HTMLWriter().write(assessment, out)
+    with open(paths[0]) as f:
+        return f.read()
+
+
+def test_html_has_csp_with_script_nonce():
+    """The report ships a CSP that only allows the nonce'd inline script (no unsafe-inline)."""
+    html = _render_html(_known_assessment())
+    m = re.search(r"script-src 'nonce-([A-Za-z0-9_-]+)'", html)
+    assert m, "CSP header missing a script nonce"
+    nonce = m.group(1)
+    # The one legitimate inline <script> must carry the matching nonce...
+    assert f'<script nonce="{nonce}">' in html
+    # ...and there must be NO bare <script> that a compliant browser would run.
+    assert "<script>" not in html
+    # unsafe-inline for scripts would defeat the whole point.
+    assert "'unsafe-inline'" not in re.search(r"script-src[^;]*", html).group(0)
+
+
+def test_html_csp_nonce_is_per_render():
+    """Each rendered file gets a fresh, unguessable nonce (never a fixed constant)."""
+    h1 = _render_html(_known_assessment())
+    h2 = _render_html(_known_assessment())
+    n1 = re.search(r"script-src 'nonce-([A-Za-z0-9_-]+)'", h1).group(1)
+    n2 = re.search(r"script-src 'nonce-([A-Za-z0-9_-]+)'", h2).group(1)
+    assert n1 != n2
+    assert len(n1) >= 16
+
+
+def test_html_malicious_identifier_is_neutralized():
+    """A BigQuery identifier attempting <code> breakout + <script> injection is escaped.
+
+    Regression for the storm-aws deep-audit XSS finding: DDL/DML rendered from
+    attacker-controlled entity names must never produce an executable <script>.
+    """
+    a = _known_assessment()
+    payload = "ds.evil</code><script>alert(document.domain)</script><code>t"
+    a.entities[0].full_name = payload
+    a.entities[0].conversion.ddl = f"CREATE TABLE {payload} (id long);"
+    a.entities[0].load_sync_dml = f"INSERT INTO {payload} SELECT * FROM src;"
+    html = _render_html(a)
+    # The raw injected script must not survive as executable markup anywhere —
+    # entity data now ships inside a JSON data block, where Jinja's |tojson
+    # escapes `<` as \\u003c so the payload can never close the block or form a tag.
+    assert "<script>alert(document.domain)</script>" not in html
+    assert "</code><script>" not in html
+    assert "\\u003cscript\\u003ealert(document.domain)\\u003c/script\\u003e" in html
+    # And the only executable <script> tag is still the nonce'd one.
+    assert "<script>" not in html
+    # The client-side renderer must insert entity data as text, never as markup.
+    assert "innerHTML" not in html
+
+

--- a/solution-architecture/clis/bq-assess/tests/unit/test_iceberg_converter.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_iceberg_converter.py
@@ -1,0 +1,383 @@
+"""Unit tests for IcebergConverter and DMLGenerator (task 2.5).
+
+Covers: each type-table row, mixed-type table, nested struct/array, each lossy type,
+each partition kind, small/large/huge DML, MERGE presence.
+Requirements: R6.1, R6.2, R7.1, R7.3, R7.4, R8.1, R12.1, R12.2
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from bq_assess import models as m
+from bq_assess.targets.iceberg.converter import (
+    IcebergConverter,
+)
+from bq_assess.targets.iceberg.dml import (
+    DMLGenerator,
+)
+
+
+converter = IcebergConverter()
+dml_gen = DMLGenerator()
+
+NOW = datetime.now(tz=timezone.utc)
+
+
+def _make_table(
+    columns, *, time_part=None, range_part=None, clustering=None,
+    num_bytes=1000, full_name="ds.tbl",
+) -> m.EntityMetadata:
+    return m.EntityMetadata(
+        entity_id="tbl", dataset_id="ds", full_name=full_name,
+        entity_type=m.EntityType.TABLE, population=m.EntityPopulation.TABLE,
+        num_rows=100, num_bytes=num_bytes, columns=columns,
+        time_partitioning=time_part, range_partitioning=range_part,
+        clustering_fields=clustering, view_query=None, mview_query=None,
+        routine=None, depends_on=[], last_modified=NOW,
+    )
+
+
+def _col(name, field_type, mode="NULLABLE", fields=None):
+    return m.ColumnSchema(name=name, field_type=field_type, mode=mode, fields=fields or [])
+
+
+# =============================================================================
+# Type mapping — each row in the type table (R6.1)
+# =============================================================================
+
+class TestCleanTypeMappings:
+    """Each clean BQ type maps to the correct Iceberg type."""
+
+    @pytest.mark.parametrize("bq_type,expected_iceberg", [
+        ("STRING", "string"),
+        ("INT64", "long"),
+        ("INTEGER", "long"),
+        ("FLOAT64", "double"),
+        ("FLOAT", "double"),
+        ("BOOL", "boolean"),
+        ("BOOLEAN", "boolean"),
+        ("BYTES", "binary"),
+        ("DATE", "date"),
+        ("TIMESTAMP", "timestamptz"),
+        ("DATETIME", "timestamp"),
+        ("NUMERIC", "decimal(38,9)"),
+    ])
+    def test_clean_scalar_type(self, bq_type, expected_iceberg):
+        entity = _make_table([_col("c", bq_type)])
+        result = converter.convert(entity)
+        assert result.success
+        assert expected_iceberg in result.ddl
+        assert result.lossy_casts == []
+
+    def test_mixed_type_table(self):
+        """Table with multiple clean types produces DDL with all columns."""
+        cols = [
+            _col("id", "INT64", "REQUIRED"),
+            _col("name", "STRING"),
+            _col("amount", "NUMERIC"),
+            _col("created", "TIMESTAMP"),
+            _col("active", "BOOL"),
+        ]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert result.success
+        assert "long NOT NULL" in result.ddl
+        assert "string" in result.ddl
+        assert "decimal(38,9)" in result.ddl
+        assert "timestamptz" in result.ddl
+        assert "boolean" in result.ddl
+
+
+# =============================================================================
+# Nested types — struct / array / struct-in-array (R6.2)
+# =============================================================================
+
+class TestNestedTypes:
+
+    def test_struct_becomes_iceberg_struct(self):
+        inner = [_col("x", "STRING"), _col("y", "INT64")]
+        cols = [_col("data", "STRUCT", fields=inner)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "struct<" in result.ddl
+        assert "x: string" in result.ddl
+        assert "y: long" in result.ddl
+
+    def test_record_treated_as_struct(self):
+        inner = [_col("a", "FLOAT64")]
+        cols = [_col("rec", "RECORD", fields=inner)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "struct<" in result.ddl
+        assert "a: double" in result.ddl
+
+    def test_repeated_scalar_becomes_list(self):
+        cols = [_col("tags", "STRING", mode="REPEATED")]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "list<string>" in result.ddl
+
+    def test_repeated_struct_becomes_list_struct(self):
+        inner = [_col("item_id", "INT64"), _col("qty", "INT64")]
+        cols = [_col("items", "STRUCT", mode="REPEATED", fields=inner)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "list<struct<" in result.ddl
+        assert "item_id: long" in result.ddl
+
+    def test_deeply_nested_struct(self):
+        """Two levels of nesting preserved."""
+        inner2 = [_col("zip", "STRING")]
+        inner1 = [_col("city", "STRING"), _col("geo", "STRUCT", fields=inner2)]
+        cols = [_col("address", "STRUCT", fields=inner1)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "struct<city: string, geo: struct<zip: string>>" in result.ddl
+
+    def test_required_nested_field_gets_not_null(self):
+        """REQUIRED sub-field inside a STRUCT renders NOT NULL (R6.4)."""
+        inner = [_col("x", "STRING", mode="REQUIRED"), _col("y", "INT64")]
+        cols = [_col("data", "STRUCT", fields=inner)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        # Required sub-field carries NOT NULL; nullable sibling does not
+        assert "x: string NOT NULL" in result.ddl
+        assert "y: long," in result.ddl or "y: long>" in result.ddl
+        assert "y: long NOT NULL" not in result.ddl
+
+    def test_required_field_in_repeated_struct_gets_not_null(self):
+        """REQUIRED sub-field inside ARRAY<STRUCT> renders NOT NULL (R6.4)."""
+        inner = [_col("item_id", "INT64", mode="REQUIRED"), _col("note", "STRING")]
+        cols = [_col("items", "STRUCT", mode="REPEATED", fields=inner)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert "list<struct<" in result.ddl
+        assert "item_id: long NOT NULL" in result.ddl
+
+
+# =============================================================================
+# Lossy types (R8.1)
+# =============================================================================
+
+class TestLossyTypes:
+
+    @pytest.mark.parametrize("bq_type", ["GEOGRAPHY", "INTERVAL", "TIME", "JSON", "BIGNUMERIC"])
+    def test_lossy_type_produces_warning(self, bq_type):
+        cols = [_col("lossy_col", bq_type)]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert result.success
+        assert len(result.lossy_casts) == 1
+        lc = result.lossy_casts[0]
+        assert lc.column == "lossy_col"
+        assert lc.source_type == bq_type
+        assert lc.iceberg_type != ""
+        assert lc.loss_description != ""
+
+    def test_unknown_type_fallback_to_string(self):
+        cols = [_col("mystery", "FOOBAR")]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert result.success
+        assert len(result.lossy_casts) == 1
+        assert result.lossy_casts[0].iceberg_type == "string"
+        assert "FOOBAR" in result.lossy_casts[0].loss_description
+
+    def test_multiple_lossy_columns(self):
+        cols = [_col("geo", "GEOGRAPHY"), _col("interval", "INTERVAL"), _col("id", "INT64")]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert len(result.lossy_casts) == 2
+        lossy_names = {lc.column for lc in result.lossy_casts}
+        assert lossy_names == {"geo", "interval"}
+
+
+# =============================================================================
+# Partition mapping — each kind (R7.1, R7.3, R7.4)
+# =============================================================================
+
+class TestPartitionMapping:
+
+    @pytest.mark.parametrize("part_type,expected_transform", [
+        ("DAY", "day(event_ts)"),
+        ("HOUR", "hour(event_ts)"),
+        ("MONTH", "month(event_ts)"),
+        ("YEAR", "year(event_ts)"),
+    ])
+    def test_explicit_time_partition_clean(self, part_type, expected_transform):
+        tp = m.TimePartitionConfig(type=part_type, field="event_ts")
+        cols = [_col("event_ts", "TIMESTAMP")]
+        entity = _make_table(cols, time_part=tp)
+        result = converter.convert(entity)
+        pm = result.partition_mapping
+        assert pm is not None
+        assert pm.auto_derived is True
+        assert expected_transform in pm.iceberg_transforms
+        assert pm.decision_flags == []
+
+    def test_ingestion_time_partition_flagged(self):
+        tp = m.TimePartitionConfig(type="DAY", field=None)
+        cols = [_col("data", "STRING")]
+        entity = _make_table(cols, time_part=tp)
+        result = converter.convert(entity)
+        pm = result.partition_mapping
+        assert pm is not None
+        assert pm.auto_derived is False
+        assert len(pm.decision_flags) > 0
+
+    def test_range_partition_flagged(self):
+        rp = m.RangePartitionConfig(field="user_id", start=0, end=10000, interval=100)
+        cols = [_col("user_id", "INT64")]
+        entity = _make_table(cols, range_part=rp)
+        result = converter.convert(entity)
+        pm = result.partition_mapping
+        assert pm is not None
+        assert pm.auto_derived is False
+        assert any("range" in f.lower() for f in pm.decision_flags)
+
+    def test_range_partition_ddl_is_valid(self):
+        """Flagged range partition emits valid DDL — no inline comment in PARTITION BY (R7.4)."""
+        rp = m.RangePartitionConfig(field="user_id", start=0, end=10000, interval=100)
+        cols = [_col("user_id", "INT64")]
+        entity = _make_table(cols, range_part=rp)
+        result = converter.convert(entity)
+        # The review caveat must NOT leak into the DDL as an inline comment
+        assert "-- REVIEW" not in result.ddl
+        assert "bucket(16, user_id)" in result.ddl
+        # PARTITION BY clause contains only the transform, comment closes the paren cleanly
+        assert "PARTITION BY (bucket(16, user_id))" in result.ddl
+        # The review caveat lives in decision_flags instead
+        assert any("review" in f.lower() for f in result.partition_mapping.decision_flags)
+
+    def test_ingestion_time_partition_ddl_is_valid(self):
+        """Flagged ingestion-time partition emits valid DDL — no inline comment (R7.3)."""
+        tp = m.TimePartitionConfig(type="DAY", field=None)
+        cols = [_col("data", "STRING")]
+        entity = _make_table(cols, time_part=tp)
+        result = converter.convert(entity)
+        assert "-- REVIEW" not in result.ddl
+        assert "PARTITION BY (day(_ingestion_time))" in result.ddl
+        assert any("review" in f.lower() for f in result.partition_mapping.decision_flags)
+
+    def test_clustering_becomes_sort_order(self):
+        cols = [_col("a", "STRING"), _col("b", "STRING"), _col("c", "STRING")]
+        entity = _make_table(cols, clustering=["a", "b"])
+        result = converter.convert(entity)
+        pm = result.partition_mapping
+        assert pm is not None
+        assert pm.sort_order == ["a", "b"]
+        assert pm.auto_derived is True
+
+    def test_no_partition_or_clustering_returns_none(self):
+        cols = [_col("id", "INT64")]
+        entity = _make_table(cols)
+        result = converter.convert(entity)
+        assert result.partition_mapping is None
+
+
+# =============================================================================
+# DML Generator — volume tiers (R12.1)
+# =============================================================================
+
+class TestDMLGenerator:
+
+    def test_small_table_uses_insert(self):
+        cols = [_col("id", "INT64")]
+        entity = _make_table(cols, num_bytes=500 * 1024**2)  # 500 MB
+        effort = m.EffortResult(
+            category=m.EffortCategory.AUTO, score=0,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is not None
+        assert "INSERT INTO" in dml
+        assert "COPY" not in dml
+
+    def test_large_table_uses_copy(self):
+        cols = [_col("id", "INT64")]
+        entity = _make_table(cols, num_bytes=50 * 1024**3)  # 50 GB
+        effort = m.EffortResult(
+            category=m.EffortCategory.ASSISTED, score=1,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is not None
+        assert "COPY" in dml
+        assert "PARQUET" in dml
+
+    def test_huge_table_uses_partition_copy(self):
+        cols = [_col("id", "INT64"), _col("event_date", "DATE")]
+        tp = m.TimePartitionConfig(type="DAY", field="event_date")
+        entity = _make_table(cols, num_bytes=500 * 1024**3, time_part=tp)  # 500 GB
+        effort = m.EffortResult(
+            category=m.EffortCategory.MANUAL, score=3,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is not None
+        assert "COPY" in dml
+        assert "partition" in dml.lower()
+
+    def test_rebuilt_entity_returns_none(self):
+        entity = m.EntityMetadata(
+            entity_id="v", dataset_id="ds", full_name="ds.v",
+            entity_type=m.EntityType.VIEW, population=m.EntityPopulation.REBUILT,
+            num_rows=0, num_bytes=0,
+            columns=[_col("x", "STRING")],
+            time_partitioning=None, range_partitioning=None,
+            clustering_fields=None, view_query="SELECT 1",
+            mview_query=None, routine=None, depends_on=[],
+            last_modified=NOW,
+        )
+        effort = m.EffortResult(
+            category=m.EffortCategory.AUTO, score=0,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is None
+
+    def test_merge_present_when_sync_signal(self):
+        """Table with time partitioning gets a MERGE statement (R12.2)."""
+        cols = [_col("id", "INT64", "REQUIRED"), _col("value", "STRING")]
+        tp = m.TimePartitionConfig(type="DAY", field="id")
+        entity = _make_table(cols, time_part=tp)
+        effort = m.EffortResult(
+            category=m.EffortCategory.ASSISTED, score=1,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is not None
+        assert "MERGE INTO" in dml
+        assert "WHEN MATCHED" in dml
+        assert "WHEN NOT MATCHED" in dml
+
+    def test_no_merge_without_sync_signal(self):
+        """Table with no partition and no timestamp columns → no MERGE."""
+        cols = [_col("x", "STRING"), _col("y", "INT64")]
+        entity = _make_table(cols)
+        effort = m.EffortResult(
+            category=m.EffortCategory.AUTO, score=0,
+            flags=[], reasoning="", confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort)
+        assert dml is not None
+        assert "MERGE" not in dml
+
+    def test_non_clean_partition_caveat_in_dml(self):
+        """Flagged partition → caveat appears in DML output (R12.4)."""
+        cols = [_col("user_id", "INT64")]
+        rp = m.RangePartitionConfig(field="user_id", start=0, end=10000, interval=100)
+        entity = _make_table(cols, range_part=rp)
+        conversion = converter.convert(entity)
+        effort = m.EffortResult(
+            category=m.EffortCategory.ASSISTED, score=1,
+            flags=["partition_decision_required"], reasoning="",
+            confidence=m.ConfidenceLevel.MEDIUM,
+        )
+        dml = dml_gen.generate(entity, effort, conversion)
+        assert dml is not None
+        assert "REVIEW REQUIRED" in dml
+        assert "range" in dml.lower()

--- a/solution-architecture/clis/bq-assess/tests/unit/test_jobs_query.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_jobs_query.py
@@ -1,0 +1,97 @@
+# Feature: bq-assess-lakehouse, issue 5.x review fix: shared JOBS reader
+"""Unit tests for the shared INFORMATION_SCHEMA.JOBS reader (core/jobs_query.py).
+
+One place builds the project-wide job-history query that PricingDetector (5.1) and
+WorkloadAnalyzer (5.2) both read — using JOBS_BY_PROJECT (not the per-user JOBS alias),
+project- and region-qualified, with the completed-query lookback filter — and runs it under
+the scanner's retry, degrading to [] on any error (never raises).
+"""
+
+from __future__ import annotations
+
+from google.api_core.exceptions import Forbidden
+
+from bq_assess.core.jobs_query import read_jobs
+
+
+class _FakeQueryJob:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def result(self):
+        return iter(self._rows)
+
+
+class _FakeClient:
+    def __init__(self, *, rows=None, error=None):
+        self._rows = rows if rows is not None else []
+        self._error = error
+        self.queries: list[str] = []
+
+    def query(self, sql, *a, **k):
+        self.queries.append(sql)
+        if self._error is not None:
+            raise self._error
+        return _FakeQueryJob(self._rows)
+
+
+def test_query_uses_jobs_by_project_not_per_user_alias() -> None:
+    """The whole-project view, not the bare per-user JOBS alias (review #1)."""
+    c = _FakeClient(rows=[{"x": 1}])
+    read_jobs(c, "proj", "SELECT reservation_id", days=30, location="US")
+    sql = c.queries[0]
+    assert "INFORMATION_SCHEMA.JOBS_BY_PROJECT" in sql
+    # Project- and region-qualified.
+    assert "`proj`" in sql
+    assert "`region-us`" in sql
+
+
+def test_query_filters_completed_queries_over_lookback() -> None:
+    """WHERE bounds to completed QUERY jobs over the lookback, excluding SCRIPT (review #2)."""
+    c = _FakeClient(rows=[])
+    read_jobs(c, "proj", "SELECT reservation_id", days=14, location="US")
+    sql = c.queries[0]
+    assert "job_type = 'QUERY'" in sql
+    assert "state = 'DONE'" in sql
+    assert "INTERVAL 14 DAY" in sql
+    assert "statement_type != 'SCRIPT'" in sql
+
+
+def test_returns_rows_on_success() -> None:
+    rows = [{"a": 1}, {"a": 2}]
+    assert read_jobs(_FakeClient(rows=rows), "proj", "SELECT a") == rows
+
+
+def test_degrades_to_empty_on_error_never_raises() -> None:
+    """Missing perms / any error → [] (callers treat no-signal as no-data), never raises."""
+    c = _FakeClient(error=Forbidden("403 bigquery.jobs.listAll"))
+    assert read_jobs(c, "proj", "SELECT a") == []
+
+
+def test_select_clause_is_caller_supplied() -> None:
+    """The caller supplies only the SELECT list; the FROM/WHERE skeleton is shared."""
+    c = _FakeClient(rows=[])
+    read_jobs(c, "proj", "SELECT total_slot_ms, creation_time")
+    assert "SELECT total_slot_ms, creation_time" in c.queries[0]
+
+
+def test_retryable_error_exhausts_retries_then_degrades_to_empty() -> None:
+    """A retryable error (429/500/503) that persists through all retry attempts still
+    degrades to [] — the retry logic re-raises on the final attempt, caught by the outer
+    except in read_jobs (R16.3/R17.3 graceful degradation)."""
+    from unittest.mock import patch
+    from google.api_core.exceptions import ServiceUnavailable
+
+    call_count = 0
+
+    class _RetryClient:
+        def query(self, sql, *a, **k):
+            nonlocal call_count
+            call_count += 1
+            raise ServiceUnavailable("503 Backend unavailable")
+
+    with patch("bq_assess.core.jobs_query.time.sleep"):
+        result = read_jobs(_RetryClient(), "proj", "SELECT a")
+
+    assert result == []
+    assert call_count == 4  # initial + 3 retries

--- a/solution-architecture/clis/bq-assess/tests/unit/test_json_writer.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_json_writer.py
@@ -1,0 +1,150 @@
+"""Unit tests for report/json_writer.py — three mirrored JSON files (R19)."""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    Assessment, AssessmentSummary, BQPricingModel, ConfidenceLevel,
+    CostComparison, CostLine, EntityPopulation, EntityReport, EntityType,
+    EffortCategory, EffortResult, ComplexityCategory, ComplexityResult,
+    ConfidenceSource, ConversionResult,
+)
+from bq_assess.report.json_writer import JSONWriter
+
+
+def _known_assessment():
+    """A deterministic Assessment for schema validation."""
+    entities = [
+        EntityReport(
+            full_name="ds.orders", entity_type=EntityType.TABLE,
+            population=EntityPopulation.TABLE, rows=1_000_000, size_gb=42.5,
+            depends_on=[],
+            effort=EffortResult(category=EffortCategory.ASSISTED, score=45, flags=["time_partitioning"], reasoning="has partitions", confidence=ConfidenceLevel.HIGH),
+            conversion=ConversionResult(ddl="CREATE TABLE ds.orders (id long);", partition_mapping=None, lossy_casts=[], warnings=[], success=True),
+            load_sync_dml="COPY INTO ds.orders FROM 's3://...'",
+            complexity=ComplexityResult(category=ComplexityCategory.ADAPT, score=60, constructs=[], flags=["UNNEST"], reasoning="uses UNNEST", confidence=ConfidenceLevel.MEDIUM, confidence_source=ConfidenceSource.QUERY_LOGS),
+            rewrite_guidance=["Replace UNNEST with SUPER type navigation"],
+            placement=None,
+        ),
+        EntityReport(
+            full_name="ds.active_users_v", entity_type=EntityType.VIEW,
+            population=EntityPopulation.REBUILT, rows=0, size_gb=0.0,
+            depends_on=["ds.orders"],
+            effort=None, conversion=None, load_sync_dml=None,
+            complexity=ComplexityResult(category=ComplexityCategory.REWRITE, score=80, constructs=[], flags=["JS_UDF"], reasoning="JS UDF", confidence=ConfidenceLevel.LOW, confidence_source=ConfidenceSource.VIEW_DEFINITION),
+            rewrite_guidance=["Rewrite JS UDF to SQL"],
+            placement=None,
+        ),
+    ]
+    return Assessment(
+        assessment_id="assess-20260617-abc123",
+        generated_at=datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc),
+        project_id="my-project",
+        summary=AssessmentSummary(
+            total_entities=2, total_tables=1, total_size_gb=42.5,
+            effort_counts={"AUTO": 0, "ASSISTED": 1, "MANUAL": 0},
+            complexity_counts={"PORTABLE": 0, "ADAPT": 1, "REWRITE": 1},
+            sql_surface_confidence=ConfidenceLevel.HIGH,
+        ),
+        cost=CostComparison(
+            bq_pricing_model=BQPricingModel.CAPACITY, bigquery_monthly=105000.0,
+            bigquery_breakdown=[CostLine(label="BigQuery capacity (ENTERPRISE)", monthly=105000.0, monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.HIGH, source_note="V4 ENTERPRISE")],
+            aws_lines=[
+                CostLine(label="S3 Tables storage", monthly=50.0, monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.HIGH, source_note="V2"),
+                CostLine(label="Redshift Serverless compute", monthly=26200.0, monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.MEDIUM, source_note="V1 via V3"),
+            ],
+            aws_monthly_low=26250.0, aws_monthly_high=26250.0,
+            monthly_delta_low=78750.0, monthly_delta_high=78750.0,
+            annual_savings_low=945000.0, annual_savings_high=945000.0,
+            migration_onetime=15000.0, breakeven_months_low=0.19, breakeven_months_high=0.19,
+            compute_confidence=ConfidenceLevel.MEDIUM,
+        ),
+        entities=entities, failures=[],
+    )
+
+
+def test_json_writer_produces_three_files():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    assert len(paths) == 3
+    assert all(p.endswith(".json") for p in paths)
+
+
+def test_json_landing_schema():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    landing_path = [p for p in paths if "landing" in p][0]
+    with open(landing_path) as f:
+        data = json.load(f)
+    for key in ["assessment_id", "generated_at", "project_id", "summary", "cost", "failures"]:
+        assert key in data
+    assert data["assessment_id"] == "assess-20260617-abc123"
+    assert data["summary"]["total_entities"] == 2
+
+
+def test_json_effort_tables_only():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    effort_path = [p for p in paths if "effort" in p][0]
+    with open(effort_path) as f:
+        data = json.load(f)
+    assert data["assessment_id"] == "assess-20260617-abc123"
+    assert len(data["entities"]) == 1
+    assert data["entities"][0]["full_name"] == "ds.orders"
+    assert data["entities"][0]["population"] == "TABLE"
+
+
+def test_json_query_includes_rebuilt():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    query_path = [p for p in paths if "query" in p][0]
+    with open(query_path) as f:
+        data = json.load(f)
+    assert len(data["entities"]) == 2
+    names = {e["full_name"] for e in data["entities"]}
+    assert names == {"ds.orders", "ds.active_users_v"}
+
+
+def test_json_crossref_by_full_name():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    all_names = set()
+    for p in paths:
+        with open(p) as f:
+            data = json.load(f)
+        if "entities" in data:
+            for e in data["entities"]:
+                all_names.add(e["full_name"])
+    expected = {e.full_name for e in a.entities}
+    assert all_names == expected
+
+
+def test_json_none_fields_omitted():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    query_path = [p for p in paths if "query" in p][0]
+    with open(query_path) as f:
+        data = json.load(f)
+    view_entity = [e for e in data["entities"] if e["full_name"] == "ds.active_users_v"][0]
+    assert "effort" not in view_entity
+    assert "conversion" not in view_entity
+    assert "load_sync_dml" not in view_entity
+
+
+def test_json_enum_serialized_as_value():
+    a = _known_assessment()
+    out = tempfile.mkdtemp()
+    paths = JSONWriter().write(a, out)
+    landing_path = [p for p in paths if "landing" in p][0]
+    with open(landing_path) as f:
+        data = json.load(f)
+    assert data["cost"]["bq_pricing_model"] == "CAPACITY"
+    assert data["cost"]["compute_confidence"] == "MEDIUM"

--- a/solution-architecture/clis/bq-assess/tests/unit/test_placement.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_placement.py
@@ -1,0 +1,77 @@
+"""Unit tests for engine/redshift/placement.py — Placement Advisor (R14)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    ConfidenceLevel,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    RoutineMetadata,
+)
+from bq_assess.engine.redshift.placement import PlacementAdvisor
+
+
+def _entity(etype=EntityType.VIEW, routine=None):
+    return EntityMetadata(
+        entity_id="v1", dataset_id="ds", full_name="ds.v1",
+        entity_type=etype,
+        population=EntityPopulation.REBUILT if etype != EntityType.TABLE else EntityPopulation.TABLE,
+        num_rows=0, num_bytes=0, columns=[],
+        time_partitioning=None, range_partitioning=None, clustering_fields=None,
+        view_query="SELECT 1" if etype == EntityType.VIEW else None,
+        mview_query="SELECT 1" if etype == EntityType.MATERIALIZED_VIEW else None,
+        routine=routine, depends_on=[],
+        last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestPlacementAdvisor:
+    def test_table_returns_none(self):
+        advisor = PlacementAdvisor()
+        assert advisor.recommend(_entity(etype=EntityType.TABLE)) is None
+
+    def test_udf_always_redshift(self):
+        advisor = PlacementAdvisor()
+        routine = RoutineMetadata(
+            name="my_fn", language="SQL", body="RETURN x + 1",
+            routine_type="SCALAR_FUNCTION", arguments=[],
+        )
+        result = advisor.recommend(_entity(etype=EntityType.ROUTINE, routine=routine))
+        assert result is not None
+        assert result.home == "REDSHIFT"
+
+    def test_js_udf_flagged(self):
+        advisor = PlacementAdvisor()
+        routine = RoutineMetadata(
+            name="js_fn", language="JAVASCRIPT", body="return x;",
+            routine_type="SCALAR_FUNCTION", arguments=[],
+        )
+        result = advisor.recommend(_entity(etype=EntityType.ROUTINE, routine=routine))
+        assert result is not None
+        assert result.home == "REDSHIFT"
+        assert any("javascript" in s.lower() or "js" in s.lower() for s in result.signals)
+
+    def test_view_defaults_redshift_low_confidence(self):
+        advisor = PlacementAdvisor()
+        result = advisor.recommend(_entity(etype=EntityType.VIEW))
+        assert result is not None
+        assert result.home == "REDSHIFT"
+        assert result.confidence == ConfidenceLevel.LOW
+
+    def test_mv_iceberg_refresh_unverified(self):
+        advisor = PlacementAdvisor()
+        result = advisor.recommend(_entity(etype=EntityType.MATERIALIZED_VIEW), has_logs=True)
+        assert result is not None
+        # With logs suggesting cross-engine, could be ICEBERG_CATALOG
+        # Without that signal, default is REDSHIFT
+        # Either way, if home is ICEBERG_CATALOG, refresh_unverified must be True
+        if result.home == "ICEBERG_CATALOG":
+            assert result.refresh_unverified is True
+
+    def test_external_returns_none(self):
+        advisor = PlacementAdvisor()
+        e = _entity(etype=EntityType.EXTERNAL)
+        e.population = EntityPopulation.TABLE
+        assert advisor.recommend(e) is None

--- a/solution-architecture/clis/bq-assess/tests/unit/test_price_lookup.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_price_lookup.py
@@ -1,0 +1,167 @@
+# Review fixes (2026-07-03): live price lookup parsing regressions.
+"""Unit tests for PriceLookup parsing — S3 Tables per-dimension tier prices and
+the zero-SKU GCP result treated as a miss (not a fake-live result)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from bq_assess.core.price_lookup import (
+    PriceLookup,
+    PricingRates,
+    PricingTimeout,
+    fetch_live_rates_with_timeout,
+)
+
+
+def _offer(products, terms):
+    return products, {"OnDemand": terms}["OnDemand"]
+
+
+def test_s3_tables_tiers_read_each_dimensions_own_price() -> None:
+    """One SKU carries all three tiers as priceDimensions with DIFFERENT prices —
+    each tier must get its own, not the first dimension's price three times."""
+    products = {
+        "SKU1": {"attributes": {"usagetype": "Tables-TimedStorage-ByteHrs"}},
+    }
+    terms = {
+        "SKU1": {
+            "offer": {
+                "priceDimensions": {
+                    "d1": {"beginRange": "0", "endRange": "51200",
+                           "pricePerUnit": {"USD": "0.0265"}},
+                    "d2": {"beginRange": "51200", "endRange": "512000",
+                           "pricePerUnit": {"USD": "0.0253"}},
+                    "d3": {"beginRange": "512000", "endRange": "Inf",
+                           "pricePerUnit": {"USD": "0.0242"}},
+                }
+            }
+        }
+    }
+    tiers = PriceLookup._parse_s3_tables_tiers(products, terms)
+    assert tiers == {"tier1": 0.0265, "tier2": 0.0253, "tier3": 0.0242}
+
+
+def test_s3_tables_ignores_intelligent_tiering_variants() -> None:
+    """INT-FA/INT-IA usagetypes must not clobber the Standard tiers."""
+    products = {
+        "STD": {"attributes": {"usagetype": "APS2-Tables-TimedStorage-ByteHrs"}},
+        "INT": {"attributes": {"usagetype": "APS2-Tables-TimedStorage-INT-FA-ByteHrs"}},
+    }
+    terms = {
+        "STD": {"o": {"priceDimensions": {"d": {"beginRange": "0", "pricePerUnit": {"USD": "0.0288"}}}}},
+        "INT": {"o": {"priceDimensions": {"d": {"beginRange": "0", "pricePerUnit": {"USD": "0.9999"}}}}},
+    }
+    tiers = PriceLookup._parse_s3_tables_tiers(products, terms)
+    assert tiers == {"tier1": 0.0288}
+
+
+def test_gcp_parse_with_no_matching_region_returns_zeroed_rates() -> None:
+    """A region-filtered parse that matches nothing yields zero rates — the caller
+    (_fetch_gcp_rates) must then treat it as a miss and fall back to hardcoded."""
+    lookup = PriceLookup(aws_region="us-east-1", bq_location="mars-north1", use_cache=False)
+    rates = lookup._parse_gcp_skus([
+        {
+            "description": "Analysis (australia-southeast1)",
+            "serviceRegions": ["australia-southeast1"],
+            "category": {"resourceGroup": "OnDemandAnalysis"},
+            "pricingInfo": [{"pricingExpression": {
+                "usageUnit": "TiBy",
+                "tieredRates": [{"unitPrice": {"units": "8", "nanos": 125000000}}],
+            }}],
+        }
+    ])
+    assert rates.ondemand_usd_per_tib == 0    # region filter excluded the only SKU
+
+
+def test_gcp_parse_matches_own_region() -> None:
+    lookup = PriceLookup(aws_region="ap-southeast-2", bq_location="australia-southeast1",
+                         use_cache=False)
+    rates = lookup._parse_gcp_skus([
+        {
+            "description": "Analysis (australia-southeast1)",
+            "serviceRegions": ["australia-southeast1"],
+            "category": {"resourceGroup": "OnDemandAnalysis"},
+            "pricingInfo": [{"pricingExpression": {
+                "usageUnit": "TiBy",
+                "tieredRates": [{"unitPrice": {"units": "8", "nanos": 125000000}}],
+            }}],
+        }
+    ])
+    assert rates.ondemand_usd_per_tib == 8.125
+
+
+def test_mixed_live_hardcoded_result_is_not_cached(tmp_path, monkeypatch) -> None:
+    """AWS-live + GCP-fallback must NOT be cached — a 24h entry would pin the fallback
+    and suppress the GCP retry after a transient failure clears."""
+    import bq_assess.core.price_lookup as pl
+    monkeypatch.setattr(pl, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(pl, "_CACHE_FILE", tmp_path / "pricing-cache.json")
+
+    lookup = PriceLookup(aws_region="us-east-1", bq_location="us", use_cache=True)
+    monkeypatch.setattr(lookup, "_fetch_aws_rates", lambda: pl.AWSRates(
+        rpu_hour_usd=0.375, fetched_at="2026-07-04", source="AWS Price List API"))
+    rates = lookup.fetch(gcp_client=None)   # no client → GCP falls back to hardcoded
+    assert rates.gcp.source.startswith("hardcoded")
+    assert not (tmp_path / "pricing-cache.json").exists()
+
+
+def test_both_live_result_is_cached(tmp_path, monkeypatch) -> None:
+    import bq_assess.core.price_lookup as pl
+    monkeypatch.setattr(pl, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(pl, "_CACHE_FILE", tmp_path / "pricing-cache.json")
+
+    lookup = PriceLookup(aws_region="us-east-1", bq_location="us", use_cache=True)
+    monkeypatch.setattr(lookup, "_fetch_aws_rates", lambda: pl.AWSRates(
+        rpu_hour_usd=0.375, fetched_at="2026-07-04", source="AWS Price List API"))
+    monkeypatch.setattr(lookup, "_fetch_gcp_rates", lambda client: pl.GCPRates(
+        ondemand_usd_per_tib=6.25, fetched_at="2026-07-04",
+        source="GCP Cloud Billing Catalog API (us)"))
+    lookup.fetch(gcp_client=object())
+    assert (tmp_path / "pricing-cache.json").exists()
+
+
+def test_fetch_live_rates_times_out_before_slow_fetch_completes() -> None:
+    """A fetch that outlasts the budget raises PricingTimeout at the deadline, not later.
+
+    Regression for the storm-aws deep-audit finding that the paginated GCP catalog fetch
+    could freeze the CLI for minutes. The wait ends at the budget, and the orphaned worker
+    thread must not delay the return.
+    """
+    class SlowLookup(PriceLookup):
+        def fetch(self, gcp_client=None):
+            time.sleep(5)
+            return PricingRates(is_live=True)
+
+    t0 = time.monotonic()
+    with pytest.raises(PricingTimeout):
+        fetch_live_rates_with_timeout(SlowLookup(), budget_seconds=0.3)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 2.0, f"waited {elapsed:.2f}s — should abort near the 0.3s budget"
+
+
+def test_fetch_live_rates_returns_result_within_budget() -> None:
+    """A fast fetch returns its PricingRates unchanged, well inside the budget."""
+    class FastLookup(PriceLookup):
+        def fetch(self, gcp_client=None):
+            return PricingRates(is_live=True, aws_region="ap-southeast-2", bq_location="australia-southeast1")
+
+    rates = fetch_live_rates_with_timeout(FastLookup(), budget_seconds=5)
+    assert rates.is_live
+    assert rates.aws_region == "ap-southeast-2"
+
+
+def test_fetch_live_rates_passes_gcp_client_through() -> None:
+    """The gcp_client argument is forwarded to the wrapped fetch()."""
+    seen = {}
+
+    class RecordingLookup(PriceLookup):
+        def fetch(self, gcp_client=None):
+            seen["client"] = gcp_client
+            return PricingRates(is_live=False)
+
+    sentinel = object()
+    fetch_live_rates_with_timeout(RecordingLookup(), gcp_client=sentinel, budget_seconds=5)
+    assert seen["client"] is sentinel

--- a/solution-architecture/clis/bq-assess/tests/unit/test_pricing.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_pricing.py
@@ -1,0 +1,309 @@
+# Feature: bq-assess-lakehouse, issue 5.1: PricingDetector (R16, V4/V5)
+"""Unit tests for the BigQuery Pricing Detector (on-demand vs capacity / Editions).
+
+Drives the four outcomes of ``PricingDetector.detect()`` per R16:
+  1. ``--reservation-config`` supplied        → CAPACITY + figures, HIGH
+  2. JOBS show a non-null ``reservation_id``   → CAPACITY + edition, MEDIUM
+  3. JOBS all-NULL ``reservation_id``          → ON_DEMAND, MEDIUM (lookback caveat)
+  4. no usable signal (empty / SCRIPT / perms) → ON_DEMAND, LOW, prompt for config
+
+The detector never returns ``model == UNKNOWN`` and never raises (R16.3 / P20 honesty).
+Inputs come from the ``pricing_jobs`` / ``reservation_config`` strategies (conftest).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from google.api_core.exceptions import Forbidden
+
+from bq_assess.core import pricing_constants as k
+from bq_assess.core.pricing import PricingDetector
+from bq_assess.models import BQPricingModel, ConfidenceLevel, PricingDetection
+
+
+class _FakeQueryJob:
+    """Stand-in for the object returned by ``bigquery.Client.query()``."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def result(self):
+        return iter(self._rows)
+
+
+class _FakeClient:
+    """Minimal BigQuery client double routing JOBS queries to canned rows.
+
+    ``jobs`` are returned for any INFORMATION_SCHEMA.JOBS query; ``jobs_error`` (if set)
+    is raised instead, simulating a missing ``bigquery.jobs.listAll`` permission.
+    """
+
+    def __init__(self, *, jobs: list[dict] | None = None, jobs_error: Exception | None = None) -> None:
+        self._jobs = jobs if jobs is not None else []
+        self._jobs_error = jobs_error
+        self.queries: list[str] = []
+
+    def query(self, sql: str, *args, **kwargs) -> _FakeQueryJob:
+        self.queries.append(sql)
+        if self._jobs_error is not None:
+            raise self._jobs_error
+        return _FakeQueryJob(self._jobs)
+
+
+def _job(*, reservation_id=None, edition=None, statement_type="SELECT"):
+    """Build one INFORMATION_SCHEMA.JOBS row dict for a deterministic unit test."""
+    return {
+        "total_slot_ms": 1000,
+        "total_bytes_processed": 10**9,
+        "creation_time": datetime(2025, 6, 1, tzinfo=timezone.utc),
+        "reservation_id": reservation_id,
+        "edition": edition,
+        "statement_type": statement_type,
+    }
+
+
+def _detect(jobs=None, *, jobs_error=None, reservation_config=None, location="US"):
+    """Run detect() against a fake client carrying *jobs* (or raising *jobs_error*)."""
+    client = _FakeClient(jobs=jobs, jobs_error=jobs_error)
+    return PricingDetector().detect(client, "proj", reservation_config, location=location)
+
+
+# --- Outcome 3: auto on-demand --------------------------------------------------------
+
+def test_all_ondemand_jobs_yields_on_demand_medium() -> None:
+    """All leaf jobs NULL reservation_id → ON_DEMAND. MEDIUM: a 30-day sample can't prove
+    a reservation never runs outside the lookback window (asymmetric-confidence policy)."""
+    jobs = [_job(reservation_id=None), _job(reservation_id=None, statement_type="INSERT")]
+
+    result = _detect(jobs)
+
+    assert isinstance(result, PricingDetection)
+    assert result.model is BQPricingModel.ON_DEMAND
+    assert result.confidence is ConfidenceLevel.MEDIUM
+    # On-demand carries no capacity figures.
+    assert result.edition is None
+    assert result.baseline_slots is None
+    assert result.max_slots is None
+    assert result.commitment_slots is None
+    assert result.commitment_plan is None
+    # Provenance names the signal + the verification date.
+    assert k.V5_JOBS_RESERVATION_ID_COLUMN in result.source_note
+    assert k.V5_CONFIRMED_DATE in result.source_note
+
+
+# --- Outcome 2: auto capacity ---------------------------------------------------------
+
+def test_capacity_jobs_yields_capacity_with_edition_medium() -> None:
+    """A non-null reservation_id → CAPACITY; edition read from the JOBS edition column.
+    MEDIUM because slot figures aren't auto-enriched in 5.1 — supply --reservation-config."""
+    jobs = [
+        _job(reservation_id="admin:us.resv1", edition="ENTERPRISE"),
+        _job(reservation_id=None, statement_type="SELECT"),  # mixed: any_capacity wins
+    ]
+
+    result = _detect(jobs)
+
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.edition == "ENTERPRISE"
+    assert result.edition in k.V4_EDITION_SLOT_HOUR_USD  # priceable by the estimator (R18.2)
+    assert result.confidence is ConfidenceLevel.MEDIUM
+    # Figures not auto-enriched in 5.1 → None, and the note prompts for --reservation-config.
+    assert result.baseline_slots is None
+    assert result.max_slots is None
+    assert result.commitment_slots is None
+    assert "--reservation-config" in result.source_note
+
+
+# --- Outcome 1: --reservation-config override ----------------------------------------
+
+def test_reservation_config_overrides_to_capacity_with_all_figures() -> None:
+    """A supplied --reservation-config is a rung above auto-detection (R16.2): CAPACITY with
+    all figures at HIGH confidence, even when the jobs look on-demand."""
+    cfg = {
+        "edition": "ENTERPRISE_PLUS",
+        "baseline_slots": 100,
+        "max_slots": 500,
+        "commitment_slots": 100,
+        "commitment_plan": "ANNUAL",
+    }
+    # Jobs say on-demand; the config must still win.
+    jobs = [_job(reservation_id=None), _job(reservation_id=None)]
+
+    result = _detect(jobs, reservation_config=cfg)
+
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.confidence is ConfidenceLevel.HIGH
+    assert result.edition == "ENTERPRISE_PLUS"
+    assert result.baseline_slots == 100
+    assert result.max_slots == 500
+    assert result.commitment_slots == 100
+    assert result.commitment_plan == "ANNUAL"
+    # Provenance marks it as manually supplied.
+    assert "--reservation-config" in result.source_note
+
+
+# --- Outcome 4: undeterminable → on-demand, LOW, prompt (R16.3 honesty) ---------------
+
+def _assert_undeterminable(result: PricingDetection) -> None:
+    """R16.3: undeterminable collapses to ON_DEMAND at LOW with a prompt — never UNKNOWN."""
+    assert result.model is BQPricingModel.ON_DEMAND
+    assert result.model is not BQPricingModel.UNKNOWN
+    assert result.confidence is ConfidenceLevel.LOW
+    assert result.edition is None
+    assert "--reservation-config" in result.source_note
+
+
+def test_empty_job_list_defaults_to_on_demand_low() -> None:
+    """No jobs at all → can't determine the model → ON_DEMAND/LOW/prompt (R16.3)."""
+    _assert_undeterminable(_detect([]))
+
+
+def test_all_script_parents_defaults_to_on_demand_low() -> None:
+    """All rows SCRIPT parents (NULL reservation_id by design) → no leaf signal → ON_DEMAND/LOW.
+    Guards the trap: SCRIPT NULLs must not be read as on-demand evidence."""
+    jobs = [_job(statement_type="SCRIPT", reservation_id=None) for _ in range(3)]
+    _assert_undeterminable(_detect(jobs))
+
+
+def test_jobs_unreadable_permission_falls_through_to_on_demand_low() -> None:
+    """Missing bigquery.jobs.listAll (Forbidden) → detect() does not raise; ON_DEMAND/LOW/prompt
+    (R16.3 / R17.3 graceful degradation)."""
+    err = Forbidden("missing bigquery.jobs.listAll")
+    _assert_undeterminable(_detect(jobs_error=err))
+
+
+def test_config_with_no_jobs_still_capacity() -> None:
+    """A config supplied with zero jobs still yields CAPACITY with figures (R18.4) — the
+    override outranks (and short-circuits) the absent job signal."""
+    cfg = {
+        "edition": "ENTERPRISE",
+        "baseline_slots": 50,
+        "max_slots": 200,
+        "commitment_slots": 0,
+        "commitment_plan": "FLEX",
+    }
+    result = _detect([], reservation_config=cfg)
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.baseline_slots == 50
+    assert result.confidence is ConfidenceLevel.HIGH
+
+
+# --- SCRIPT / mixed traps -------------------------------------------------------------
+
+def test_script_parent_with_capacity_leaf_yields_capacity() -> None:
+    """A SCRIPT parent (NULL reservation_id) plus a capacity leaf child → CAPACITY.
+    Proves SCRIPT *exclusion*, not inclusion: the leaf's signal still classifies."""
+    jobs = [
+        _job(statement_type="SCRIPT", reservation_id=None),          # parent: NULL by design
+        _job(statement_type="SELECT", reservation_id="admin:us.r1", edition="ENTERPRISE"),
+    ]
+    result = _detect(jobs)
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.edition == "ENTERPRISE"
+
+
+# --- Robustness: never raise (P20) ----------------------------------------------------
+
+def test_missing_columns_on_row_do_not_raise() -> None:
+    """A JOBS row missing the signal columns degrades gracefully (.get semantics), never
+    KeyErrors — real INFORMATION_SCHEMA rows can omit columns."""
+    jobs = [{"total_slot_ms": 1, "creation_time": None}]  # no reservation_id/edition/stmt
+    result = _detect(jobs)
+    assert isinstance(result, PricingDetection)
+    assert result.model is not BQPricingModel.UNKNOWN  # never UNKNOWN externally
+
+
+def test_malformed_partial_config_does_not_raise() -> None:
+    """A --reservation-config missing keys still classifies CAPACITY; absent figures are
+    None rather than raising (P20 honesty)."""
+    result = _detect([], reservation_config={"edition": "ENTERPRISE"})  # only edition
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.edition == "ENTERPRISE"
+    assert result.baseline_slots is None
+    assert result.max_slots is None
+
+
+def test_capacity_job_with_null_edition_is_capacity_edition_none() -> None:
+    """A capacity job (non-null reservation_id) whose edition column is NULL → still CAPACITY,
+    but edition=None: the detector cannot invent an edition from a reservation_id alone."""
+    jobs = [_job(reservation_id="admin:us.r1", edition=None)]
+    result = _detect(jobs)
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.edition is None
+    assert result.confidence is ConfidenceLevel.MEDIUM
+
+
+# --- Edition contradiction edge (V4) --------------------------------------------------
+
+def test_standard_edition_with_commitment_slots_is_flagged() -> None:
+    """STANDARD has no true capacity/slot commitments (V4). A config claiming STANDARD +
+    commitment_slots is surfaced as a warning in source_note (not silently priced)."""
+    cfg = {
+        "edition": "STANDARD",
+        "baseline_slots": 100,
+        "max_slots": 100,
+        "commitment_slots": 100,  # contradiction: STANDARD has no slot commitments
+        "commitment_plan": "ANNUAL",
+    }
+    result = _detect([], reservation_config=cfg)
+    assert result.model is BQPricingModel.CAPACITY
+    assert result.edition == "STANDARD"
+    assert "STANDARD" in result.source_note
+    # The contradiction is named, referencing the verified no-commitment fact.
+    assert "commitment" in result.source_note.lower()
+
+
+# --- Region (location param) ----------------------------------------------------------
+
+def test_location_region_qualifies_the_jobs_query() -> None:
+    """The location arg region-qualifies the INFORMATION_SCHEMA.JOBS query (e.g. region-eu)."""
+    client = _FakeClient(jobs=[_job(reservation_id=None)])
+    PricingDetector().detect(client, "proj", None, location="EU")
+    assert client.queries
+    assert "`region-eu`.INFORMATION_SCHEMA.JOBS" in client.queries[0]
+
+
+# --- Provenance + R18.7 overridability ------------------------------------------------
+
+def test_constants_are_sourced_not_inlined(monkeypatch) -> None:
+    """Overriding the SCRIPT-statement constant changes which rows are excluded — proving the
+    detector reads pricing_constants at call time, not a hardcoded 'SCRIPT' (R18.7)."""
+    # Re-label the SCRIPT sentinel; a row carrying the new sentinel must now be excluded.
+    monkeypatch.setattr(k, "V5_JOBS_SCRIPT_STATEMENT_TYPE", "SENTINEL_SCRIPT")
+    jobs = [_job(statement_type="SENTINEL_SCRIPT", reservation_id=None)]
+    result = _detect(jobs)
+    # With the override, the only row is treated as a SCRIPT parent → no leaf signal → LOW.
+    assert result.confidence is ConfidenceLevel.LOW
+
+
+# --- Grouped reservation rows (2026-07-08 storm audit: bounded-rows JOBS read) ----------
+
+def test_detector_sql_is_grouped() -> None:
+    """The JOBS read GROUPs BY reservation/edition server-side — a handful of rows
+    regardless of the Source's query volume."""
+    client = _FakeClient(jobs=[])
+    PricingDetector().detect(client, "proj", None, location="US")
+    sql = client.queries[0]
+    assert "GROUP BY reservation_id, edition" in sql
+    assert "COUNT(*)" in sql
+
+
+def test_grouped_capacity_rows_classify_with_true_job_counts() -> None:
+    """Grouped rows carry job_count — the source_note quotes real job totals, not group counts."""
+    groups = [
+        {"reservation_id": None, "edition": None, "job_count": 9_000},
+        {"reservation_id": "proj:US.res1", "edition": "ENTERPRISE", "job_count": 1_000},
+    ]
+    detection = _detect(groups)
+    assert detection.model == BQPricingModel.CAPACITY
+    assert detection.edition == "ENTERPRISE"
+    assert "1000 of 10000" in detection.source_note.replace(",", "")
+
+
+def test_grouped_all_null_reservation_is_on_demand() -> None:
+    groups = [{"reservation_id": None, "edition": None, "job_count": 42}]
+    detection = _detect(groups)
+    assert detection.model == BQPricingModel.ON_DEMAND
+    assert detection.confidence == ConfidenceLevel.MEDIUM
+    assert "42" in detection.source_note

--- a/solution-architecture/clis/bq-assess/tests/unit/test_relationships.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_relationships.py
@@ -1,0 +1,339 @@
+"""Unit tests for the RelationshipInferrer.
+
+Requirements: 7.1, 7.2, 7.3
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bq_assess.core.analyzer import JoinPattern, QueryAnalysis
+from bq_assess.core.relationships import RelationshipInferrer
+from bq_assess.models import ColumnSchema, ConfidenceLevel, EntityMetadata, EntityType, EntityPopulation
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_table(
+    table_id: str = "test_table",
+    dataset_id: str = "test_dataset",
+    columns: list[ColumnSchema] | None = None,
+    clustering_fields: list[str] | None = None,
+) -> EntityMetadata:
+    """Build a minimal EntityMetadata (TABLE) for relationship tests."""
+    if columns is None:
+        columns = [ColumnSchema(name="id", field_type="INT64", mode="REQUIRED", fields=[])]
+    return EntityMetadata(
+        entity_id=table_id,
+        dataset_id=dataset_id,
+        full_name=f"{dataset_id}.{table_id}",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=100,
+        num_bytes=1024,
+        columns=columns,
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=clustering_fields,
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# ── 1. _id column detection (naming heuristic) ──────────────────────────
+
+
+def test_id_column_detected_in_more_than_3_tables() -> None:
+    """customer_id in 4 tables → appears in likely_join_keys.
+
+    Requirements: 7.1
+    """
+    tables = [
+        _make_table(
+            table_id=f"table_{i}",
+            dataset_id="ds",
+            columns=[
+                ColumnSchema(name="customer_id", field_type="INT64", mode="NULLABLE", fields=[]),
+                ColumnSchema(name="value", field_type="STRING", mode="NULLABLE", fields=[]),
+            ],
+        )
+        for i in range(4)
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert "customer_id" in result.likely_join_keys
+
+
+def test_id_column_not_detected_in_3_or_fewer_tables() -> None:
+    """order_id in only 3 tables → NOT in likely_join_keys.
+
+    Requirements: 7.1
+    """
+    tables = [
+        _make_table(
+            table_id=f"table_{i}",
+            dataset_id="ds",
+            columns=[
+                ColumnSchema(name="order_id", field_type="INT64", mode="NULLABLE", fields=[]),
+            ],
+        )
+        for i in range(3)
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert "order_id" not in result.likely_join_keys
+
+
+def test_id_column_creates_pairwise_relationships() -> None:
+    """customer_id in 4 tables → pairwise InferredRelationships created.
+
+    Requirements: 7.1
+    """
+    tables = [
+        _make_table(
+            table_id=f"table_{i}",
+            dataset_id="ds",
+            columns=[
+                ColumnSchema(name="customer_id", field_type="INT64", mode="NULLABLE", fields=[]),
+            ],
+        )
+        for i in range(4)
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    # 4 tables → C(4,2) = 6 pairwise relationships
+    naming_rels = [r for r in result.relationships if r.source == "naming_convention"]
+    assert len(naming_rels) == 6
+    for rel in naming_rels:
+        assert rel.join_column == "customer_id"
+        assert rel.confidence == ConfidenceLevel.MEDIUM
+
+
+# ── 2. View SQL JOIN parsing ─────────────────────────────────────────────
+
+
+def test_view_sql_single_join() -> None:
+    """Simple JOIN SQL → one InferredRelationship with correct fields.
+
+    Requirements: 7.2
+    """
+    view_defs = {
+        "my_view": (
+            "SELECT * FROM orders JOIN customers "
+            "ON orders.customer_id = customers.customer_id"
+        ),
+    }
+
+    result = RelationshipInferrer().infer([], view_definitions=view_defs)
+
+    view_rels = [r for r in result.relationships if r.source == "view_definition"]
+    assert len(view_rels) == 1
+    rel = view_rels[0]
+    assert rel.source_table == "orders"
+    assert rel.target_table == "customers"
+    assert rel.join_column == "customer_id"
+    assert rel.confidence == ConfidenceLevel.MEDIUM
+
+
+def test_view_sql_multiple_joins() -> None:
+    """SQL with multiple JOINs → multiple relationships extracted.
+
+    Requirements: 7.2
+    """
+    view_defs = {
+        "complex_view": (
+            "SELECT * FROM orders "
+            "JOIN customers ON orders.customer_id = customers.customer_id "
+            "JOIN products ON orders.product_id = products.product_id"
+        ),
+    }
+
+    result = RelationshipInferrer().infer([], view_definitions=view_defs)
+
+    view_rels = [r for r in result.relationships if r.source == "view_definition"]
+    assert len(view_rels) == 2
+
+    join_cols = {r.join_column for r in view_rels}
+    assert "customer_id" in join_cols
+    assert "product_id" in join_cols
+
+
+def test_view_sql_no_on_clause_fallback() -> None:
+    """JOIN without ON clause → fallback relationship with 'unknown' join column.
+
+    The JOIN_PATTERN regex requires whitespace after the table name, so we
+    add a trailing space to ensure the pattern matches.
+
+    Requirements: 7.2
+    """
+    view_defs = {
+        "simple_view": "SELECT * FROM orders JOIN customers WHERE 1=1",
+    }
+
+    result = RelationshipInferrer().infer([], view_definitions=view_defs)
+
+    view_rels = [r for r in result.relationships if r.source == "view_definition"]
+    assert len(view_rels) >= 1
+    assert view_rels[0].join_column == "unknown"
+
+
+# ── 3. Clustering key → Iceberg sort-order hint mapping ─────────────────
+
+
+def test_clustering_keys_become_sort_order_hints() -> None:
+    """Tables with clustering_fields → those appear in sort_order_hints (R7; not SORTKEY per R15.5).
+
+    Requirements: 7.3, 15.5
+    """
+    tables = [
+        _make_table(
+            table_id="orders",
+            dataset_id="sales",
+            clustering_fields=["order_date", "region"],
+        ),
+        _make_table(
+            table_id="events",
+            dataset_id="analytics",
+            clustering_fields=["event_time"],
+        ),
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert "sales.orders" in result.sort_order_hints
+    assert result.sort_order_hints["sales.orders"] == ["order_date", "region"]
+    assert "analytics.events" in result.sort_order_hints
+    assert result.sort_order_hints["analytics.events"] == ["event_time"]
+
+
+def test_no_clustering_means_no_sort_order_hints() -> None:
+    """Table without clustering_fields → not in sort_order_hints.
+
+    Requirements: 7.3
+    """
+    tables = [
+        _make_table(table_id="plain", dataset_id="ds", clustering_fields=None),
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert "ds.plain" not in result.sort_order_hints
+
+
+# ── 4. Query log integration ────────────────────────────────────────────
+
+
+def test_query_log_produces_high_confidence_relationships() -> None:
+    """QueryAnalysis with join_patterns → HIGH confidence relationships.
+
+    Requirements: 7.1, 7.2
+    """
+    qa = QueryAnalysis(
+        table_query_counts={"orders": 50, "customers": 30},
+        join_patterns={
+            "orders": [
+                JoinPattern(
+                    left_table="orders",
+                    right_table="customers",
+                    join_column="customer_id",
+                    frequency=50,
+                ),
+            ],
+        },
+        where_columns={},
+        hub_tables=[],
+        anonymized=True,
+    )
+
+    result = RelationshipInferrer().infer([], query_analysis=qa)
+
+    log_rels = [r for r in result.relationships if r.source == "query_logs"]
+    assert len(log_rels) == 1
+    assert log_rels[0].confidence == ConfidenceLevel.HIGH
+    assert log_rels[0].source_table == "orders"
+    assert log_rels[0].target_table == "customers"
+    assert log_rels[0].join_column == "customer_id"
+    assert result.confidence == ConfidenceLevel.HIGH
+
+
+# ── 5. Empty input ──────────────────────────────────────────────────────
+
+
+def test_empty_tables_returns_empty_results() -> None:
+    """Empty tables list → empty relationships, join keys, and candidates.
+
+    Requirements: 7.1
+    """
+    result = RelationshipInferrer().infer([])
+
+    assert result.relationships == []
+    assert result.likely_join_keys == []
+    assert result.sort_order_hints == {}
+    assert result.confidence == ConfidenceLevel.LOW
+
+
+# ── 6. Confidence level determination ───────────────────────────────────
+
+
+def test_confidence_medium_with_view_definitions() -> None:
+    """View definitions present → MEDIUM confidence.
+
+    Requirements: 7.1
+    """
+    view_defs = {
+        "v": "SELECT * FROM a JOIN b ON a.id = b.id",
+    }
+
+    result = RelationshipInferrer().infer([], view_definitions=view_defs)
+
+    assert result.confidence == ConfidenceLevel.MEDIUM
+
+
+def test_confidence_medium_with_naming_heuristics() -> None:
+    """Naming heuristics produce join keys → MEDIUM confidence.
+
+    Requirements: 7.1
+    """
+    tables = [
+        _make_table(
+            table_id=f"t{i}",
+            dataset_id="ds",
+            columns=[
+                ColumnSchema(name="user_id", field_type="INT64", mode="NULLABLE", fields=[]),
+            ],
+        )
+        for i in range(5)
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert result.confidence == ConfidenceLevel.MEDIUM
+
+
+def test_confidence_low_schema_only() -> None:
+    """No query logs, no views, no naming matches → LOW confidence.
+
+    Requirements: 7.1
+    """
+    tables = [
+        _make_table(
+            table_id="lonely",
+            dataset_id="ds",
+            columns=[
+                ColumnSchema(name="value", field_type="STRING", mode="NULLABLE", fields=[]),
+            ],
+        ),
+    ]
+
+    result = RelationshipInferrer().infer(tables)
+
+    assert result.confidence == ConfidenceLevel.LOW

--- a/solution-architecture/clis/bq-assess/tests/unit/test_report_serialize.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_report_serialize.py
@@ -1,0 +1,198 @@
+"""Unit tests for report/_serialize.py — shared serialization helpers."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from bq_assess.report._serialize import (
+    _EFFORT_ROW_KEYS, _QUERY_ROW_KEYS, _to_dict, build_report_rows, serialize_entities,
+)
+from bq_assess.models import (
+    Assessment, AssessmentSummary, CostComparison, CostLine, EntityReport,
+    EntityType, EntityPopulation, EffortCategory, EffortResult,
+    ComplexityCategory, ComplexityResult, ConfidenceLevel, ConfidenceSource,
+    BQPricingModel, ConversionResult,
+)
+
+
+class _Color(Enum):
+    RED = "RED"
+    BLUE = "BLUE"
+
+
+def test_enum_serializes_to_value():
+    assert _to_dict(_Color.RED) == "RED"
+
+
+def test_datetime_serializes_to_isoformat():
+    dt = datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc)
+    assert _to_dict(dt) == "2026-06-17T12:00:00+00:00"
+
+
+def test_none_fields_omitted_from_dict():
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Sample:
+        a: str
+        b: str | None = None
+
+    result = _to_dict(_Sample(a="hello", b=None))
+    assert result == {"a": "hello"}
+
+
+def test_nested_dataclass_recursion():
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Inner:
+        x: int
+
+    @dataclass
+    class _Outer:
+        inner: _Inner
+        name: str
+
+    result = _to_dict(_Outer(inner=_Inner(x=42), name="test"))
+    assert result == {"inner": {"x": 42}, "name": "test"}
+
+
+def test_list_of_dataclasses():
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Item:
+        val: int
+
+    result = _to_dict([_Item(val=1), _Item(val=2)])
+    assert result == [{"val": 1}, {"val": 2}]
+
+
+def _make_entity(full_name, population, entity_type):
+    """Minimal EntityReport for filter tests."""
+    effort = None
+    conversion = None
+    if population is EntityPopulation.TABLE:
+        effort = EffortResult(
+            category=EffortCategory.AUTO, score=0, flags=[], reasoning="", confidence=ConfidenceLevel.HIGH
+        )
+        conversion = ConversionResult(ddl="CREATE TABLE t (id long);", partition_mapping=None, lossy_casts=[], warnings=[], success=True)
+    return EntityReport(
+        full_name=full_name, entity_type=entity_type, population=population,
+        rows=100, size_gb=1.0, depends_on=[],
+        effort=effort, conversion=conversion, load_sync_dml=None,
+        complexity=ComplexityResult(
+            category=ComplexityCategory.PORTABLE, score=0, constructs=[], flags=[],
+            reasoning="", confidence=ConfidenceLevel.HIGH, confidence_source=ConfidenceSource.SCHEMA_ONLY,
+        ),
+        rewrite_guidance=[], placement=None,
+    )
+
+
+def _minimal_assessment(entities):
+    return Assessment(
+        assessment_id="assess-20260617-abc123",
+        generated_at=datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc),
+        project_id="test-proj",
+        summary=AssessmentSummary(
+            total_entities=len(entities), total_tables=sum(1 for e in entities if e.population is EntityPopulation.TABLE),
+            total_size_gb=0.0, effort_counts={"AUTO": 0, "ASSISTED": 0, "MANUAL": 0},
+            complexity_counts={"PORTABLE": 0, "ADAPT": 0, "REWRITE": 0},
+            sql_surface_confidence=ConfidenceLevel.HIGH,
+        ),
+        cost=CostComparison(
+            bq_pricing_model=BQPricingModel.ON_DEMAND, bigquery_monthly=1000.0,
+            bigquery_breakdown=[], aws_lines=[CostLine(label="s3", monthly=100.0, monthly_low=None, monthly_high=None, confidence=ConfidenceLevel.HIGH, source_note="test")],
+            aws_monthly_low=100.0, aws_monthly_high=100.0,
+            monthly_delta_low=900.0, monthly_delta_high=900.0,
+            annual_savings_low=10800.0, annual_savings_high=10800.0,
+            migration_onetime=500.0, breakeven_months_low=0.56, breakeven_months_high=0.56,
+            compute_confidence=ConfidenceLevel.HIGH,
+        ),
+        entities=entities, failures=[],
+    )
+
+
+def test_effort_filters_tables_only():
+    entities = [
+        _make_entity("ds.tbl", EntityPopulation.TABLE, EntityType.TABLE),
+        _make_entity("ds.view1", EntityPopulation.REBUILT, EntityType.VIEW),
+    ]
+    effort, _ = serialize_entities(_minimal_assessment(entities))
+    assert len(effort) == 1
+    assert effort[0]["full_name"] == "ds.tbl"
+
+
+def test_query_includes_all_entities():
+    entities = [
+        _make_entity("ds.tbl", EntityPopulation.TABLE, EntityType.TABLE),
+        _make_entity("ds.view1", EntityPopulation.REBUILT, EntityType.VIEW),
+    ]
+    _, query = serialize_entities(_minimal_assessment(entities))
+    assert len(query) == 2
+    names = {e["full_name"] for e in query}
+    assert names == {"ds.tbl", "ds.view1"}
+
+
+def test_serialize_entities_memoized():
+    """JSONWriter and HTMLWriter both serialize per run — the walk must happen once."""
+    entities = [_make_entity("ds.tbl", EntityPopulation.TABLE, EntityType.TABLE)]
+    a = _minimal_assessment(entities)
+    first = serialize_entities(a)
+    assert serialize_entities(a) is first
+
+
+def test_report_rows_prune_nested_dead_fields():
+    """The embedded report JSON must not carry fields the renderer never reads —
+    especially complexity.constructs, whose anonymized SQL snippets dominate the
+    payload at query-log scale."""
+    from bq_assess.models import DetectedConstruct, PlacementRecommendation
+
+    entities = [_make_entity("ds.tbl", EntityPopulation.TABLE, EntityType.TABLE)]
+    entities[0].complexity.constructs = [
+        DetectedConstruct(construct_class="UNNEST", snippet="SELECT * FROM UNNEST(?)", description="x")
+    ]
+    entities[0].placement = PlacementRecommendation(
+        home="REDSHIFT", signals=["s"], confidence=ConfidenceLevel.HIGH, refresh_unverified=False
+    )
+    effort, query = serialize_entities(_minimal_assessment(entities))
+    rows = build_report_rows(effort, query)
+
+    q = rows["query"][0]
+    assert "constructs" not in q["complexity"]
+    assert "refresh_unverified" not in q["placement"]
+    e = rows["effort"][0]
+    assert "success" not in e["conversion"]
+    # Pruning must not mutate the shared dicts the JSON sidecars serialize.
+    assert query[0]["complexity"]["constructs"], "sidecar dict was mutated"
+
+
+def test_report_rows_drop_unscored_entities():
+    entities = [
+        _make_entity("ds.tbl", EntityPopulation.TABLE, EntityType.TABLE),
+        _make_entity("ds.view1", EntityPopulation.REBUILT, EntityType.VIEW),
+    ]
+    entities[1].complexity = None
+    effort, query = serialize_entities(_minimal_assessment(entities))
+    rows = build_report_rows(effort, query)
+    assert [r["full_name"] for r in rows["query"]] == ["ds.tbl"]
+
+
+def test_report_rows_cover_template_accesses():
+    """Pin the two-sided contract: every top-level `e.<field>` the report's JS renderer
+    reads must be in the corresponding allowlist, so a renderer change that forgets to
+    extend the allowlist fails here instead of rendering undefined in the browser."""
+    import re
+    from pathlib import Path
+
+    template = (
+        Path(__file__).parent.parent.parent
+        / "src" / "bq_assess" / "report" / "templates" / "combined.html.j2"
+    ).read_text()
+    script = template[template.index("</noscript>"):]
+
+    # Row-level metadata added by the renderer itself, not the serializer.
+    renderer_owned = {"_nameLower"}
+    accessed = set(re.findall(r"\be\.([a-z_]+)\b", script)) - renderer_owned
+    allowed = set(_EFFORT_ROW_KEYS) | set(_QUERY_ROW_KEYS)
+    assert accessed <= allowed, f"JS reads fields missing from allowlists: {accessed - allowed}"

--- a/solution-architecture/clis/bq-assess/tests/unit/test_report_template.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_report_template.py
@@ -1,0 +1,51 @@
+"""Unit tests for report/templates/combined.html.j2 — template source validation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TEMPLATES = Path(__file__).parent.parent.parent / "src" / "bq_assess" / "report" / "templates"
+
+
+def test_storage_assumptions_conditional_exists():
+    """Storage Assumptions section has storage_basis == 'measured' conditional."""
+    raw = (TEMPLATES / "combined.html.j2").read_text()
+    assert 'storage_basis == "measured"' in raw
+    assert "Storage Assumptions" in raw
+
+
+def test_storage_assumptions_measured_content():
+    """When storage_basis='measured', assumptions mention TABLE_STORAGE."""
+    raw = (TEMPLATES / "combined.html.j2").read_text()
+    assert "TABLE_STORAGE" in raw
+    assert "measured physical bytes" in raw
+
+
+def test_storage_assumptions_fallback_content():
+    """When storage_basis != 'measured', assumptions interpolate pricing.physical_ratio."""
+    raw = (TEMPLATES / "combined.html.j2").read_text()
+    assert "pricing.physical_ratio" in raw
+    assert "Parquet compression" in raw
+
+
+def test_total_size_stat_shows_both_bases():
+    """Total Size card shows BigQuery logical headline plus projected S3 size with a basis tooltip."""
+    raw = (TEMPLATES / "combined.html.j2").read_text()
+    assert "Total Size" in raw
+    assert "summary.total_logical_size_gb" in raw   # headline = customer's console number
+    assert "summary.total_size_gb" in raw           # secondary = projected S3 footprint
+    assert "on S3 Iceberg" in raw
+    assert "matches your BigQuery console" in raw   # tooltip explains both numbers
+
+
+def test_entity_size_has_reconciliation_tooltip():
+    """Per-entity size column has reconciliation tooltip showing logical vs physical.
+
+    Entity rows render client-side, so the tooltip is built by the report's JS
+    renderer rather than a Jinja data-tip attribute.
+    """
+    raw = (TEMPLATES / "combined.html.j2").read_text()
+    # The physical_size_gb rendering should have a tooltip showing logical_size_gb
+    assert "e.physical_size_gb" in raw
+    assert "e.logical_size_gb" in raw
+    assert "'BigQuery logical: '" in raw

--- a/solution-architecture/clis/bq-assess/tests/unit/test_rewrite_guide.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_rewrite_guide.py
@@ -1,0 +1,49 @@
+"""Unit tests for engine/redshift/rewrite.py — Query-Rewrite Guidance (R13)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bq_assess.models import (
+    DetectedConstruct,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+)
+from bq_assess.engine.redshift.rewrite import RewriteGuide
+
+
+def _entity():
+    return EntityMetadata(
+        entity_id="v1", dataset_id="ds", full_name="ds.v1",
+        entity_type=EntityType.VIEW, population=EntityPopulation.REBUILT,
+        num_rows=0, num_bytes=0, columns=[],
+        time_partitioning=None, range_partitioning=None, clustering_fields=None,
+        view_query="SELECT UNNEST(arr) FROM t", mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _construct(cls: str) -> DetectedConstruct:
+    return DetectedConstruct(construct_class=cls, snippet="...", description="desc")
+
+
+class TestRewriteGuide:
+    def test_no_constructs_empty_list(self):
+        guide = RewriteGuide()
+        assert guide.guide(_entity(), []) == []
+
+    def test_one_construct_one_guidance(self):
+        guide = RewriteGuide()
+        result = guide.guide(_entity(), [_construct("UNNEST")])
+        assert len(result) == 1
+        assert "UNNEST" in result[0]
+
+    def test_js_udf_mentions_rewrite(self):
+        guide = RewriteGuide()
+        result = guide.guide(_entity(), [_construct("JS_UDF")])
+        assert any("Python" in g or "Lambda" in g for g in result)
+
+    def test_multiple_constructs_multiple_guidance(self):
+        guide = RewriteGuide()
+        result = guide.guide(_entity(), [_construct("UNNEST"), _construct("FUNCTION_DRIFT")])
+        assert len(result) == 2

--- a/solution-architecture/clis/bq-assess/tests/unit/test_scanner.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_scanner.py
@@ -1,0 +1,341 @@
+"""Unit tests for BigQuery scanner — credential validation, filtering, retry, and resilience."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import bigquery
+
+from bq_assess.scanner import BigQueryScanner, ScannerError, _retry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_scanner(**kwargs) -> BigQueryScanner:
+    """Create a scanner with use_adc=True and inject a mock client."""
+    scanner = BigQueryScanner(project_id="test-project", use_adc=True, **kwargs)
+    scanner._client = MagicMock(spec=bigquery.Client)
+    # Default: no routines in any dataset (tests that exercise tables override per-dataset).
+    scanner._client.list_routines.return_value = []
+    return scanner
+
+
+def _make_schema_field(name: str, field_type: str = "STRING", mode: str = "NULLABLE", fields=()):
+    """Build a mock SchemaField."""
+    sf = MagicMock(spec=bigquery.SchemaField)
+    sf.name = name
+    sf.field_type = field_type
+    sf.mode = mode
+    sf.fields = [_make_schema_field(**f) if isinstance(f, dict) else f for f in fields]
+    return sf
+
+
+def _make_table(dataset_id: str, table_id: str, *, num_rows: int = 100, num_bytes: int = 2048):
+    """Build a mock bigquery.Table with minimal metadata."""
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = table_id
+    tbl.dataset_id = dataset_id
+    tbl.table_type = "TABLE"
+    tbl.num_rows = num_rows
+    tbl.num_bytes = num_bytes
+    tbl.schema = [_make_schema_field("id", "INT64", "REQUIRED")]
+    tbl.time_partitioning = None
+    tbl.range_partitioning = None
+    tbl.clustering_fields = None
+    tbl.view_query = None
+    tbl.mview_query = None
+    tbl.modified = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    return tbl
+
+
+def _make_dataset_list_item(dataset_id: str):
+    item = MagicMock(spec=bigquery.dataset.DatasetListItem)
+    item.dataset_id = dataset_id
+    return item
+
+
+def _make_table_list_item(dataset_id: str, table_id: str):
+    item = MagicMock(spec=bigquery.table.TableListItem)
+    item.dataset_id = dataset_id
+    item.table_id = table_id
+    item.reference = MagicMock(spec=bigquery.TableReference)
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Credential validation
+# ---------------------------------------------------------------------------
+
+class TestValidateCredentials:
+    """Requirement 2.1 — lightweight metadata query to verify read access."""
+
+    def test_success_returns_true(self):
+        scanner = _make_scanner()
+        scanner._client.list_datasets.return_value = [_make_dataset_list_item("ds1")]
+
+        assert scanner.validate_credentials() is True
+        scanner._client.list_datasets.assert_called_once_with(max_results=1)
+
+    def test_failure_raises_scanner_error(self):
+        scanner = _make_scanner()
+        scanner._client.list_datasets.side_effect = Exception("403 Forbidden")
+
+        with pytest.raises(ScannerError, match="permissions"):
+            scanner.validate_credentials()
+
+    def test_failure_project_not_found(self):
+        scanner = _make_scanner()
+        scanner._client.list_datasets.side_effect = Exception("404 Not Found")
+
+        with pytest.raises(ScannerError, match="not found"):
+            scanner.validate_credentials()
+
+    def test_failure_invalid_credentials(self):
+        scanner = _make_scanner()
+        scanner._client.list_datasets.side_effect = Exception("401 invalid credentials")
+
+        with pytest.raises(ScannerError, match="Invalid credentials"):
+            scanner.validate_credentials()
+
+    def test_no_credentials_raises_scanner_error(self):
+        """When neither credentials_path nor use_adc is set, ScannerError is raised."""
+        scanner = BigQueryScanner(project_id="test-project")
+        with pytest.raises(ScannerError, match="No credentials provided"):
+            scanner.validate_credentials()
+
+
+# ---------------------------------------------------------------------------
+# Dataset filtering  (Requirement 3.2)
+# ---------------------------------------------------------------------------
+
+class TestDatasetFiltering:
+
+    def test_filter_limits_to_specified_datasets(self):
+        scanner = _make_scanner()
+        client = scanner._client
+
+        ds_a = _make_dataset_list_item("alpha")
+        ds_b = _make_dataset_list_item("beta")
+        ds_c = _make_dataset_list_item("gamma")
+        client.list_datasets.return_value = [ds_a, ds_b, ds_c]
+
+        tbl_a = _make_table_list_item("alpha", "t1")
+        tbl_b = _make_table_list_item("beta", "t2")
+        client.list_tables.side_effect = lambda ds_id: {
+            "alpha": [tbl_a],
+            "beta": [tbl_b],
+        }.get(ds_id, [])
+
+        client.get_table.side_effect = lambda ref: {
+            tbl_a.reference: _make_table("alpha", "t1"),
+            tbl_b.reference: _make_table("beta", "t2"),
+        }[ref]
+
+        results = list(scanner.scan(dataset_filter=["alpha", "beta"]))
+
+        assert len(results) == 2
+        dataset_ids = {r.dataset_id for r in results}
+        assert dataset_ids == {"alpha", "beta"}
+        # gamma should never have been listed
+        listed_ds_ids = [call.args[0] for call in client.list_tables.call_args_list]
+        assert "gamma" not in listed_ds_ids
+
+    def test_no_filter_scans_all_datasets(self):
+        scanner = _make_scanner()
+        client = scanner._client
+
+        ds_a = _make_dataset_list_item("alpha")
+        ds_b = _make_dataset_list_item("beta")
+        client.list_datasets.return_value = [ds_a, ds_b]
+
+        tbl_a = _make_table_list_item("alpha", "t1")
+        tbl_b = _make_table_list_item("beta", "t2")
+        client.list_tables.side_effect = lambda ds_id: {
+            "alpha": [tbl_a],
+            "beta": [tbl_b],
+        }.get(ds_id, [])
+
+        client.get_table.side_effect = lambda ref: {
+            tbl_a.reference: _make_table("alpha", "t1"),
+            tbl_b.reference: _make_table("beta", "t2"),
+        }[ref]
+
+        results = list(scanner.scan())
+
+        assert len(results) == 2
+        dataset_ids = {r.dataset_id for r in results}
+        assert dataset_ids == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# Retry logic  (Requirement 15.1)
+# ---------------------------------------------------------------------------
+
+class TestRetryLogic:
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_retries_on_429_then_succeeds(self, mock_sleep):
+        """Transient 429 on first call, success on second."""
+        err = GoogleAPICallError("rate limited")
+        err._code = 429  # noqa: SLF001
+        err.code = 429
+
+        call_count = 0
+
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise err
+            return "ok"
+
+        result = _retry(fn)
+        assert result == "ok"
+        assert call_count == 2
+        mock_sleep.assert_called_once()  # slept once between attempts
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_retries_on_500_then_succeeds(self, mock_sleep):
+        err = GoogleAPICallError("internal error")
+        err._code = 500
+        err.code = 500
+
+        call_count = 0
+
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise err
+            return "ok"
+
+        result = _retry(fn)
+        assert result == "ok"
+        assert call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        err = GoogleAPICallError("service unavailable")
+        err._code = 503
+        err.code = 503
+
+        with pytest.raises(GoogleAPICallError):
+            _retry(lambda: (_ for _ in ()).throw(err))
+
+        # 1 initial + 3 retries = 4 calls, 3 sleeps
+        assert mock_sleep.call_count == 3
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_exponential_backoff_delays(self, mock_sleep):
+        err = GoogleAPICallError("rate limited")
+        err._code = 429
+        err.code = 429
+
+        call_count = 0
+
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                raise err
+            return "ok"
+
+        _retry(fn)
+        delays = [c.args[0] for c in mock_sleep.call_args_list]
+        assert len(delays) == 3
+        for i, actual in enumerate(delays):
+            base = 1.0 * (2.0 ** i)
+            assert base * 0.5 <= actual <= base * 1.5
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_non_retryable_error_raises_immediately(self, mock_sleep):
+        """A 400 Bad Request should not be retried."""
+        err = GoogleAPICallError("bad request")
+        err._code = 400
+        err.code = 400
+
+        with pytest.raises(GoogleAPICallError):
+            _retry(lambda: (_ for _ in ()).throw(err))
+
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-table failure skipping  (Requirement 15.2)
+# ---------------------------------------------------------------------------
+
+class TestPerTableFailureSkipping:
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_failed_table_is_skipped_and_recorded(self, mock_sleep):
+        scanner = _make_scanner()
+        client = scanner._client
+
+        ds = _make_dataset_list_item("ds1")
+        client.list_datasets.return_value = [ds]
+
+        tbl_ok = _make_table_list_item("ds1", "good_table")
+        tbl_bad = _make_table_list_item("ds1", "bad_table")
+        client.list_tables.return_value = [tbl_ok, tbl_bad]
+
+        err = GoogleAPICallError("permanent failure")
+        err._code = 400
+        err.code = 400
+
+        def get_table_side_effect(ref):
+            if ref is tbl_bad.reference:
+                raise err
+            return _make_table("ds1", "good_table")
+
+        client.get_table.side_effect = get_table_side_effect
+
+        results = list(scanner.scan())
+
+        # good_table yielded, bad_table skipped
+        assert len(results) == 1
+        assert results[0].entity_id == "good_table"
+
+        # failure recorded
+        assert len(scanner.failures) == 1
+        assert scanner.failures[0].entity_name == "ds1.bad_table"
+        assert "permanent failure" in scanner.failures[0].error
+
+    @patch("bq_assess.scanner.time.sleep")
+    def test_multiple_failures_still_yield_remaining(self, mock_sleep):
+        scanner = _make_scanner()
+        client = scanner._client
+
+        ds = _make_dataset_list_item("ds1")
+        client.list_datasets.return_value = [ds]
+
+        tbl1 = _make_table_list_item("ds1", "t1")
+        tbl2 = _make_table_list_item("ds1", "t2")
+        tbl3 = _make_table_list_item("ds1", "t3")
+        client.list_tables.return_value = [tbl1, tbl2, tbl3]
+
+        err = GoogleAPICallError("fail")
+        err._code = 400
+        err.code = 400
+
+        def get_table_side_effect(ref):
+            if ref is tbl1.reference:
+                raise err
+            if ref is tbl3.reference:
+                raise err
+            return _make_table("ds1", "t2")
+
+        client.get_table.side_effect = get_table_side_effect
+
+        results = list(scanner.scan())
+
+        assert len(results) == 1
+        assert results[0].entity_id == "t2"
+        assert len(scanner.failures) == 2
+        failed_refs = {f.entity_name for f in scanner.failures}
+        assert failed_refs == {"ds1.t1", "ds1.t3"}

--- a/solution-architecture/clis/bq-assess/tests/unit/test_scanner_routines_and_failures.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_scanner_routines_and_failures.py
@@ -1,0 +1,242 @@
+"""Unit tests filling the #11 (1.6) gaps not already covered by #6/#8/#9.
+
+Most of the task-1.6 checklist (credential success/failure, dataset filter, retry,
+per-table skip, cache overwrite) is already covered in ``test_scanner.py`` / ``test_cache.py``.
+This module adds the genuinely-missing scanner branches:
+- routine scanning success (R3.3) and routine-level failure resilience (R23.2)
+- dataset-level list-tables failure recorded + continue (R23.2)
+- view entity population/SQL captured at scan time (R3.2, R4.3)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import bigquery
+
+from bq_assess.core.scanner import BigQueryScanner
+from bq_assess.models import EntityPopulation, EntityType
+
+
+# ---------------------------------------------------------------------------
+# Mock builders
+# ---------------------------------------------------------------------------
+
+def _make_scanner() -> BigQueryScanner:
+    scanner = BigQueryScanner(project_id="test-project", use_adc=True)
+    scanner._client = MagicMock(spec=bigquery.Client)
+    scanner._client.list_routines.return_value = []
+    return scanner
+
+
+def _make_dataset_list_item(dataset_id: str):
+    item = MagicMock(spec=bigquery.dataset.DatasetListItem)
+    item.dataset_id = dataset_id
+    return item
+
+
+def _make_schema_field(name: str, field_type: str = "STRING", mode: str = "NULLABLE"):
+    sf = MagicMock(spec=bigquery.SchemaField)
+    sf.name = name
+    sf.field_type = field_type
+    sf.mode = mode
+    sf.fields = []
+    return sf
+
+
+def _make_view(dataset_id: str, table_id: str, view_query: str):
+    tbl = MagicMock(spec=bigquery.Table)
+    tbl.table_id = table_id
+    tbl.dataset_id = dataset_id
+    tbl.table_type = "VIEW"
+    tbl.num_rows = 0
+    tbl.num_bytes = 0
+    tbl.schema = [_make_schema_field("id", "INT64", "NULLABLE")]
+    tbl.time_partitioning = None
+    tbl.range_partitioning = None
+    tbl.clustering_fields = None
+    tbl.view_query = view_query
+    tbl.mview_query = None
+    tbl.modified = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    return tbl
+
+
+def _make_table_list_item(dataset_id: str, table_id: str):
+    item = MagicMock(spec=bigquery.table.TableListItem)
+    item.dataset_id = dataset_id
+    item.table_id = table_id
+    item.reference = MagicMock(spec=bigquery.TableReference)
+    return item
+
+
+def _make_routine_list_item(dataset_id: str, routine_id: str):
+    item = MagicMock()
+    item.routine_id = routine_id
+    item.dataset_id = dataset_id
+    item.reference = MagicMock()
+    return item
+
+
+def _make_full_routine(routine_id: str, *, language="JAVASCRIPT", body="return x;"):
+    r = MagicMock()
+    r.routine_id = routine_id
+    r.language = language
+    arg = MagicMock()
+    arg.name = "x"
+    r.arguments = [arg]
+    r.body = body
+    r.type_ = "SCALAR_FUNCTION"
+    r.modified = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Routine scanning (R3.3)
+# ---------------------------------------------------------------------------
+
+
+class TestRoutineScanning:
+    def test_routine_yielded_as_rebuilt_entity(self):
+        scanner = _make_scanner()
+        client = scanner._client
+        client.list_datasets.return_value = [_make_dataset_list_item("udfs")]
+        client.list_tables.return_value = []
+        rli = _make_routine_list_item("udfs", "to_upper")
+        client.list_routines.return_value = [rli]
+        client.get_routine.return_value = _make_full_routine("to_upper")
+
+        results = list(scanner.scan())
+
+        assert len(results) == 1
+        e = results[0]
+        assert e.entity_type is EntityType.ROUTINE
+        assert e.population is EntityPopulation.REBUILT
+        assert e.routine is not None
+        assert e.routine.language == "JAVASCRIPT"
+        assert e.routine.arguments == ["x"]
+        assert e.full_name == "udfs.to_upper"
+        assert scanner.failures == []
+
+    @patch("bq_assess.core.scanner.time.sleep")
+    def test_routine_failure_recorded_and_skipped(self, _sleep):
+        """A routine that fails to fetch is recorded and does not abort the scan (R23.2)."""
+        scanner = _make_scanner()
+        client = scanner._client
+        client.list_datasets.return_value = [_make_dataset_list_item("udfs")]
+        client.list_tables.return_value = []
+
+        good = _make_routine_list_item("udfs", "good_fn")
+        bad = _make_routine_list_item("udfs", "bad_fn")
+        client.list_routines.return_value = [bad, good]
+
+        err = GoogleAPICallError("boom")
+        err.code = 400
+
+        def get_routine(ref):
+            if ref is bad.reference:
+                raise err
+            return _make_full_routine("good_fn")
+
+        client.get_routine.side_effect = get_routine
+
+        results = list(scanner.scan())
+
+        assert {e.entity_id for e in results} == {"good_fn"}
+        assert len(scanner.failures) == 1
+        assert scanner.failures[0].entity_name == "udfs.bad_fn"
+        assert scanner.failures[0].stage == "scan"
+
+
+# ---------------------------------------------------------------------------
+# Dataset-level resilience (R23.2)
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetLevelFailures:
+    @patch("bq_assess.core.scanner.time.sleep")
+    def test_list_tables_failure_recorded_and_continues(self, _sleep):
+        """If list_tables fails for a dataset, record it and continue to the next dataset."""
+        scanner = _make_scanner()
+        client = scanner._client
+        client.list_datasets.return_value = [
+            _make_dataset_list_item("bad_ds"),
+            _make_dataset_list_item("good_ds"),
+        ]
+
+        good_item = _make_table_list_item("good_ds", "t1")
+        err = GoogleAPICallError("dataset boom")
+        err.code = 400
+
+        def list_tables(ds):
+            if ds == "bad_ds":
+                raise err
+            return [good_item]
+
+        client.list_tables.side_effect = list_tables
+
+        good_table = MagicMock(spec=bigquery.Table)
+        good_table.table_id = "t1"
+        good_table.dataset_id = "good_ds"
+        good_table.table_type = "TABLE"
+        good_table.num_rows = 1
+        good_table.num_bytes = 1
+        good_table.schema = [_make_schema_field("id", "INT64", "REQUIRED")]
+        good_table.time_partitioning = None
+        good_table.range_partitioning = None
+        good_table.clustering_fields = None
+        good_table.view_query = None
+        good_table.mview_query = None
+        good_table.modified = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        client.get_table.return_value = good_table
+
+        results = list(scanner.scan())
+
+        assert {e.entity_id for e in results} == {"t1"}
+        # bad_ds recorded as a scan failure
+        assert any(f.entity_name == "bad_ds" for f in scanner.failures)
+
+    @patch("bq_assess.core.scanner.time.sleep")
+    def test_list_routines_failure_recorded(self, _sleep):
+        """If list_routines fails for a dataset, record it and continue (R23.2)."""
+        scanner = _make_scanner()
+        client = scanner._client
+        client.list_datasets.return_value = [_make_dataset_list_item("ds")]
+        client.list_tables.return_value = []
+
+        err = GoogleAPICallError("routines boom")
+        err.code = 400
+        client.list_routines.side_effect = err
+
+        results = list(scanner.scan())
+
+        assert results == []
+        assert any("routines" in f.entity_name for f in scanner.failures)
+
+
+# ---------------------------------------------------------------------------
+# View entity at scan time (R3.2, R4.3)
+# ---------------------------------------------------------------------------
+
+
+class TestViewScanning:
+    def test_view_population_and_sql_captured(self):
+        scanner = _make_scanner()
+        client = scanner._client
+        client.list_datasets.return_value = [_make_dataset_list_item("analytics")]
+        item = _make_table_list_item("analytics", "active_users")
+        client.list_tables.return_value = [item]
+        client.get_table.return_value = _make_view(
+            "analytics", "active_users", "SELECT id FROM analytics.users WHERE active"
+        )
+
+        results = list(scanner.scan())
+
+        assert len(results) == 1
+        e = results[0]
+        assert e.entity_type is EntityType.VIEW
+        assert e.population is EntityPopulation.REBUILT
+        assert e.view_query is not None
+        # best-effort dependency extracted from the view SQL (R4.5)
+        assert "analytics.users" in e.depends_on

--- a/solution-architecture/clis/bq-assess/tests/unit/test_sql_surface.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_sql_surface.py
@@ -1,0 +1,177 @@
+"""Unit tests for SQLSurfaceAnalyzer — construct detection, anonymization, assembly (R10).
+
+The P16 (construct↔score) and P17 (anonymization) Hypothesis properties are owned by issue
+#22 (3.4). These unit tests pin #19's detection/anonymize/assemble behavior per construct
+class and the surface-attribution rules.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bq_assess.core.sql_surface import (
+    ARRAY_FN,
+    FUNCTION_DRIFT,
+    JS_UDF,
+    STRUCT_NAV,
+    UNNEST,
+    SQLSurfaceAnalyzer,
+)
+from bq_assess.models import (
+    ColumnSchema,
+    EntityMetadata,
+    EntityPopulation,
+    EntityType,
+    RoutineMetadata,
+)
+
+
+def _analyzer() -> SQLSurfaceAnalyzer:
+    return SQLSurfaceAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# Detection — one class at a time
+# ---------------------------------------------------------------------------
+
+
+class TestDetect:
+    def test_unnest(self):
+        c = _analyzer().detect("SELECT x FROM t, UNNEST(items) AS x")
+        assert [d.construct_class for d in c] == [UNNEST]
+
+    def test_array_fn_function(self):
+        c = _analyzer().detect("SELECT ARRAY_LENGTH(tags) FROM t")
+        classes = {d.construct_class for d in c}
+        # ARRAY_LENGTH is both an ARRAY_* fn and a drift name — both are legitimate signals
+        assert ARRAY_FN in classes or FUNCTION_DRIFT in classes
+
+    def test_array_constructor(self):
+        c = _analyzer().detect("SELECT ARRAY[1, 2, 3] AS a")
+        assert ARRAY_FN in {d.construct_class for d in c}
+
+    def test_function_drift(self):
+        c = _analyzer().detect("SELECT DATE_DIFF(d2, d1, DAY) FROM t")
+        assert FUNCTION_DRIFT in {d.construct_class for d in c}
+
+    def test_struct_nav(self):
+        c = _analyzer().detect("SELECT payload.user.id FROM t")
+        assert STRUCT_NAV in {d.construct_class for d in c}
+
+    def test_js_udf(self):
+        sql = "CREATE TEMP FUNCTION f(x FLOAT64) RETURNS FLOAT64 LANGUAGE js AS 'return x*2;'"
+        assert JS_UDF in {d.construct_class for d in _analyzer().detect(sql)}
+
+    def test_clean_sql_has_no_constructs(self):
+        assert _analyzer().detect("SELECT id, name FROM users WHERE active = TRUE") == []
+
+    def test_empty_sql(self):
+        assert _analyzer().detect("") == []
+
+    def test_multiple_constructs_deduped_by_class(self):
+        sql = (
+            "SELECT payload.user.id, ARRAY_LENGTH(tags) "
+            "FROM t, UNNEST(items) AS x WHERE a.b.c = 1"
+        )
+        classes = [d.construct_class for d in _analyzer().detect(sql)]
+        # each class at most once
+        assert len(classes) == len(set(classes))
+        assert UNNEST in classes
+        assert STRUCT_NAV in classes
+
+    def test_snippet_is_anonymized(self):
+        sql = "SELECT * FROM t, UNNEST(items) WHERE name = 'secret_value'"
+        c = _analyzer().detect(sql)
+        for d in c:
+            assert "secret_value" not in d.snippet
+
+
+# ---------------------------------------------------------------------------
+# Anonymization (R10.4 / R22.4)
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymize:
+    def test_string_literal_removed(self):
+        out = _analyzer().anonymize("WHERE name = 'Alice'")
+        assert "Alice" not in out
+        assert "'?'" in out
+
+    def test_numeric_literal_removed(self):
+        out = _analyzer().anonymize("WHERE age = 42")
+        assert "42" not in out
+
+    def test_identifier_with_digits_preserved(self):
+        out = _analyzer().anonymize("SELECT col1, table2.col3 FROM table2")
+        assert "col1" in out
+        assert "table2" in out
+        assert "col3" in out
+
+    def test_empty(self):
+        assert _analyzer().anonymize("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Surface assembly (R10.1, R10.2, R10.5)
+# ---------------------------------------------------------------------------
+
+
+def _entity(full_name, etype, *, view=None, mview=None, routine_body=None):
+    dataset, eid = full_name.split(".")
+    routine = None
+    if routine_body is not None:
+        routine = RoutineMetadata(
+            name=eid, language="JAVASCRIPT", arguments=["x"],
+            body=routine_body, routine_type="SCALAR_FUNCTION",
+        )
+    pop = (
+        EntityPopulation.TABLE
+        if etype in (EntityType.TABLE, EntityType.EXTERNAL)
+        else EntityPopulation.REBUILT
+    )
+    return EntityMetadata(
+        entity_id=eid, dataset_id=dataset, full_name=full_name,
+        entity_type=etype, population=pop, num_rows=0, num_bytes=0,
+        columns=[ColumnSchema(name="id", field_type="INT64", mode="NULLABLE")],
+        time_partitioning=None, range_partitioning=None, clustering_fields=None,
+        view_query=view, mview_query=mview, routine=routine, depends_on=[],
+        last_modified=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestAssemble:
+    def test_view_mview_routine_captured(self):
+        entities = [
+            _entity("d.v", EntityType.VIEW, view="SELECT a FROM d.t"),
+            _entity("d.mv", EntityType.MATERIALIZED_VIEW, mview="SELECT b FROM d.t"),
+            _entity("d.fn", EntityType.ROUTINE, routine_body="return x;"),
+            _entity("d.plain", EntityType.TABLE),  # no SQL surface
+        ]
+        surface = _analyzer().assemble(entities)
+        assert set(surface) == {"d.v", "d.mv", "d.fn"}  # plain table omitted
+        assert surface["d.v"] == ["SELECT a FROM d.t"]
+
+    def test_surface_is_anonymized(self):
+        entities = [_entity("d.v", EntityType.VIEW, view="SELECT a FROM d.t WHERE x = 'top_secret'")]
+        surface = _analyzer().assemble(entities)
+        assert "top_secret" not in surface["d.v"][0]
+
+    def test_ad_hoc_only_with_logs(self):
+        entities = [_entity("d.t", EntityType.TABLE)]
+        # No logs → no ad-hoc bucket
+        assert "__ad_hoc__" not in _analyzer().assemble(entities)
+        # With logs → ad-hoc bucket present + anonymized
+        surface = _analyzer().assemble(entities, query_log_text=["SELECT * FROM d.t WHERE id = 99"])
+        assert "__ad_hoc__" in surface
+        assert "99" not in surface["__ad_hoc__"][0]
+
+    def test_detect_for_entities_attributes_constructs(self):
+        entities = [
+            _entity("d.unnest_view", EntityType.VIEW, view="SELECT x FROM d.t, UNNEST(items) AS x"),
+            _entity("d.js_fn", EntityType.ROUTINE, routine_body="LANGUAGE js AS 'return 1;'"),
+            _entity("d.clean", EntityType.VIEW, view="SELECT id FROM d.t"),
+        ]
+        attributed = _analyzer().detect_for_entities(entities)
+        assert UNNEST in {c.construct_class for c in attributed["d.unnest_view"]}
+        assert JS_UDF in {c.construct_class for c in attributed["d.js_fn"]}
+        assert "d.clean" not in attributed  # no constructs → omitted

--- a/solution-architecture/clis/bq-assess/tests/unit/test_storage_stats.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_storage_stats.py
@@ -1,0 +1,171 @@
+"""Unit tests for storage stats — physical bytes, compression ratio fallbacks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from hypothesis import given, strategies as st
+
+from bq_assess.core.storage_stats import resolve_physical_bytes, effective_physical_bytes
+from bq_assess.engine.redshift.cost import _tiered_s3_tables_usd
+from bq_assess.engine.redshift import cost_constants as k
+from bq_assess.models import EntityMetadata, EntityPopulation, EntityType
+
+
+def test_entity_metadata_physical_bytes_default_none():
+    """physical_bytes defaults to None for backward compat."""
+    e = EntityMetadata(
+        entity_id="t1",
+        dataset_id="ds",
+        full_name="ds.t1",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=100,
+        num_bytes=1_000_000,
+        columns=[],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime.now(),
+    )
+    assert e.physical_bytes is None
+
+
+def test_entity_metadata_physical_bytes_set():
+    """physical_bytes can be explicitly set."""
+    e = EntityMetadata(
+        entity_id="t1",
+        dataset_id="ds",
+        full_name="ds.t1",
+        entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE,
+        num_rows=100,
+        num_bytes=1_000_000,
+        columns=[],
+        time_partitioning=None,
+        range_partitioning=None,
+        clustering_fields=None,
+        view_query=None,
+        mview_query=None,
+        routine=None,
+        depends_on=[],
+        last_modified=datetime.now(),
+        physical_bytes=750_000,
+    )
+    assert e.physical_bytes == 750_000
+
+
+def _make_entity(full_name, num_bytes, physical_bytes=None):
+    """Helper: minimal EntityMetadata-like object."""
+    from bq_assess.models import EntityMetadata, EntityType, EntityPopulation
+    from datetime import datetime
+    return EntityMetadata(
+        entity_id=full_name.split(".")[-1], dataset_id=full_name.split(".")[0],
+        full_name=full_name, entity_type=EntityType.TABLE,
+        population=EntityPopulation.TABLE, num_rows=100,
+        num_bytes=num_bytes, columns=[], time_partitioning=None,
+        range_partitioning=None, clustering_fields=None,
+        view_query=None, mview_query=None, routine=None,
+        depends_on=[], last_modified=datetime.now(),
+        physical_bytes=physical_bytes,
+    )
+
+
+def test_resolve_measured_path():
+    """When TABLE_STORAGE returns data, physical_map uses measured values."""
+    client = MagicMock()
+    # Simulate query result: two rows with current_physical_bytes
+    row1 = MagicMock()
+    row1.table_schema = "ds"
+    row1.table_name = "t1"
+    row1.current_physical_bytes = 500_000
+    row2 = MagicMock()
+    row2.table_schema = "ds"
+    row2.table_name = "t2"
+    row2.current_physical_bytes = 300_000
+    client.query.return_value.result.return_value = [row1, row2]
+
+    entities = [_make_entity("ds.t1", 1_000_000), _make_entity("ds.t2", 800_000)]
+    stats = resolve_physical_bytes(client, "my-project", "us", entities)
+
+    assert stats.basis == "measured"
+    assert stats.measured_count == 2
+    assert stats.assumed_count == 0
+    assert stats.physical_map == {"ds.t1": 500_000, "ds.t2": 300_000}
+    assert "TABLE_STORAGE" in stats.source_note
+    # Verify the generated SQL has WHERE clause
+    sql = client.query.call_args[0][0]
+    assert "WHERE table_schema IN" in sql
+
+
+def test_resolve_fallback_on_error():
+    """When TABLE_STORAGE query fails, fall back to 0.75 × logical."""
+    client = MagicMock()
+    client.query.side_effect = Exception("Permission denied")
+
+    entities = [_make_entity("ds.t1", 1_000_000), _make_entity("ds.t2", 800_000)]
+    stats = resolve_physical_bytes(client, "my-project", "us", entities)
+
+    assert stats.basis == "assumed"
+    assert stats.measured_count == 0
+    assert stats.assumed_count == 2
+    assert stats.physical_map == {
+        "ds.t1": round(1_000_000 * k.ASSUMED_PHYSICAL_RATIO),
+        "ds.t2": round(800_000 * k.ASSUMED_PHYSICAL_RATIO),
+    }
+    assert str(k.ASSUMED_PHYSICAL_RATIO) in stats.source_note
+
+
+def test_resolve_partial_coverage():
+    """Entities missing from TABLE_STORAGE get ratio fallback."""
+    client = MagicMock()
+    row1 = MagicMock()
+    row1.table_schema = "ds"
+    row1.table_name = "t1"
+    row1.current_physical_bytes = 500_000
+    client.query.return_value.result.return_value = [row1]
+
+    entities = [_make_entity("ds.t1", 1_000_000), _make_entity("ds.t2", 800_000)]
+    stats = resolve_physical_bytes(client, "my-project", "us", entities)
+
+    assert stats.basis == "mixed"
+    assert stats.measured_count == 1
+    assert stats.assumed_count == 1
+    assert stats.physical_map["ds.t1"] == 500_000
+    assert stats.physical_map["ds.t2"] == round(800_000 * k.ASSUMED_PHYSICAL_RATIO)
+
+
+def test_resolve_zero_bytes_entities():
+    """Views/routines with num_bytes=0 get physical_bytes=0, no ratio math."""
+    client = MagicMock()
+    client.query.side_effect = Exception("fail")
+
+    entities = [_make_entity("ds.v1", 0)]
+    stats = resolve_physical_bytes(client, "my-project", "us", entities)
+    assert stats.physical_map["ds.v1"] == 0
+
+
+def test_effective_physical_bytes():
+    """effective_physical_bytes helper uses physical when set, fallback otherwise."""
+    assert effective_physical_bytes(1000, None) == 750
+    assert effective_physical_bytes(1000, 400) == 400
+    assert effective_physical_bytes(1000, 0) == 0
+    assert effective_physical_bytes(0, None) == 0
+
+
+@given(logical_bytes=st.integers(min_value=0, max_value=10 * 10**12))
+def test_physical_storage_cost_leq_logical(logical_bytes):
+    """S3 cost on physical bytes is always ≤ cost on logical bytes (ratio ≤ 1.0)."""
+    physical_bytes = round(logical_bytes * k.ASSUMED_PHYSICAL_RATIO)
+    logical_gb = logical_bytes * k.GB_PER_BYTE
+    physical_gb = physical_bytes * k.GB_PER_BYTE
+
+    cost_logical = _tiered_s3_tables_usd(logical_gb)
+    cost_physical = _tiered_s3_tables_usd(physical_gb)
+
+    assert cost_physical <= cost_logical

--- a/solution-architecture/clis/bq-assess/tests/unit/test_translate.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_translate.py
@@ -1,0 +1,81 @@
+"""Unit tests for RewriteGuide.translate() — best-effort BQ→Redshift translation."""
+import pytest
+
+from bq_assess.engine.redshift.rewrite import RewriteGuide
+
+
+@pytest.fixture
+def guide():
+    return RewriteGuide()
+
+
+class TestTranslateBasic:
+    def test_date_diff(self, guide):
+        result = guide.translate("SELECT DATE_DIFF(a, b, DAY) FROM t")
+        assert "DATEDIFF" in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+    def test_safe_cast(self, guide):
+        result = guide.translate("SELECT SAFE_CAST(x AS INT64) FROM t")
+        assert "TRY_CAST" in result.redshift_sql
+        assert "BIGINT" in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+    def test_if_to_case(self, guide):
+        result = guide.translate("SELECT IF(a > 1, a, b) FROM t")
+        assert "CASE WHEN" in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+    def test_backticks_to_double_quotes(self, guide):
+        result = guide.translate("SELECT * FROM `project.dataset.table`")
+        assert "`" not in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+    def test_int64_to_bigint(self, guide):
+        result = guide.translate("SELECT CAST(x AS INT64) FROM t")
+        assert "BIGINT" in result.redshift_sql
+
+    def test_format_date(self, guide):
+        result = guide.translate("SELECT FORMAT_DATE('%Y-%m', dt) FROM t")
+        assert "TO_CHAR" in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+
+class TestTranslateEdgeCases:
+    def test_empty_sql(self, guide):
+        result = guide.translate("")
+        assert result.confidence == "LOW"
+        assert result.warnings
+
+    def test_whitespace_only(self, guide):
+        result = guide.translate("   \n  ")
+        assert result.confidence == "LOW"
+
+    def test_none_sql(self, guide):
+        result = guide.translate(None)
+        assert result.confidence == "LOW"
+
+    def test_js_udf_detected(self, guide):
+        sql = "CREATE FUNCTION fn(x STRING) RETURNS STRING LANGUAGE js AS 'return x;'"
+        result = guide.translate(sql)
+        assert result.confidence == "LOW"
+        assert any("Lambda UDF" in w for w in result.warnings)
+
+    def test_unparseable_sql(self, guide):
+        result = guide.translate("THIS IS NOT VALID SQL @@@ !!!")
+        assert result.confidence == "LOW"
+        assert "TRANSLATION FAILED" in result.redshift_sql
+
+
+class TestTranslateComplex:
+    def test_qualify_passes_through(self, guide):
+        sql = "SELECT x FROM t QUALIFY ROW_NUMBER() OVER (ORDER BY x) = 1"
+        result = guide.translate(sql)
+        assert "QUALIFY" in result.redshift_sql
+        assert result.confidence == "HIGH"
+
+    def test_multi_statement(self, guide):
+        sql = "SELECT 1; SELECT 2"
+        result = guide.translate(sql)
+        assert ";" in result.redshift_sql
+        assert result.confidence == "HIGH"

--- a/solution-architecture/clis/bq-assess/tests/unit/test_workload.py
+++ b/solution-architecture/clis/bq-assess/tests/unit/test_workload.py
@@ -1,0 +1,590 @@
+# Feature: bq-assess-lakehouse, issue 5.2: WorkloadAnalyzer (R17)
+"""Unit tests for the Workload Analyzer (slot-time utilization curve).
+
+Drives ``WorkloadAnalyzer.analyze_from_api`` / ``analyze_from_file`` (R17): extract
+``total_slot_ms`` / ``total_bytes_processed`` / ``creation_time`` over the lookback window,
+compute the avg/P50/P99/peak slot curve + active-hour fraction, and return ``None`` (never a
+zero-struct, never raise) when there is no usable workload — the ``None`` that trips the
+LOW-confidence cost range downstream (R18.4).
+
+Locked metric decisions (see SCRUM_NOTES § Issue 5.2):
+- days_sampled = distinct UTC dates with a slot-bearing job
+- avg_slots = total_slot_ms / (days_sampled * 86_400_000)
+- per-hour slot series over [first, last] active hour with idle zero-fill → P50/P99/peak
+- active_hour_fraction = busy_hours / (days_sampled * 24), clamped [0, 1]
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from google.api_core.exceptions import Forbidden
+
+from bq_assess.core.workload import WorkloadAnalyzer
+from bq_assess.models import SlotUtilization
+
+
+class _FakeQueryJob:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def result(self):
+        return iter(self._rows)
+
+
+class _FakeClient:
+    """BigQuery client double: returns canned JOBS rows, or raises *query_error*."""
+
+    def __init__(self, *, rows: list[dict] | None = None, query_error: Exception | None = None) -> None:
+        self._rows = rows if rows is not None else []
+        self._query_error = query_error
+        self.queries: list[str] = []
+
+    def query(self, sql: str, *args, **kwargs) -> _FakeQueryJob:
+        self.queries.append(sql)
+        if self._query_error is not None:
+            raise self._query_error
+        return _FakeQueryJob(self._rows)
+
+
+def _job(*, slot_ms=3_600_000, bytes_=10**9, creation_time=None):
+    """Build one JOBS row dict for a deterministic unit test."""
+    return {
+        "total_slot_ms": slot_ms,
+        "total_bytes_processed": bytes_,
+        "creation_time": creation_time or datetime(2025, 6, 1, 10, tzinfo=timezone.utc),
+    }
+
+
+def _analyze(rows, *, days=30, location="US"):
+    slots, _raw = WorkloadAnalyzer().analyze_from_api(_FakeClient(rows=rows), "proj", days=days, location=location)
+    return slots
+
+
+# --- No-data contract (load-bearing: feeds R18.4 cost range) --------------------------
+
+def test_empty_jobs_returns_none() -> None:
+    """No jobs → None (not a zero-struct, no raise). This None trips the cost range (R18.4)."""
+    assert _analyze([]) is None
+
+
+# --- Core metric computation ----------------------------------------------------------
+
+def test_single_job_one_bucket_curve() -> None:
+    """One job of exactly one slot-hour in a single UTC hour → unit curve, 1 day sampled."""
+    result = _analyze([_job(slot_ms=3_600_000)])
+
+    assert isinstance(result, SlotUtilization)
+    assert result.total_slot_ms == 3_600_000          # verbatim sum
+    assert result.days_sampled == 1
+    # One bucket carrying one slot-hour ⇒ concurrency 1.0 everywhere on the curve.
+    assert result.p50_slots == 1.0
+    assert result.p99_slots == 1.0
+    assert result.peak_slots == 1.0
+
+
+def test_total_slot_ms_is_verbatim_sum() -> None:
+    """total_slot_ms is the plain integer sum — no conversion."""
+    jobs = [_job(slot_ms=10), _job(slot_ms=20), _job(slot_ms=30)]
+    assert _analyze(jobs).total_slot_ms == 60
+
+
+_HOUR = 3_600_000
+
+
+def _at(day, hour):
+    return datetime(2025, 6, day, hour, tzinfo=timezone.utc)
+
+
+def test_all_curve_metrics_present_and_typed() -> None:
+    """avg/p50/p99/peak/fraction are floats; total_slot_ms/days_sampled are ints (R17.2)."""
+    r = _analyze([_job(creation_time=_at(1, 10)), _job(creation_time=_at(1, 11))])
+    for v in (r.avg_slots, r.p50_slots, r.p99_slots, r.peak_slots, r.active_hour_fraction):
+        assert isinstance(v, float)
+    assert isinstance(r.total_slot_ms, int)
+    assert isinstance(r.days_sampled, int)
+
+
+def test_curve_ordering_invariant() -> None:
+    """p50 <= p99 <= peak holds (P21). avg is NOT constrained — bursty loads break avg<=p50."""
+    jobs = [
+        _job(slot_ms=1 * _HOUR, creation_time=_at(1, 0)),
+        _job(slot_ms=5 * _HOUR, creation_time=_at(1, 1)),
+        _job(slot_ms=9 * _HOUR, creation_time=_at(1, 2)),
+    ]
+    r = _analyze(jobs)
+    assert r.p50_slots <= r.p99_slots <= r.peak_slots
+
+
+def test_active_hour_fraction_in_unit_interval() -> None:
+    """active_hour_fraction is bounded [0,1] (P21) and low for a clustered workload."""
+    # One busy hour, but jobs land on 3 distinct dates → days_sampled=3 → 72 nominal hours.
+    jobs = [
+        _job(creation_time=_at(1, 9)),
+        _job(creation_time=_at(2, 9)),
+        _job(creation_time=_at(3, 9)),
+    ]
+    r = _analyze(jobs)
+    assert 0.0 <= r.active_hour_fraction <= 1.0
+    assert r.days_sampled == 3
+    # 3 busy hours / (3 days * 24h) = 3/72.
+    assert r.active_hour_fraction == 3 / 72
+
+
+def test_all_zero_slot_ms_yields_zero_curve_not_none() -> None:
+    """Jobs present but every slot_ms==0 → zero curve, NOT None (jobs existed)."""
+    jobs = [_job(slot_ms=0, creation_time=_at(1, 10)), _job(slot_ms=0, creation_time=_at(1, 11))]
+    r = _analyze(jobs)
+    assert r is not None
+    assert r.avg_slots == 0.0
+    assert r.peak_slots == 0.0
+    assert r.active_hour_fraction == 0.0       # busy = slot_ms>0, so no busy hours
+
+
+def test_clustered_load_peak_exceeds_avg_and_p50_is_low() -> None:
+    """A spike in one hour across a multi-day window: peak >> avg, and idle zero-fill → P50≈0.
+    This is the over-provisioning signal the cost step reads (D1a/D1c)."""
+    # 10 slot-hours all in a single hour on day 1; nothing else, but window spans to day 3.
+    jobs = [_job(slot_ms=10 * 3_600_000, creation_time=_at(1, 9)),
+            _job(slot_ms=0, creation_time=_at(3, 9))]
+    r = _analyze(jobs)
+    assert r.peak_slots == 10.0
+    assert r.peak_slots > r.avg_slots          # spike dwarfs the day-normalized average
+    assert r.p50_slots == 0.0                  # most hours in the span are idle (zero-fill)
+
+
+# --- API read: SQL shape + graceful degradation (R17.1, R17.3) ------------------------
+
+def test_api_sql_pulls_fields_over_lookback() -> None:
+    """The api query selects the slot fields it consumes from the whole-project view over
+    `days`, excluding SCRIPT parents (R17.1; project/region-qualified, location matches pricing)."""
+    client = _FakeClient(rows=[_job()])
+    WorkloadAnalyzer().analyze_from_api(client, "proj", days=30, location="EU")
+    sql = client.queries[0]
+    assert "total_slot_ms" in sql
+    assert "creation_time" in sql
+    # Whole-project view (not the per-user JOBS alias), project- and region-qualified.
+    assert "`proj`.`region-eu`.INFORMATION_SCHEMA.JOBS_BY_PROJECT" in sql
+    assert "INTERVAL 30 DAY" in sql
+    assert "statement_type != 'SCRIPT'" in sql
+
+
+def test_missing_jobs_listall_returns_none_no_raise() -> None:
+    """Missing bigquery.jobs.listAll (Forbidden) → (None, []), never raises (R17.3 degradation).
+    The descriptive permission message is the CLI's job (R17.3 names THE CLI)."""
+    client = _FakeClient(query_error=Forbidden("403 Access Denied: bigquery.jobs.listAll"))
+    slots, raw = WorkloadAnalyzer().analyze_from_api(client, "proj")
+    assert slots is None
+    assert raw == []
+
+
+def test_rows_with_null_creation_time_are_skipped() -> None:
+    """A row whose creation_time is NULL can't be bucketed → skipped; null slot_ms → 0."""
+    jobs = [
+        {"total_slot_ms": None, "total_bytes_processed": 0, "creation_time": _at(1, 10)},
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 0, "creation_time": None},
+    ]
+    r = _analyze(jobs)
+    # Only the first row is usable (second has no timestamp); its null slot_ms coerces to 0.
+    assert r is not None
+    assert r.total_slot_ms == 0
+
+
+# --- File path: analyze_from_file (R1.3 --query-logs, R17.4) --------------------------
+
+import json  # noqa: E402
+
+
+def _write(tmp_path, obj):
+    p = tmp_path / "jobs.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def test_file_missing_returns_none(tmp_path) -> None:
+    """A nonexistent path → (None, []) (no raise; diverges from analyzer.py per the | None contract)."""
+    slots, raw = WorkloadAnalyzer().analyze_from_file(tmp_path / "nope.json")
+    assert slots is None
+    assert raw == []
+
+
+def test_file_malformed_or_unusable_object_returns_none(tmp_path) -> None:
+    """Invalid JSON → (None, []). A bare JSON object is accepted as a one-entry log
+    (2026-07-08: a single-line JSONL export parses as a bare dict) but still yields
+    (None, []) when the entry carries no usable timestamp."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    slots, raw = WorkloadAnalyzer().analyze_from_file(bad)
+    assert slots is None
+    assert raw == []
+    slots2, raw2 = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, {"a": 1}))
+    assert slots2 is None
+    assert raw2 == []
+
+
+def test_file_bare_object_with_valid_bucket_is_accepted(tmp_path) -> None:
+    """A single-line jobs_hourly.jsonl export parses as a bare JSON object — it must be
+    treated as a one-entry log, not rejected as an invalid format (2026-07-08 fix; the
+    exporter round-trip depends on it)."""
+    entry = {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR,
+             "job_count": 2, "total_bytes_processed": 10**9, "total_bytes_billed": 10**9}
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entry))
+    assert slots is not None
+    assert slots.total_queries == 2
+    assert len(raw) == 1
+
+
+def test_file_empty_array_returns_none(tmp_path) -> None:
+    """An empty array → no usable jobs → (None, [])."""
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, []))
+    assert slots is None
+    assert raw == []
+
+
+def test_file_all_unusable_entries_returns_none(tmp_path) -> None:
+    """A non-empty array whose entries all lack a usable creation_time → (None, [])."""
+    entries = [{"total_slot_ms": 100, "creation_time": "not-a-date"},
+               {"total_slot_ms": 200}]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is None
+    assert raw == []
+
+
+def test_file_and_api_parity(tmp_path) -> None:
+    """The same logical jobs via file and api produce field-identical SlotUtilization —
+    one shared normalizer behind both paths, including the billed-basis rule."""
+    times = [_at(1, 9), _at(1, 10), _at(2, 9)]
+    api_rows = [
+        {**_job(slot_ms=_HOUR, creation_time=t), "total_bytes_billed": 0} for t in times
+    ]
+    file_entries = [
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9, "total_bytes_billed": 0,
+         "creation_time": t.isoformat()}
+        for t in times
+    ]
+    api_result = _analyze(api_rows)
+    file_result, _raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, file_entries))
+    assert file_result == api_result
+
+
+def test_api_per_job_rows_without_billed_key_degrade(tmp_path) -> None:
+    """Per-job shaped API rows lacking the billed column degrade the window — the same
+    'absent means unavailable' rule as file entries, NOT a hardcoded billed basis
+    (2026-07-08 review: the old hardcoded True zeroed the scan estimate for NULL-billed
+    jobs). Same rows WITH billed keep the basis."""
+    without = _analyze([_job(slot_ms=_HOUR)])
+    assert without is not None
+    assert without.has_billed_bytes is False
+    with_billed = _analyze([{**_job(slot_ms=_HOUR), "total_bytes_billed": 5 * 10**8}])
+    assert with_billed is not None
+    assert with_billed.has_billed_bytes is True
+    assert with_billed.total_bytes_billed == 5 * 10**8
+
+
+def test_file_naive_and_aware_timestamps_bucket_together(tmp_path) -> None:
+    """A naive timestamp is treated as UTC (D3), bucketing with its explicit +00:00 twin."""
+    entries = [
+        {"total_slot_ms": _HOUR, "creation_time": "2025-06-01T10:00:00"},        # naive
+        {"total_slot_ms": _HOUR, "creation_time": "2025-06-01T10:30:00+00:00"},  # aware, same hr
+    ]
+    r, _raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    # Both land in the single 10:00 UTC bucket → 2 slot-hours in one hour → peak 2.0.
+    assert r is not None
+    assert r.peak_slots == 2.0
+
+
+def test_file_zulu_suffix_timestamps_parse(tmp_path) -> None:
+    """BigQuery exports stamp creation_time with a trailing 'Z' — must parse on py3.9+ (review #3)."""
+    entries = [
+        {"total_slot_ms": _HOUR, "creation_time": "2025-06-01T10:00:00Z"},
+        {"total_slot_ms": _HOUR, "creation_time": "2025-06-01T10:30:00.123456Z"},
+    ]
+    r, _raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert r is not None                       # NOT silently dropped → None
+    assert r.peak_slots == 2.0                 # both land in the same UTC hour bucket
+
+
+def test_file_non_numeric_slot_ms_does_not_raise(tmp_path) -> None:
+    """A non-numeric total_slot_ms degrades to 0, never raises (review #8)."""
+    entries = [
+        {"total_slot_ms": "not-a-number", "creation_time": "2025-06-01T10:00:00Z"},
+        {"total_slot_ms": -500, "creation_time": "2025-06-01T11:00:00Z"},   # negative clamps to 0
+    ]
+    r, _raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert r is not None
+    assert r.total_slot_ms == 0                # garbage → 0, negative → 0
+
+
+def test_file_query_text_is_anonymized(tmp_path) -> None:
+    """R17.4/R22.4: a `query` field in the export is anonymized (literals stripped) — reuses
+    QueryAnalyzer.anonymize_query rather than re-implementing the regex."""
+    analyzer = WorkloadAnalyzer()
+    raw = "SELECT * FROM t WHERE name = 'secret' AND n = 42"
+    cleaned = analyzer.anonymize_query(raw)
+    assert "secret" not in cleaned
+    assert "42" not in cleaned
+    assert "'?'" in cleaned
+
+
+def test_mixed_export_degrades_to_processed_fallback(tmp_path) -> None:
+    """One new-format job in a legacy export must NOT flip the window to the billed basis
+    (that would silently drop every legacy job's scan volume) — all-or-nothing."""
+    entries = [
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**12,
+         "creation_time": _at(1, 9).isoformat()},                      # legacy: no billed
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 0, "creation_time": _at(1, 10).isoformat()},  # new format
+    ]
+    slots, _ = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.has_billed_bytes is False
+
+
+def test_all_carrying_export_keeps_billed_basis(tmp_path) -> None:
+    entries = [
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 0, "creation_time": _at(1, 9).isoformat()},
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 2 * 10**9, "creation_time": _at(1, 10).isoformat()},
+    ]
+    slots, _ = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.has_billed_bytes is True
+    assert slots.total_bytes_billed == 2 * 10**9
+
+
+# --- Hourly aggregation (2026-07-08 storm audit: 10 PB-scale OOM fix) ------------------
+
+def test_api_reads_hourly_aggregates() -> None:
+    """The live path GROUPs BY hour server-side — bounded rows regardless of query volume."""
+    client = _FakeClient(rows=[])
+    WorkloadAnalyzer().analyze_from_api(client, "proj", days=30, location="US")
+    sql = client.queries[0]
+    assert "TIMESTAMP_TRUNC(creation_time, HOUR)" in sql
+    assert "GROUP BY hour_bucket" in sql
+    assert "SUM(total_slot_ms)" in sql
+    assert "COUNTIF(total_bytes_billed IS NULL)" in sql
+    # user_email must NOT cross the wire on the aggregated path.
+    assert "user_email" not in sql
+
+
+def test_hourly_rows_produce_same_curve_as_per_job_rows() -> None:
+    """Equivalence: pre-aggregated hourly rows yield the same SlotUtilization as the
+    per-job rows they summarize — aggregation is output-identical, the audit's key claim."""
+    t0 = datetime(2025, 6, 2, 9, tzinfo=timezone.utc)
+    per_job = [
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 2 * 10**9, "creation_time": t0},
+        {"total_slot_ms": 2 * _HOUR, "total_bytes_processed": 3 * 10**9,
+         "total_bytes_billed": 10**9, "creation_time": t0.replace(minute=30)},
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 10**9, "creation_time": t0.replace(hour=14)},
+    ]
+    hourly = [
+        {"hour_bucket": t0, "total_slot_ms": 3 * _HOUR, "job_count": 2,
+         "total_bytes_processed": 4 * 10**9, "total_bytes_billed": 3 * 10**9,
+         "missing_billed_jobs": 0},
+        {"hour_bucket": t0.replace(hour=14), "total_slot_ms": _HOUR, "job_count": 1,
+         "total_bytes_processed": 10**9, "total_bytes_billed": 10**9,
+         "missing_billed_jobs": 0},
+    ]
+    from_jobs, _ = WorkloadAnalyzer().analyze_from_api(_FakeClient(rows=per_job), "proj")
+    from_hourly, _ = WorkloadAnalyzer().analyze_from_api(_FakeClient(rows=hourly), "proj")
+    assert from_jobs == from_hourly
+
+
+def test_hourly_bucket_with_missing_billed_degrades_window() -> None:
+    """missing_billed_jobs > 0 in ANY bucket flips the window off the billed basis —
+    same all-or-nothing rule as the per-job fold."""
+    rows = [
+        {"hour_bucket": datetime(2025, 6, 2, 9, tzinfo=timezone.utc),
+         "total_slot_ms": _HOUR, "job_count": 5, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 10**9, "missing_billed_jobs": 0},
+        {"hour_bucket": datetime(2025, 6, 2, 10, tzinfo=timezone.utc),
+         "total_slot_ms": _HOUR, "job_count": 5, "total_bytes_processed": 10**9,
+         "total_bytes_billed": 10**9, "missing_billed_jobs": 2},
+    ]
+    slots, _ = WorkloadAnalyzer().analyze_from_api(_FakeClient(rows=rows), "proj")
+    assert slots is not None
+    assert slots.has_billed_bytes is False
+    assert slots.total_queries == 10
+
+
+def test_file_accepts_hourly_aggregate_format(tmp_path) -> None:
+    """analyze_from_file consumes the exporter's hourly format (hour_bucket key)."""
+    entries = [
+        {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": 2 * _HOUR,
+         "job_count": 3, "total_bytes_processed": 10**9, "total_bytes_billed": 10**9},
+        {"hour_bucket": "2025-06-02T11:00:00Z", "total_slot_ms": _HOUR,
+         "job_count": 1, "total_bytes_processed": 10**9, "total_bytes_billed": 0},
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_queries == 4
+    assert slots.total_slot_ms == 3 * _HOUR
+    assert slots.has_billed_bytes is True      # both entries carry the billed key
+    assert slots.peak_slots == 2.0
+    assert len(raw) == 2
+
+
+def test_file_mixed_hourly_and_per_job_entries_merge(tmp_path) -> None:
+    """A concatenated export (hourly + legacy per-job) merges into one window."""
+    entries = [
+        {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR,
+         "job_count": 2, "total_bytes_processed": 10**9, "total_bytes_billed": 10**9},
+        {"total_slot_ms": _HOUR, "total_bytes_processed": 10**9,
+         "creation_time": "2025-06-02T09:30:00Z"},   # legacy, same hour, no billed key
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_queries == 3
+    assert slots.total_slot_ms == 2 * _HOUR
+    assert slots.has_billed_bytes is False     # legacy entry lacks billed → window degrades
+    assert len(raw) == 1                        # merged into one bucket
+
+
+# --- 2026-07-08 review fixes (hourly-aggregation merge) ---------------------------------
+
+def test_file_null_hour_bucket_falls_back_to_creation_time(tmp_path) -> None:
+    """An entry with hour_bucket=null but a valid creation_time is consumed via the
+    per-job branch, not dropped (review: key-presence dispatch lost whole workloads
+    from producers emitting both columns)."""
+    entries = [
+        {"hour_bucket": None, "creation_time": "2025-06-02T09:30:00Z",
+         "total_slot_ms": _HOUR, "total_bytes_processed": 10**9},
+        {"hour_bucket": None, "creation_time": "2025-06-02T10:30:00Z",
+         "total_slot_ms": _HOUR, "total_bytes_processed": 10**9},
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_queries == 2
+    assert slots.total_slot_ms == 2 * _HOUR
+
+
+def test_partial_billed_bucket_keeps_sum_and_degrades(tmp_path) -> None:
+    """A bucket with a partial billed sum (missing_billed_jobs > 0 but < job_count)
+    keeps the sum in the window total while degrading the basis — and the count
+    round-trips through the exporter (review: dropping the value flipped the cost
+    basis between a live run and its re-imported export)."""
+    entries = [
+        {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR, "job_count": 10,
+         "total_bytes_processed": 10**12, "total_bytes_billed": 8 * 10**11,
+         "missing_billed_jobs": 2},
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.has_billed_bytes is False           # degraded basis
+    assert slots.total_bytes_billed == 8 * 10**11    # partial sum preserved
+    assert raw[0]["missing_billed_jobs"] == 2
+
+
+def test_per_job_null_billed_is_unavailable_not_zero() -> None:
+    """The per-job billed rule (_per_job_fields): an explicit NULL billed value means
+    'unavailable' and degrades the window, while a genuine 0 from a carrying source
+    keeps the billed basis (review: NULL must never launder into $0 billed)."""
+    t = datetime(2025, 6, 2, 9, 30, tzinfo=timezone.utc)
+    null_billed = _analyze([{"total_slot_ms": _HOUR, "creation_time": t,
+                             "total_bytes_processed": 10**9, "total_bytes_billed": None}])
+    assert null_billed is not None
+    assert null_billed.has_billed_bytes is False    # NULL → unavailable
+    genuine_zero = _analyze([{"total_slot_ms": _HOUR, "creation_time": t,
+                              "total_bytes_processed": 10**9, "total_bytes_billed": 0}])
+    assert genuine_zero is not None
+    assert genuine_zero.has_billed_bytes is True    # genuine 0 → carrying
+
+
+def test_garbage_missing_billed_count_degrades_not_promotes(tmp_path) -> None:
+    """A corrupt missing_billed_jobs (negative / non-numeric) is a broken signal about
+    missing billed data — it must degrade the window (fail toward the processed
+    overestimate), never assert a billed-carrying basis (2026-07-08 review: _safe_int's
+    clamp-to-0 promoted garbage to has_billed_bytes=True with billed=0, which cost.py
+    reads as a genuine $0 scan month)."""
+    for garbage in (-2, "not-a-number"):
+        entries = [
+            {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR,
+             "job_count": 10, "total_bytes_processed": 10**9,
+             "total_bytes_billed": 0, "missing_billed_jobs": garbage},
+        ]
+        slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+        assert slots is not None
+        assert slots.has_billed_bytes is False, f"garbage={garbage!r} must degrade"
+        assert raw[0]["missing_billed_jobs"] == 10
+
+
+def test_corrupt_far_future_timestamp_is_dropped_not_series_inflating(tmp_path) -> None:
+    """A parseable-but-corrupt timestamp (year 9999) must be DROPPED, not zero-fill the
+    hourly series across ~70M idle hours — the OOM class the hourly aggregation was
+    built to remove (2026-07-08 storm assess, MRI-4). The real workload survives."""
+    entries = [
+        {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR, "job_count": 1,
+         "total_bytes_processed": 10**9},
+        {"hour_bucket": "2025-06-02T10:00:00Z", "total_slot_ms": _HOUR, "job_count": 1,
+         "total_bytes_processed": 10**9},
+        {"hour_bucket": "9999-01-01T00:00:00Z", "total_slot_ms": 1, "job_count": 1,
+         "total_bytes_processed": 1},
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_queries == 2                 # outlier's stats excluded entirely
+    assert slots.total_slot_ms == 2 * _HOUR
+    assert len(raw) == 2
+    # Epoch-adjacent outlier drops the same way (outlier on the other side of median).
+    entries[2] = {"hour_bucket": "1970-01-01T00:00:00Z", "total_slot_ms": 1,
+                  "job_count": 1, "total_bytes_processed": 1}
+    slots2, raw2 = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots2 is not None
+    assert slots2.total_queries == 2
+    assert len(raw2) == 2
+
+
+def test_single_entry_workload_is_never_dropped_as_outlier(tmp_path) -> None:
+    """The outlier guard is relative to the median — a one-entry workload has no peers
+    to be an outlier against and must pass through untouched."""
+    entries = [{"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": _HOUR,
+                "job_count": 3, "total_bytes_processed": 10**9}]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_queries == 3
+    assert len(raw) == 1
+
+
+def test_float_formatted_numeric_strings_are_parsed_not_zeroed(tmp_path) -> None:
+    """Float-formatted numeric strings ("3600000.0", "1e6") from spreadsheet-mediated
+    exports must parse, not silently zero the compute curve — the underestimate
+    direction the module forbids (2026-07-08 storm assess, MRI-5). True garbage still
+    coerces to 0."""
+    from bq_assess.core.workload import _safe_int
+
+    entries = [
+        {"hour_bucket": "2025-06-02T09:00:00Z", "total_slot_ms": "3600000.0",
+         "job_count": "2.0", "total_bytes_processed": "1e9"},
+    ]
+    slots, raw = WorkloadAnalyzer().analyze_from_file(_write(tmp_path, entries))
+    assert slots is not None
+    assert slots.total_slot_ms == _HOUR
+    assert slots.total_queries == 2
+    assert slots.total_bytes_processed == 10**9
+    assert _safe_int("not-a-number") == 0
+    assert _safe_int(float("inf")) == 0
+    assert _safe_int(float("nan")) == 0
+
+
+def test_merge_preserves_degraded_legacy_bucket() -> None:
+    """_merge_buckets must not un-degrade a legacy-shaped bucket (has_billed_bytes=False,
+    no missing_billed_jobs key) when merging — the count is derived from the flag, not
+    defaulted to 0 (2026-07-08 review: the 0-default silently flipped merged degraded
+    buckets to billed-carrying)."""
+    from bq_assess.core.workload import _merge_buckets
+
+    hour = datetime(2025, 6, 2, 9, tzinfo=timezone.utc)
+    legacy_degraded = {"hour_bucket": hour, "total_slot_ms": _HOUR, "job_count": 2,
+                       "total_bytes_processed": 10**9, "total_bytes_billed": 0,
+                       "has_billed_bytes": False}   # pre-2026-07-08 shape: no count
+    clean = {"hour_bucket": hour, "total_slot_ms": _HOUR, "job_count": 3,
+             "total_bytes_processed": 10**9, "total_bytes_billed": 10**9,
+             "missing_billed_jobs": 0, "has_billed_bytes": True}
+    for ordering in ([legacy_degraded, clean], [clean, legacy_degraded]):
+        merged = _merge_buckets(list(ordering))
+        assert len(merged) == 1
+        assert merged[0]["has_billed_bytes"] is False, f"order={ordering[0]['job_count']}"
+        assert merged[0]["missing_billed_jobs"] == 2


### PR DESCRIPTION
## Problem

Startups and enterprises increasingly want to move analytics workloads off **Google BigQuery** to an **AWS lakehouse** — but before they'll commit, they need to know two things: **how much it will cost** and **how much work it will be**. Today there's no AWS-native way to answer either up front.

AWS SCT supports BigQuery as a source, but it **can't convert the nested constructs** (STRUCT, ARRAY, UNNEST) that modern BigQuery warehouses are built on, and it **produces no cost comparison** — the single most important input to a customer's decision. That leaves AWS teams reliant on partner accelerators or weeks of manual, per-table analysis across environments that routinely hold tens of thousands of tables. The result: slow, inconsistent assessments that stall deals at the qualification stage.

## Solution

**bq-assess** closes that gap. A read-only scan of a customer's BigQuery environment produces a per-table migration plan scored on two independent axes — **Migration Effort** (moving the data) and **Query Complexity** (rewriting the SQL) — plus generated Iceberg DDL and a directional cost comparison. It turns a multi-week manual effort into a minutes-long, reproducible assessment, giving customers a credible plan and AWS teams a data-backed starting point for the migration conversation.

Ships under a new `solution-architecture/clis/` subfolder as a full Python CLI plus a guided Claude Code skill. The scan needs only `roles/bigquery.metadataViewer` (reads no table data), targets S3 Tables (Apache Iceberg) storage with Amazon Redshift compute, and requires no AWS account to run. It assesses only; it does not execute the migration. Two run modes: direct (`bq-assess`), or collect-then-report (`bq-collect` writes a reviewable plain-JSON bundle; `bq-assess report` renders it offline anywhere).

### What's included

- `solution-architecture/clis/bq-assess/` — the tool
  - `src/`, `tests/` (479 unit + property-based tests), `pyproject.toml`, `LICENSE` (Apache-2.0)
  - `skills/bq-assess/` — Claude Code skill (preflight → scan → interpret state machine)
  - `.claude-plugin/plugin.json`, `README.md`, `PRIVACY.md`
  - `docs/` — CLI reference, complexity scoring guide, 4 ADRs
  - `bandit.yml` — plugin-scoped skips (B101/B608) with documented reasoning, following the `ai-to-aws` pattern
- Root `.claude-plugin/marketplace.json` — new `bq-assess` entry
- Root `README.md` — plugins table row + repository structure tree
- `mise.toml` + `.github/workflows/security-scanners.yml` — bandit extended from two-pass to three-pass so this plugin scans with its own config (exact same mechanism as `ai-to-aws`)

### Validation

- `mise run build` passes locally — all stages green: `lint:md` (0 errors), `fmt:check`, bandit (0 issues across all three passes), semgrep, gitleaks (no leaks; also run in dir mode over the working tree), checkov (160 passed / 0 failed), grype (no vulnerabilities)
- 479 pytest pass; the plugin's `tests/plugin/structure.sh` passes (updated for the new layout, with a stricter no-internal-hostnames check — zero exceptions)
- **Both install paths tested end-to-end from this fork:** `pip install "git+…#subdirectory=solution-architecture/clis/bq-assess"` in a clean venv (both entry points run, report templates ship in the wheel), and `claude plugin marketplace add` → `claude plugin install bq-assess@startups-for-aws` → skill discovered (1 skill, ~180 always-on tokens)
- `claude plugin validate` passes on the plugin manifest and the marketplace manifest
- The tool has been run against three customer BigQuery environments during live migration engagements and five internal test environments

## Type of Change

- [x] New plugin/power/tool

## Team Folder

- [ ] `advisor/`
- [ ] `migrate/`
- [x] Other: `solution-architecture/` (existing folder, new `clis/` subfolder)

## ⚠️ Admin approval required

Per CODEOWNERS, this PR touches admin-gated paths and needs `@awslabs/startups-admins` review in addition to `@awslabs/startups-solution-architects`:

- `**/.claude-plugin/` — new plugin manifest **and** root `marketplace.json`
- `**/SKILL.md` — the skill
- `/.github/` — the three-pass bandit extension in `security-scanners.yml`
- `mise.toml`

## Checklist

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [x] I have run `mise run build` locally and it passes
- [x] I have updated documentation if needed
- [x] My changes are scoped to my team's folder only (plus the root marketplace/README/mise/CI wiring required to register a new plugin with Python code)
