### PR TITLE
refactor(migration-to-aws): tf-best-practices owns AWS authoring posture; gcp-to-aws consumes it as a black box

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
@@ -264,28 +264,70 @@ terraform.tfvars
 
 ## Step 3: Generate Per-Domain .tf Files
 
+### Step 3.0: Apply AWS authoring posture (before writing)
+
+**Before generating any `.tf`, invoke the `tf-best-practices` skill for its authoring posture** —
+it is the single source of truth for "what good AWS Terraform looks like." Treat it as a **black
+box**: pass the context below and follow whatever posture it returns. Do **not** reach into its
+files or assume how it is organized internally — it evolves independently.
+
+> Invoke the **`tf-best-practices`** skill, telling it you are **about to author `terraform/`**
+> (the authoring/pre-generation context), and emit Terraform that satisfies every rule it
+> returns.
+
+**Pass the caller context** the skill needs (these are gcp-to-aws's to supply; the skill reads
+none of our artifacts itself):
+
+- **`compliance`** — the value of `preferences.json` → `design_constraints.compliance` (array;
+  may be empty/absent). Empty ⇒ the skill emits no compliance-conditional hardening, keeping the
+  stack minimal and immediately applyable.
+- **`aws_config` values** — instance classes, CPU/memory, storage sizes, engine versions from
+  each resource's `aws_config` in `aws-design.json`. Populate resource attributes from these;
+  the skill's posture constrains the shape, not the numbers.
+
+**Do not re-specify the skill's posture here** — the skill owns it. Step 3.1 covers only the
+source-glue and resource wiring the skill does not (and should not) know about.
+
+### Step 3.1: gcp-to-aws generation rules (source glue — NOT AWS posture)
+
 For each domain with resources in the generation manifest:
 
 **General rules:**
 
 - Consult `references/design-refs/*.md` for AWS configuration best practices
 - A single GCP resource may map to multiple AWS resources (1:Many expansion)
-- Use `gcp_config` values from `aws-design.json` to populate resource attributes
+- Use `gcp_config` / `aws_config` values from `aws-design.json` to populate resource attributes
 - For `confidence: "inferred"` resources, add comment: `# Tailored to your setup — verify configuration (JSON confidence: inferred)`
 - For `confidence: "deterministic"` resources, optional comment: `# Standard pairing (fixed mapping list)`
 - Include `secondary_resources` from the cluster (IAM roles, security groups)
 - Tag every resource: Project, Environment, ManagedBy, MigrationId
 
-**Domain-specific rules:**
+**GCP-source-specific rules (these stay here — the skill is source-agnostic and cannot own them):**
 
