### PR TITLE
fix(migration-to-aws): _check_phase_completed honors skill-declared resolved statuses

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/vendored/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/vendored/dsl/INTERPRETER.md
@@ -380,13 +380,13 @@ heroku-to-aws's own gate contract — phases do NOT load any shared gate file.
 Each entry is a single check plus an `_on_failure` action (see the `_on_error`
 dictionary below). Closed vocabulary of check kinds:
 
-| Check                        | Arg                       | Passes when                                                    |
-| ---------------------------- | ------------------------- | -------------------------------------------------------------- |
-| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name> == "completed"`            |
-| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                        |
-| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                    |
-| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                           |
-| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts |
+| Check                        | Arg                       | Passes when                                                                                                  |
+| ---------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name>` is `"completed"` or a skill-declared resolved status (§ Skill bindings) |
+| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                                                                      |
+| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                                                                  |
+| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                                                                         |
+| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts                                               |
 
 `_assert` is the JUDGMENT escape hatch: arithmetic (e.g. the Property-16 total ==
 sum invariant), enum-membership over an artifact's runtime content (e.g.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/dsl/INTERPRETER.md
@@ -380,13 +380,13 @@ heroku-to-aws's own gate contract — phases do NOT load any shared gate file.
 Each entry is a single check plus an `_on_failure` action (see the `_on_error`
 dictionary below). Closed vocabulary of check kinds:
 
-| Check                        | Arg                       | Passes when                                                    |
-| ---------------------------- | ------------------------- | -------------------------------------------------------------- |
-| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name> == "completed"`            |
-| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                        |
-| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                    |
-| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                           |
-| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts |
+| Check                        | Arg                       | Passes when                                                                                                  |
+| ---------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name>` is `"completed"` or a skill-declared resolved status (§ Skill bindings) |
+| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                                                                      |
+| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                                                                  |
+| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                                                                         |
+| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts                                               |
 
 `_assert` is the JUDGMENT escape hatch: arithmetic (e.g. the Property-16 total ==
 sum invariant), enum-membership over an artifact's runtime content (e.g.

--- a/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
@@ -380,13 +380,13 @@ heroku-to-aws's own gate contract — phases do NOT load any shared gate file.
 Each entry is a single check plus an `_on_failure` action (see the `_on_error`
 dictionary below). Closed vocabulary of check kinds:
 
-| Check                        | Arg                       | Passes when                                                    |
-| ---------------------------- | ------------------------- | -------------------------------------------------------------- |
-| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name> == "completed"`            |
-| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                        |
-| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                    |
-| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                           |
-| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts |
+| Check                        | Arg                       | Passes when                                                                                                  |
+| ---------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `_check_phase_completed`     | a phase name              | `.phase-status.json` `phases.<name>` is `"completed"` or a skill-declared resolved status (§ Skill bindings) |
+| `_check_single_active_phase` | `true`                    | at most one core phase is `in_progress`                                                                      |
+| `_check_file_exists`         | filename or `[names]`     | each named file exists in `$MIGRATION_DIR/`                                                                  |
+| `_validate_json`             | filename or `[names]`     | each named file parses as valid JSON                                                                         |
+| `_assert`                    | an opaque prose predicate | you (the interpreter) evaluate the prose against the artifacts                                               |
 
 `_assert` is the JUDGMENT escape hatch: arithmetic (e.g. the Property-16 total ==
 sum invariant), enum-membership over an artifact's runtime content (e.g.


### PR DESCRIPTION
## What

Widen the `_check_phase_completed` check-kind definition in `INTERPRETER.md` so that a phase resolved to a **skill-declared resolved status** (e.g. `skipped`, `not_applicable`) satisfies the gate — not only the literal `"completed"`.

## Why

The check-kind table defined the gate as passing only when `phases.<name> == "completed"` — a strict equality that did not account for the **§ Skill bindings** contract, which states:

> A resolved status satisfies `_requires_phase` and the backbone walk exactly like `completed`; state validation treats declared statuses as recognized.

`_check_phase_completed` is a distinct precondition check-kind (not `_requires_phase`, not the backbone walk), so the strict wording contradicted the bindings contract for any skill that declares resolved statuses.

**Where it bites (agent-advisor, merged in #147):** `clarify` gates on `_check_phase_completed: discover` and `generate` gates on `_check_phase_completed: estimate`. But `discover` is set to `skipped` on the `build_scratch` entry point, and `estimate` is skipped on `migrate`. Under the strict reading, a literal interpreter evaluates `"skipped" == "completed"` → false → `_halt_and_inform` — halting the two most common entry paths. These gates were re-added in #147 to restore failed-predecessor safety; this change makes them behave as intended.

## Safety

- **Failed-predecessor safety is preserved.** A failed phase never becomes a resolved status — on `GATE_FAIL` the interpreter STOPs without updating `.phase-status.json`, so a crashed predecessor stays `in_progress`/`pending`. The widened gate still halts on a failed predecessor while passing on a skipped one.
- **heroku-to-aws is unaffected** — it declares no resolved statuses (takes the default `pending`/`in_progress`/`completed` vocabulary), so the "or a skill-declared resolved status" clause is a no-op for it.

## Changes

- All 3 `INTERPRETER.md` copies updated byte-identically (canonical `skills/shared/dsl/` + the `agent-advisor` and `heroku-to-aws` vendored copies). `dprint fmt` re-aligned the table.

## Testing

- `frontmatter validator`: OK — agent-advisor (10 phases), heroku-to-aws (6 phases)
- `shared:check`: OK (2 vendored trees, byte-identical — verified via md5sum across all 3 copies)
- `dprint check`: clean
- `markdownlint-cli2@0.17`: clean on the changed file

Follow-up to review feedback on #147.
