### PR TITLE
docs(heroku-to-aws): retire redundant fragment-load prose from phase files

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/design/design.md
@@ -63,36 +63,19 @@ _forbids_files:
 
 # Phase 3: Design AWS Architecture
 
-Single-pass mapping engine that translates each Heroku resource to its AWS equivalent using deterministic lookup tables. No clustering, no dependency graphs — resources are processed as a flat list in input order.
-**Execute ALL steps in order. Do not skip or deviate.**
+## Orientation
 
-The EKS branch (`design-eks.md`, fired by its `_when` trigger when the Kubernetes preference selects EKS) is an ALTERNATIVE path, not an addition: it maps ALL formations to EKS pods + an `eks_cluster` aggregate instead of the Fargate path.
+Single-pass mapping engine: translate each Heroku resource to its AWS equivalent
+using deterministic lookup tables. No clustering, no dependency graphs — resources
+are processed as a flat list in input order.
 
-## Lookup Table References (Conditional Loading)
-
-The per-resource sizing/mapping data this phase consults lives in the phase's
-`_knowledge` frontmatter (the `knowledge/design/*.json` files), each gated by a
-`_when` condition. Load a knowledge file only when its `_when` holds; do NOT
-speculatively load knowledge for resource types absent from the inventory — see
-`INTERPRETER.md` § `_knowledge`.
-
----
-
-## Step 1: Run the Mapping Engine
-
-Load `references/phases/design/design-mapping.md` and follow it. It validates
-prerequisites, performs the single-pass resource mapping (loading `design-eks.md`
-for formations when the Kubernetes preference selects EKS), designs the VPC +
-security groups, and adds Cedar/Fir notation + metadata.
-
----
-
-## Step 2: Assemble and Validate
-
-Load `references/phases/design/design-assemble.md` (the phase's assembler) and
-follow it to write `aws-design.json`, run the output route gates + completion
-handoff gate, and update `.phase-status.json`. It owns the artifact-level contract
-for this phase.
+Composed of a mapping fragment + one assembler (declared in the frontmatter
+`_fragments`/`_assemble`); the interpreter runs the fragments whose `_trigger` is
+true, then the assembler, and evaluates the `_knowledge` `_when` guards to load only
+the sizing tables the inventory needs (see `INTERPRETER.md` § `_knowledge`). The EKS
+branch (`design-eks`, fired by its `_when` trigger when the Kubernetes preference
+selects EKS) is an ALTERNATIVE path, not an addition: it maps ALL formations to EKS
+pods + an `eks_cluster` aggregate instead of the Fargate path.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/discover/discover.md
@@ -39,6 +39,10 @@ _postconditions:
     _on_failure: _halt_and_inform
   - _assert: "no forbidden clustering fields are present (cluster_id, creation_order_depth, edges, dependencies, must_migrate_together)"
     _on_failure: _halt_and_inform
+  - _assert: "metadata.discovery_sources reflects which sub-discoveries actually ran; if the terraform sub-discovery ran, resources[] contains at least one Terraform-sourced resource"
+    _on_failure: _halt_and_inform
+  - _assert: "if a billing/invoice file was present in the workspace, heroku-resource-inventory.json has a billing_profile section"
+    _on_failure: _halt_and_inform
 _forbids_files:
   - README.md
   - discovery-summary.md
@@ -48,118 +52,29 @@ _forbids_files:
 
 # Phase 1: Discover Heroku Resources
 
-Lightweight orchestrator that delegates to domain-specific discoverers. Each sub-discovery file is self-contained — it scans for its own input, processes what it finds, and exits cleanly if nothing is relevant.
-**Execute ALL steps in order. Do not skip or deviate.**
+## Orientation
 
-Procfile and app.json parsing is integrated into the Terraform discovery flow (there is no standalone Procfile fragment) — when repo artifacts are found alongside Terraform, they supplement resource data with commands, buildpacks, and declared add-ons.
+Inventory what exists on Heroku into a single flat `heroku-resource-inventory.json`
+in `$MIGRATION_DIR/`. This phase is composed of FRAGMENTS (independent discoverers)
+plus one ASSEMBLER, declared in the frontmatter `_fragments`/`_assemble` — the
+interpreter runs each fragment whose `_trigger` is true (loading its `_file` only
+then), then the assembler. Read each unit file for its own contract; this phase
+owns only lifecycle + the cross-cutting `_postconditions`.
 
-**Note:** Platform API discovery is NOT supported in v1. No API calls are made. Discovery is entirely file-based (Terraform + repo + billing). All sub-discoveries contribute to a single `heroku-resource-inventory.json` artifact via the phase assembler.
-
----
-
-## Step 0: Initialize Migration State
-
-This phase has `_init: true`. Per `INTERPRETER.md` (§ `_init`), establish migration
-state before running the sub-discovery fragments: resolve resume-vs-fresh, set
-`$MIGRATION_DIR`, create `.migration/.gitignore`, and write the initial
-`.phase-status.json`. Confirm both files exist before proceeding to Step 1.
-
----
-
-## Step 1: Validate Prerequisites and Scan for Input Sources
-
-### 1a. Check for Terraform files (PRIMARY)
-
-Glob for: `**/*.tf` containing `heroku_*` resource types.
-
-- If found → Mark Terraform discovery as enabled. This is the primary discovery path.
-- If not found → Log: "No Terraform files with heroku_* resources found."
-
-### 1b. Check for Procfile / app.json (SUPPLEMENTARY)
-
-Search for: `Procfile`, `app.json` at workspace root or in subdirectories.
-
-- If found → Mark repo artifact discovery as enabled. These supplement Terraform with commands and declared add-ons.
-- If not found → Log: "No Procfile or app.json found — `command` fields will be null for formations."
-
-### 1c. Check for billing data (OPTIONAL)
-
-Glob for: `**/*billing*.csv`, `**/*invoice*.csv`, `**/*billing*.json`, `**/*invoice*.json`
-
-- If found → Mark billing discovery as enabled.
-- If not found → Log: "No billing files found — skipping billing discovery."
-
-### 1d. Source validation gate
-
-**If NO Terraform files with `heroku_*` resources found** (regardless of whether Procfile/app.json exist): this phase's `_preconditions` `_assert` fails with `_on_failure: _unrecoverable` (see `INTERPRETER.md` § Gate protocol / `_on_error`) — STOP and output: "No Terraform files with heroku_* resources found. Heroku Terraform is required for discovery. Procfile and app.json alone are not sufficient."
+Two facts the contract can't express: Procfile/app.json parsing is integrated into
+the terraform fragment (there is no standalone Procfile fragment) — when present
+alongside Terraform, they supplement resource data with commands, buildpacks, and
+declared add-ons. And Platform API discovery is NOT supported in v1: no API calls
+are made, discovery is entirely file-based. Billing data, when present, is embedded
+in `heroku-resource-inventory.json` (not a separate file); all user communication
+is via output messages only (no report/log files).
 
 ---
 
-## Step 2: Run Sub-Discoveries
+## Handoff
 
-Execute applicable sub-discoveries in order. Each produces its contribution to the inventory.
-
-**2a. Terraform Discovery (PRIMARY):**
-
-If Terraform files with `heroku_*` resources found → Load `references/phases/discover/discover-terraform.md`
-
-This produces:
-
-- Resource extraction from `.tf` files (`heroku_app`, `heroku_addon`, `heroku_formation`, `heroku_domain`, `heroku_pipeline`, `heroku_space`)
-- Procfile and app.json parsing (integrated — supplements Terraform with commands, buildpacks, declared add-ons)
-- Cedar/Fir generation detection from `stack` attribute
-- Private Space and peering detection from `heroku_space` resources
-
-**2b. Billing Discovery (OPTIONAL):**
-
-If billing data files found → Load `references/phases/discover/discover-billing.md`
-
-This produces:
-
-- Billing profile: total monthly cost, billing period, currency, per-resource line items
-- Per-app cost breakdown when available
-
----
-
-## Step 3: Assemble Inventory
-
-Load `references/phases/discover/discover-assemble.md` (the phase's assembler) and follow it to combine the sub-discovery outputs into the single `heroku-resource-inventory.json` artifact. It owns that artifact's assembly rules and the failure behavior if no valid resources were produced.
-
----
-
-## Step 4: Check Outputs
-
-Verify required artifacts exist in `$MIGRATION_DIR/`:
-
-1. `heroku-resource-inventory.json` — MUST exist with at least one resource entry.
-2. `.phase-status.json` — MUST exist and be valid JSON with correct schema.
-
-**Route output gates (fail closed):**
-
-- If Terraform discovery ran → inventory MUST contain resources sourced from Terraform.
-- If Procfile/app.json found → formation resources SHOULD have `command` fields populated (warning if not, not a gate failure).
-- If billing discovery ran → inventory MUST contain a `billing_profile` section.
-- If any triggered route is missing its required contribution: STOP and output which sub-discovery failed.
-
----
-
-## Completion Handoff Gate (Fail Closed)
-
-The completion checks are declared in this phase's `_postconditions` frontmatter and
-enforced per `INTERPRETER.md` § Gate protocol: re-read `heroku-resource-inventory.json`
-from disk, run the mechanical checks (`_check_file_exists` / `_validate_json`) and the
-`_assert` judgment checks (at least one resource + required metadata, per-resource
-fields, no forbidden clustering fields), plus the route output gates from Step 4, then
-emit `GATE_FAIL` (STOP; do not patch artifacts) or
-`HANDOFF_OK | phase=discover | artifacts=<files verified>` and advance.
-
----
-
-## Step 5: Update Phase Status and Hand Off
-
-Only after `HANDOFF_OK`, apply the phase-status update protocol (`INTERPRETER.md` § The interpreter loop) — mark `phases.discover` completed and advance per `_advances_to` — in the **same turn** as the output message below.
-
-Output to user — build message from inventory contents:
+After the interpreter emits `HANDOFF_OK | phase=discover`, build the user-facing
+completion message from the inventory contents:
 
 - "Discovered X total resources across Y apps."
 - If billing data available: "Parsed billing data ($Z/month)."
@@ -168,12 +83,6 @@ Output to user — build message from inventory contents:
 - If Cedar/Fir mixed: "Generation detection: N Cedar, M Fir, P unknown."
 
 Format: "Discover phase complete. [artifact summaries] Next required step: Phase 2 — Clarify. Load `references/phases/clarify/clarify.md` now. Do not load Design, Estimate, or Generate until Clarify completes and `.phase-status.json` marks `phases.clarify` as `completed`."
-
----
-
-## Output Files
-
-This phase's artifacts are declared in `_produces` and its scope boundary (files it must NOT create) in `_forbids_files`. Billing data, when present, is embedded in `heroku-resource-inventory.json` — not a separate file. All user communication is via output messages only (no report/log files).
 
 ---
 
@@ -187,8 +96,6 @@ Non-fatal discovery errors and their handling (fatal source/gate failures are ha
 | Procfile/app.json parse error                     | Record warning per-app, continue               |
 | Generation detection unresolvable (no stack attr) | Set `heroku_generation` to `unknown`, continue |
 | Pipeline detection from Terraform incomplete      | Record with available data, continue           |
-
-When all sub-discoveries produce no resources (or no Heroku Terraform is present), the phase's source `_precondition` fails `_unrecoverable`; a completion-gate failure halts per the gate protocol (retain `in_progress`, do not patch).
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -63,25 +63,20 @@ _forbids_files:
 
 # Phase 4: Estimate AWS Costs
 
-**Execute ALL steps in order. Do not skip or optimize.**
+## Orientation
 
-Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture, producing `estimation-infra.json` (conforming to `references/vendored/estimate/estimation-infra.schema.json`) and classifying migration complexity using the tier thresholds in `references/vendored/estimate/complexity-tiers.json`.
+Calculate projected monthly AWS costs for the designed Heroku-to-AWS architecture,
+producing `estimation-infra.json` (conforming to
+`references/vendored/estimate/estimation-infra.schema.json`) and classifying
+migration complexity using the tier thresholds in
+`references/vendored/estimate/complexity-tiers.json`.
 
----
-
-## Step 1: Compute the Estimate
-
-Load `references/phases/estimate/estimate-cost-engine.md` and follow it. It selects the
-pricing mode, validates the design inputs, and computes the entire financial picture.
-
----
-
-## Step 2: Assemble and Validate
-
-Load `references/phases/estimate/estimate-assemble.md` (the phase's assembler) and
-follow it to write the final `estimation-infra.json`, run the completion handoff gate,
-update `.phase-status.json`, and present the summary. It owns the artifact-level
-contract for this phase.
+Composed of a cost-engine fragment + one assembler (declared in the frontmatter
+`_fragments`/`_assemble`); the interpreter runs the fragment, then the assembler,
+and evaluates the `_knowledge` guards to load the pricing/defaults/tier data. The
+fragment selects the pricing mode and computes the financial picture; the assembler
+writes the final artifact, runs the completion gate, and presents the summary — read
+each unit file for its own contract.
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -68,36 +68,20 @@ _forbids_files:
 
 # Phase 5: Generate Migration Artifacts
 
-**Execute ALL steps in order. Do not skip or optimize.**
+## Orientation
 
-## Step 0: Validate Prerequisites
+Transform the design + estimate into deployable artifacts in `$MIGRATION_DIR/`: a
+`terraform/` directory, `MIGRATION_GUIDE.md`, `README.md`, database migration
+scripts, and `generation-warnings.json`. This is the multi-artifact phase.
 
-The entry gate (estimate completed, single active phase, all four inputs present + valid
-JSON) is enforced by this phase's `_preconditions` frontmatter per `INTERPRETER.md`
-§ Gate protocol; proceed once it passes.
-
----
-
-## Step 1: Generate Terraform Configurations
-
-Load `references/phases/generate/generate-terraform.md` and execute completely. When the
-design contains EKS (`aws_service: "EKS"`), the `eks-generate` fragment also fires per its
-`_fragments` `_when` trigger; follow `references/phases/generate/generate-eks.md`.
-
----
-
-## Step 2: Generate Documentation and Scripts
-
-Load `references/phases/generate/generate-docs.md` and execute completely.
-
----
-
-## Step 3: Assemble and Validate
-
-Load `references/phases/generate/generate-assemble.md` (the phase's assembler) and
-follow it to validate the complete artifact set (cross-reference checks), run the
-completion handoff gate, and update `.phase-status.json`. It owns the phase's final
-artifact-level contract.
+Composed of the terraform + docs fragments + an EKS-generate fragment + one
+cross-artifact validator assembler (declared in the frontmatter
+`_fragments`/`_assemble`); the interpreter runs each fragment whose `_trigger` is
+true, then the assembler. The `eks-generate` fragment is an ALTERNATIVE compute
+path — it fires only when the design has an `eks_cluster` (its `_when` trigger),
+emitting `eks.tf` + `kubernetes/` manifests. Templates are output skeletons
+(`templates/generate/...`); the fragments are the routing algorithm. Read each unit
+file for its own contract; the assembler owns the cross-artifact completion gate.
 
 ---
 


### PR DESCRIPTION
## Summary

The `discover`/`design`/`estimate`/`generate` phase bodies in `heroku-to-aws` still carried pre-DSL orchestration prose — `## Step N: Load references/phases/.../X.md and follow it` — that re-narrates the composition the phase **frontmatter already declares** (`_fragments`/`_trigger`/`_assemble` + the gate keys). Per `INTERPRETER.md`, the interpreter drives execution entirely off that frontmatter, so the "Load X" steps are redundant — and in two cases actively **contradicted** the contract. This PR retires them, aligning the phase files with the DSL phase shape (Orientation + Scope Boundary, no step-list body).

## Per phase

- **discover** (207→114): remove Step 0–5 (init/scan/load/gate/status re-narration). Delete the "enable-flags" scan model (1a–1c) that contradicted the `_always` terraform `_trigger` and invented a phantom "repo artifact discovery" route with no fragment. **Migrate the two real route-output gates** (billing_profile present iff a billing file was seen; terraform-sourced resources iff terraform ran) from Step-4 prose into `_postconditions` as conditional `_assert`s. Keep Orientation, a trimmed Handoff message, the Error Handling table, and Scope Boundary.
- **design** (113→96): remove Step 1–2 loads and the "Lookup Table References (Conditional Loading)" section that re-legislated the `_knowledge` `_when` load decision the interpreter owns. Keep the anti-clustering + EKS-alternative-path notes as Orientation.
- **estimate** (101→96): remove Step 1–2 loads + "Execute ALL steps" preamble.
- **generate** (116→100): remove Step 0–3 loads.

`## Scope Boundary` is **kept** in every file — `_scope` is not yet in the prose skill's frontmatter vocabulary, so it remains the only home for the topic-scope boundary.

## Testing

- `mise run build` green on a clean tree: `lint:frontmatter` 0 errors + validator tests pass; `lint:md`/`fmt:check` clean on the changed files; security 160 checks passed / 0 failed.
- End-to-end **cold run** (`claude -p` against the local plugin dir, `heroku-sample-app`) completed `discover → generate`, producing all expected artifacts and driving every phase transition off frontmatter + `INTERPRETER.md` with no reliance on the removed prose.

## Blast radius

Docs/prose only — no frontmatter contract changes except the two discover route-gates moved into `_postconditions` (net −191/+60). No behavior change to the interpreter or validator.