-| Domain     | Key Rules                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Networking | At least 2 AZs; public + private subnets; NAT gateway for private subnet internet; internet-facing ALB must terminate TLS on 443 and HTTP 80 must redirect to HTTPS; when `preferences.json.compliance` contains `pci`, `hipaa`, or `fedramp`, emit `aws_flow_log` for the VPC targeting a CloudWatch log group — add inline cost disclosure comment: `# VPC Flow Logs: ~$0.50/GB ingested. Enabled for compliance. Disable if cost is a concern and compliance posture allows.` — omit for non-compliance stacks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| Security   | Least-privilege IAM (specific ARNs, never wildcards); per-service roles for Fargate/Lambda; Secrets Manager resources with no plaintext defaults; when `preferences.json.compliance` contains `soc2`, `pci`, `hipaa`, or `fedramp`, emit a companion `aws_secretsmanager_secret_rotation` block for every `aws_secretsmanager_secret` resource with `automatically_after_days = 30` and a TODO comment for the rotation Lambda ARN — omit the rotation block for non-compliance stacks to keep the generated Terraform immediately applyable; when `preferences.json.compliance` contains `pci`, `hipaa`, or `fedramp`, generate a customer-managed KMS key (`aws_kms_key`) and reference it via `kms_key_id` on every `aws_secretsmanager_secret` — omit for non-compliance stacks (AWS-managed key is sufficient)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| Storage    | Versioning enabled; SSE-S3 or SSE-KMS encryption; block public access by default; lifecycle policies; if public content is required use CloudFront/OAC instead of public bucket policy; when `preferences.json.compliance` contains `pci`, `hipaa`, or `fedramp`, emit `aws_s3_bucket_logging` for every application S3 bucket (not the CloudTrail/Config log buckets themselves) targeting a dedicated access-log bucket — add inline cost disclosure comment: `# S3 access logging: ~$0.023/GB stored. Enabled for compliance. Disable if cost is a concern and compliance posture allows.` — omit for non-compliance stacks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| Database   | Private subnets; subnet group + parameter group + security group; backups; encryption at rest (`storage_encrypted = true`); `deletion_protection = true` by default; **`publicly_accessible = false` always** — never emit `publicly_accessible = true` unless the user has explicitly requested it via a compliance exception in `preferences.json`; **never emit a security group rule allowing ingress on port 5432 or 3306 from `0.0.0.0/0`** — database ports must only allow ingress from the application security group CIDR or security group ID; if GCP Cloud SQL `authorized_networks` contains `0.0.0.0/0`, emit a `warnings[]` entry in `aws-design.json`: "Cloud SQL authorized_networks includes 0.0.0.0/0 — mapped to private RDS with no public access" (add inline comment: `# Set to false only when intentionally destroying this cluster`); **never use `master_password = var.database_master_password`** — instead generate the master password into Secrets Manager and reference it via data source: emit `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version` (with `secret_string = jsonencode({password = random_password.db_master.result})`) and `resource "random_password" "db_master"`, then set `master_password = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)["password"]` on the cluster — this keeps the password out of `terraform.tfvars` and Terraform state plaintext |
-| Compute    | Fargate in private subnets; task definitions from `aws_config` CPU/memory; auto-scaling; for EKS clusters set `endpoint_private_access = true` and `endpoint_public_access = false` by default — add inline comment: `# Public endpoint disabled. To enable kubectl access from outside the VPC set endpoint_public_access = true and restrict public_access_cidrs to known CIDRs.`; every `aws_ecr_repository` resource must include `image_scanning_configuration { scan_on_push = true }` — ECR basic scanning is free and catches known CVEs before images reach production                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| Monitoring | Log groups per service; dashboard with key metrics; alarms from `generation-infra.json` success_metrics; 30-day log retention                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+- **Cloud SQL `authorized_networks` → warning:** if a source `google_sql_database_instance` has
+  `authorized_networks` containing `0.0.0.0/0`, emit a `warnings[]` entry in `aws-design.json`:
+  "Cloud SQL authorized_networks includes 0.0.0.0/0 — mapped to private RDS with no public
+  access." (The skill already mandates a private, non-`0.0.0.0/0` RDS; this warning just records
+  that the source was public and was intentionally not carried over.)
+- **Monitoring alarms** derive from `generation-infra.json` success_metrics (a gcp-to-aws
+  artifact); wire them into the CloudWatch dashboard/alarms the skill's monitoring baseline calls
+  for.
+- **Domain resource wiring** the skill's rules assume you emit — DB subnet group + parameter
+  group; per-service Fargate/Lambda IAM roles; compute auto-scaling — populated with this
+  migration's `aws_config` values.
+
+**Domain-specific wiring** (posture is owned by the `tf-best-practices` skill — these rows list
+only the gcp-to-aws resource wiring / value population per domain; for every security rule,
+follow the posture the skill returned in Step 3.0):
+
+| Domain     | gcp-to-aws wiring (skill owns the posture)                                                                                                                                                                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Networking | Emit the VPC/subnets/NAT/SGs and (for compliance) flow logs per the skill's posture; populate CIDRs/AZ count from design. Wire an internet-facing ALB only if the design has one.                                                                                                   |
+| Security   | Emit per-service Fargate/Lambda IAM roles and Secrets Manager resources per the skill's posture (least-privilege, no plaintext master password, compliance-conditional rotation/KMS). Populate ARNs/role names from the cluster's `secondary_resources`.                            |
+| Storage    | Emit S3 buckets per the skill's posture (versioning, SSE, block-public-access, CloudFront/OAC for public, compliance-conditional access logging). Populate bucket names/lifecycle from design.                                                                                      |
+| Database   | Emit RDS/Aurora per the skill's posture (private, encrypted, `deletion_protection`, master-password-via-Secrets-Manager, DB-port SG scoping). Populate engine/version/instance class from `aws_config`; add the Cloud SQL `authorized_networks` warning (Step 3.1) when applicable. |
+| Compute    | Emit Fargate/EKS/ECR per the skill's posture (private subnets, EKS private endpoint, ECR scan-on-push). Populate task CPU/memory and autoscaling from `aws_config`.                                                                                                                 |
+| Monitoring | Emit CloudWatch log groups/dashboard/alarms per the skill's monitoring baseline; source alarm thresholds from `generation-infra.json` success_metrics.                                                                                                                              |
 
 ## Step 4: Generate outputs.tf
 
@@ -322,17 +364,15 @@ output "migration_summary" {
 
 Verify these quality rules before reporting completion:
 
-- [ ] No wildcard IAM policies (`"Action": "*"` or `"Resource": "*"`)
+**Security posture (owned by the `tf-best-practices` skill; the Step 6 policy gate re-verifies the statically-checkable subset):**
+
+- [ ] Generated Terraform satisfies the authoring posture the `tf-best-practices` skill returned at Step 3.0, for the `compliance` context passed. (The skill defines the rules; do not re-enumerate them here.)
+
+**gcp-to-aws generation self-check (caller-specific — not owned by the skill):**
+
 - [ ] No default VPC references — all resources use the created VPC
 - [ ] No hardcoded credentials in any .tf file
 - [ ] Tags on every resource (Project, Environment, ManagedBy, MigrationId)
-- [ ] Encryption at rest on all storage (S3, EBS, RDS)
-- [ ] Databases and internal services use private subnets
-- [ ] All RDS/Aurora resources have `publicly_accessible = false`
-- [ ] No security group rule allows ingress on port 5432 or 3306 from `0.0.0.0/0`
-- [ ] ALB listeners enforce HTTPS (443) and HTTP (80) only redirects to HTTPS
-- [ ] No S3 bucket policy with `Principal = "*"` unless explicitly approved by user requirements
-- [ ] No `0.0.0.0/0` ingress except ALB port 443
 - [ ] Every variable has `type` and `description`
 - [ ] Every output has `description`
 - [ ] Region from `var.aws_region`, never hardcoded
@@ -359,14 +399,17 @@ Verify these quality rules before reporting completion:
 After the Step 5 self-check, validate `$MIGRATION_DIR/terraform` and write
 `$MIGRATION_DIR/validation-report.json`.
 
-> Follow the protocol and the policy gate defined by the **tf-best-practices** skill:
->
-> - Protocol: `skills/tf-best-practices/references/terraform-validation.md`
->   (`fmt → init → validate → policy → fix-and-retry → offline-fallback`).
-> - Policy gate + invocation, exit codes, and verdict shape: the skill's `SKILL.md` (Part 2).
-> - ALB TLS posture to emit: `skills/tf-best-practices/references/security-posture-rules.md`.
+**Invoke the `tf-best-practices` skill for the post-writing validation context** — tell it the
+`terraform/` directory has been written and pass `$MIGRATION_DIR/terraform` as the target dir.
+Treat it as a **black box**: follow the validation protocol and policy verdict it returns (exit
+codes, `violations[]` shape). Do **not** reach into its internal files — it evolves
+independently.
 
-This phase is the **caller** in that protocol. tf-best-practices is a read-only verdict
+> The authoring posture was already applied at **Step 3.0**, so the generated Terraform should
+> pass by construction; this step re-verifies the statically checkable subset and produces the
+> machine-readable verdict.
+
+This phase is the **caller** in that protocol. `tf-best-practices` is a read-only verdict
 producer — it reports whether the Terraform passes. This phase owns everything the skill does
 NOT: pass `$MIGRATION_DIR/terraform` as the target dir, run the fmt/init/validate stages, apply
 the fix-and-retry edits to the reported `violations[]` sites (budget 3), run the retry/skip/abort

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/SKILL.md
@@ -13,6 +13,22 @@ questions for a phase that generates AWS Terraform:
 2. **After writing** — "does the generated `terraform/` pass policy?" (a deterministic,
    **read-only** verdict + a machine-readable report)
 
+## Routing — load the part that matches your context
+
+This skill is entered at two touchpoints in the caller's Generate flow, with the caller's
+own terraform-authoring work in between. **The caller states which touchpoint it is at when it
+loads this skill**, and reads the corresponding part:
+
+| Caller context                                              | Load                                                                                                      | Why                                                                                               |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **About to author `terraform/`** (before writing)           | Part 1 → [`references/security-posture-rules.md`](references/security-posture-rules.md)                   | The "what to emit" AWS authoring rules (gate-enforced + authoring-only + compliance-conditional). |
+| **`terraform/` written, ready to validate** (after writing) | Part 2 → [`references/terraform-validation.md`](references/terraform-validation.md) + run the gate script | The `fmt → init → validate → policy` protocol and the read-only verdict.                          |
+
+Everything this skill states is **source-cloud-agnostic** (pure AWS Terraform). Any GCP/Heroku
+detection or artifact reading is the caller's job; where a rule needs a caller-known fact (e.g.
+declared compliance frameworks), the caller passes it as a **caller-context signal** — see
+`references/security-posture-rules.md` § _Caller-context signals_.
+
 ## Boundary (read this first)
 
 This unit is a **verdict producer, never a mutator**. Its entire write surface is the
@@ -35,16 +51,23 @@ generate phase for how the verdict feeds those decisions.
 Emit generated Terraform that satisfies the posture in
 [`references/security-posture-rules.md`](references/security-posture-rules.md).
 
-These are the "what to emit" rules. Following them makes the Part 2 gate pass by
-construction. This unit does not read the caller's artifacts.
+These are the "what good AWS Terraform looks like" rules. Following them makes the Part 2 gate
+pass by construction. This unit does not read the caller's artifacts — it consumes only
+caller-context signals the caller passes in.
 
-> **Scope.** The posture rules and the Part 2 gate cover internet-facing ALB TLS termination,
-> no-public-database, no-public admin/datastore-port ingress, no-wildcard-IAM, and RDS +
-> ElastiCache encryption-at-rest (see **Policy rules enforced today** below). This unit is
-> intentionally extensible: further cross-cutting posture rules (private-subnet placement as a
-> positive assertion, the account-hardening `baseline.tf` layer, S3 SSE correlation, CloudFront
-> viewer-protocol TLS) are candidates to migrate here over time. Until then those remain the
-> consuming skill's own generation rules.
+> **Scope.** `security-posture-rules.md` covers, in three tiers:
+>
+> - **Gate-enforced** (Part 2 verifies statically): ALB TLS, no-public-database, RDS +
+>   ElastiCache encryption-at-rest, no-public-DB-port ingress, no-public admin/datastore-port
+>   ingress, no-wildcard-IAM.
+> - **Authoring-only** (not gate-checkable, still required): `deletion_protection`,
+>   master-password-via-Secrets-Manager, S3 hardening, Fargate/EKS/ECR settings, private-subnet
+>   placement, backups, baseline monitoring.
+> - **Compliance-conditional** (emitted when the caller declares `soc2`/`pci`/`hipaa`/`fedramp`):
+>   VPC flow logs, S3 access logging, secret rotation, customer-managed KMS.
+>
+> Still the **caller's** own generation concern (candidates to migrate here later): the
+> account-hardening `baseline.tf` layer (CloudTrail, GuardDuty, Config, Security Hub).
 
 ## Part 2 — Policy gate (run after writing `terraform/`)
 

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
@@ -1,17 +1,40 @@
 # Generated-IaC Security Posture Rules
 
 Cross-cutting security posture that generated AWS Terraform must follow, regardless of the
-source cloud. These are **authoring rules** ("what to emit"); the read-only policy gate
-(`scripts/validate-terraform-policy.py`) verifies the subset it can check statically.
+source cloud (GCP, Heroku, …). These are **authoring rules** — "what good AWS Terraform looks
+like." Load this file **before** writing `terraform/`; emit resources that satisfy it.
 
-> **Scope.** tf-best-practices owns these posture areas as authoring rules AND enforces them
-> in the read-only gate: internet-facing ALB TLS, no-public-database, no-public-DB-port
-> ingress, no-wildcard-IAM, and RDS encryption-at-rest. Each gate rule is **fail-open on
-> ambiguity** — it fires only on unambiguous, in-block literal evidence, so a valid stack is
-> never falsely blocked (the mirror of the ALB rule's fail-safe stance). Remaining posture
-> areas (private-subnet placement as a positive assertion, the account-hardening `baseline.tf`
-> layer, S3 SSE correlation) stay the consuming skill's own generation rules for now and are
-> candidates to migrate here later.
+**Source-agnostic by design.** Every rule here is a statement about AWS Terraform only. This
+file contains **no** GCP/Heroku/source-cloud logic — the consuming skill (the caller) owns all
+source-specific concerns and passes the caller-context signals a rule needs (see below).
+
+## Rule categories
+
+- **Gate-enforced** — the read-only policy gate (`scripts/validate-terraform-policy.py`)
+  statically verifies these after generation: ALB TLS, no-public-database, RDS + ElastiCache
+  encryption-at-rest, no-public-DB-port ingress, no-public admin/datastore-port ingress,
+  no-wildcard-IAM. Each is **fail-open on ambiguity** — fires only on unambiguous in-block
+  literal evidence, so a valid stack is never falsely blocked.
+- **Authoring-only** — best-practice rules the static gate cannot check but the caller must
+  still emit: `deletion_protection`, the master-password-via-Secrets-Manager recipe, S3
+  hardening, EKS/ECR settings, private-subnet placement, backups, and the compliance-conditional
+  emissions below. Not gate-blocked; still required for well-formed output.
+
+## Caller-context signals
+
+A few rules are conditional on facts only the caller knows. The caller passes these when it
+loads this file; the rules reference them abstractly (never a source-cloud artifact):
+
+- **`compliance`** — the set of declared compliance frameworks (`soc2`, `pci`, `hipaa`,
+  `fedramp`), or empty. Gates the **Compliance-conditional emissions** section. The caller
+  derives this from its own requirements gathering and supplies the value; this file only says
+  "if `compliance` includes X, emit Y."
+- **`aws_config` values** (instance classes, CPU/memory, sizes) — the caller reads these from
+  its own design artifact and populates resource attributes; the posture rules constrain the
+  _shape_, not the specific numbers.
+
+The caller also owns any source-cloud detection (e.g. mapping a public-ingress finding from the
+source infra into a warning) — that logic never lives here.
 
 ## Internet-facing ALB — TLS termination and HTTP redirect
 
@@ -146,3 +169,107 @@ not a blanket wildcard and is allowed.
 open (their statements are HCL blocks, not literal JSON the reader can inspect), and assume-role
 trust policies on `aws_iam_role` are out of scope — so a scoped data-source policy is never
 falsely flagged.
+
+---
+
+## Authoring-only rules (not gate-enforced)
+
+The static gate cannot verify these, but well-formed AWS Terraform must still emit them. Apply
+them at authoring time alongside the gate-enforced rules above.
+
+## Database — durability & credential hygiene
+
+**Applies to:** `aws_db_instance`, `aws_rds_cluster` and their supporting resources.
+
+1. **`deletion_protection = true`** by default. Add an inline comment:
+   `# Set to false only when intentionally destroying this cluster.`
+2. **Backups enabled** (`backup_retention_period` > 0).
+3. Emit a **DB subnet group + parameter group + security group**; place the instance in
+   **private subnets**.
+4. **Never** set the master password from a plaintext variable
+   (`master_password = var.database_master_password` is forbidden — it lands in `terraform.tfvars`
+   and state in plaintext). Instead generate it into Secrets Manager and reference it via a data
+   source:
+
+   ```hcl
+   resource "random_password" "db_master" {
+     length  = 32
+     special = true
+   }
+
+   resource "aws_secretsmanager_secret" "db_master" {
+     name = "${var.project_name}/rds/master-credentials"
+   }
+
+   resource "aws_secretsmanager_secret_version" "db_master" {
+     secret_id     = aws_secretsmanager_secret.db_master.id
+     secret_string = jsonencode({ password = random_password.db_master.result })
+   }
+
+   data "aws_secretsmanager_secret_version" "db_master" {
+     secret_id  = aws_secretsmanager_secret.db_master.id
+     depends_on = [aws_secretsmanager_secret_version.db_master]
+   }
+
+   # on the instance/cluster:
+   #   master_password = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)["password"]
+   ```
+
+## S3 — bucket hardening
+
+**Applies to:** application `aws_s3_bucket` resources (not log-sink buckets, which have their
+own policies).
+
+1. **Versioning enabled.**
+2. **Encryption:** SSE-S3 or SSE-KMS (a bucket without an explicit SSE block still has default
+   SSE-S3 since Jan 2023 — do not treat its absence as unencrypted, but prefer an explicit block).
+3. **Block public access** by default (account- and bucket-level).
+4. **Lifecycle policies** for cost/retention where applicable.
+5. If **public content** is required, front it with **CloudFront + Origin Access Control (OAC)** —
+   never a public bucket policy.
+
+## Compute — Fargate / EKS / ECR
+
+1. **Fargate** tasks run in **private subnets**; size from the caller-supplied `aws_config`
+   CPU/memory.
+2. **EKS:** default to a private API endpoint — `endpoint_private_access = true`,
+   `endpoint_public_access = false`. Add a comment: `# Public endpoint disabled. To enable
+   kubectl access from outside the VPC set endpoint_public_access = true and restrict
+   public_access_cidrs to known CIDRs.`
+3. **ECR:** every `aws_ecr_repository` includes `image_scanning_configuration { scan_on_push = true }`
+   (free basic scanning catches known CVEs before images reach production).
+
+## Networking — subnet & egress baseline
+
+1. Span at least **2 Availability Zones**.
+2. **Public + private subnets**; workloads (compute, database) live in private subnets.
+3. **NAT gateway** for private-subnet outbound internet when required.
+
+## Monitoring — baseline observability
+
+1. A **CloudWatch log group per service** with a sane retention (default 30 days).
+2. A **dashboard** with key metrics. (Specific alarm thresholds come from the caller's context —
+   the caller supplies success-metric targets; this rule constrains the shape, not the values.)
+
+---
+
+## Compliance-conditional emissions
+
+These are AWS best-practice hardening steps that apply **only when the caller declares a
+compliance framework**. The **rule lives here**; the **trigger** (the `compliance` set) is a
+caller-context signal (see _Caller-context signals_ above) — the caller passes it in; this file
+never reads a source-cloud artifact.
+
+Apply based on the caller-supplied `compliance` set:
+
+| Emit when `compliance` includes…     | Emit                                                                                                                                                                                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pci`, `hipaa`, or `fedramp`         | **VPC flow logs** — `aws_flow_log` for the VPC → a CloudWatch log group. Inline cost note: `# VPC Flow Logs: ~$0.50/GB ingested. Enabled for compliance. Disable if cost is a concern and compliance posture allows.`                                         |
+| `pci`, `hipaa`, or `fedramp`         | **S3 access logging** — `aws_s3_bucket_logging` for every application bucket → a dedicated access-log bucket. Inline cost note: `# S3 access logging: ~$0.023/GB stored. Enabled for compliance. Disable if cost is a concern and compliance posture allows.` |
+| `soc2`, `pci`, `hipaa`, or `fedramp` | **Secret rotation** — a companion `aws_secretsmanager_secret_rotation` (`automatically_after_days = 30`) for every `aws_secretsmanager_secret`, with a TODO comment for the rotation Lambda ARN.                                                              |
+| `pci`, `hipaa`, or `fedramp`         | **Customer-managed KMS** — an `aws_kms_key` referenced via `kms_key_id` on every `aws_secretsmanager_secret` (AWS-managed key is sufficient otherwise).                                                                                                       |
+
+When `compliance` is empty, emit **none** of the above — keep the generated Terraform minimal
+and immediately applyable. (The account-hardening `baseline.tf` layer — CloudTrail, GuardDuty,
+Config, Security Hub — remains the caller's own generation concern for now; it is a candidate to
+migrate here later.)


### PR DESCRIPTION
## Summary

Makes the **tf-best-practices** skill the single source of truth for "what good AWS Terraform looks like," and has **gcp-to-aws** consume it as a **black box** — invoking it by name and passing context, with no knowledge of its internal files, part structure, or rule list. This lets the posture evolve independently of any one caller and prepares it for reuse by future callers (heroku-to-aws).

Builds on #142 (which introduced the tf-best-practices policy gate).

## What moved

**tf-best-practices — the "what":**
- `SKILL.md` gains a **routing contract**: callers enter *by name* and state their context (authoring/pre-generation vs post-writing validation); the skill routes to its own reference files. Scope broadened to three tiers: **gate-enforced / authoring-only / compliance-conditional**.
- `security-posture-rules.md` becomes the single source of AWS authoring truth — source-cloud-agnostic framing, a **Caller-context signals** contract (`compliance`, `aws_config`), the migrated **authoring-only** rules (`deletion_protection`, master-password-via-Secrets-Manager, S3 hardening, Fargate/EKS/ECR, subnet/NAT, monitoring), and a **compliance-conditional** section (the rule lives in the skill; the compliance *trigger* is a caller-supplied signal).

**gcp-to-aws — the "wiring":**
- **Step 3.0 (new):** before writing terraform, invoke tf-best-practices by name for the authoring context and pass caller context (`compliance` from preferences, `aws_config` values); follow the returned posture.
- **Step 3.1 + domain table:** keep only GCP-source glue (`authorized_networks` warning, `success_metrics` alarms, resource wiring); posture removed.
- **Step 5 self-check + Step 6:** reference the skill as a black box — invoke by name for validation, no internal paths, no rule enumeration, no Part 1/Part 2 structure.

## Black-box boundary

gcp-to-aws no longer references any tf-best-practices internal file, its part structure, or its rule list — it only invokes by name and passes context. The skill can reorganize files, rename parts, or add rules without touching the caller.

## Verification

Verified **end-to-end** with a live gcp-to-aws run (not just build-green):
- The skill was invoked at **both** touchpoints inside Generate (authoring + validation); nested skill-invocation returned control cleanly.
- Step 3.0 posture **landed in the generated `.tf`**: `storage_encrypted=true`, `publicly_accessible=false`, `deletion_protection=true`, the Secrets-Manager master-password recipe, scoped SG + least-privilege IAM.
- Compliance-conditionals **correctly suppressed** for empty compliance.
- Step 6 returned **POLICY_OK** (0 violations, no fix-and-retry).
- `mise build` green.

## Not covered (follow-up)

The compliance-conditional branch was verified only in the *suppressed* direction (empty compliance). Emitting flow logs / rotation / KMS for a declared `pci`/`hipaa` stack uses the same delegation mechanism but was not exercised in this run.