### PR TITLE
refactor(migrate): rename DSL _kind 'checkpoint' → 'sidebar'

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/SKILL.md
@@ -44,7 +44,7 @@ it reads `.phase-status.json`, determines the current phase, runs each phase's
 `_preconditions` / fragments / `_assemble` / `_postconditions`, advances on `HANDOFF_OK`
 via `_advances_to`, and validates state. The backbone (intake → discover → clarify →
 confirm → design → estimate → generate → migration-plan → poc → complete) and the
-one checkpoint branch (add-capabilities) are derived
+one sidebar branch (add-capabilities) are derived
 from the phase files' frontmatter — they are not restated here.
 
 **Cold start (entry phase).** With no run under `.agent-advisor/` carrying a
@@ -67,8 +67,8 @@ phase (the one carrying `_init: true`). On a warm start, `current_phase` in
 
 ## Routing & gates (orchestration)
 
-Checkpoint placement and conditional backbone routing are orchestration prose owned by
-this file (`INTERPRETER.md` § Skill bindings, § Backbone vs checkpoint).
+Sidebar placement and conditional backbone routing are orchestration prose owned by
+this file (`INTERPRETER.md` § Skill bindings, § Backbone vs sidebar).
 
 **Entry-point routing:**
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/add-capabilities/add-capabilities-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/add-capabilities/add-capabilities-assemble.md
@@ -15,6 +15,6 @@ _produces:
 > within `add-capabilities.md` (Step 5). This unit records the artifact-level
 > contract for the branch: it is the single creator of
 > `capabilities-recommendation.md`, and its postconditions (declared on the
-> phase) are the branch's completion gate. This is a self-contained checkpoint
+> phase) are the branch's completion gate. This is a self-contained sidebar
 > branch — no runtime scoring, no handoff; it ends after writing the file. See
 > `add-capabilities.md` § Step 5 for the document contents.

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/add-capabilities/add-capabilities.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/add-capabilities/add-capabilities.md
@@ -1,7 +1,7 @@
 ---
 _phase: add-capabilities
 _title: "Add Capabilities (branch)"
-_kind: checkpoint
+_kind: sidebar
 _requires_phase: intake
 _trigger: { _when: "intake is done AND entry_point == add_capabilities" }
 _input: workspace

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate-assemble.md
@@ -21,4 +21,4 @@ _produces:
 > the single creator of `diagram.md`, `recommendation.md`, and `mini-brief.md`,
 > and its postconditions (declared on the phase) are the phase's completion gate.
 > See `generate.md` § Steps 2–5 for the section fill order, the freshness footer,
-> and the Step 5.5 recommendation-review checkpoint that must precede any gate.
+> and the Step 5.5 recommendation-review sidebar that must precede any gate.

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate.md
@@ -90,7 +90,7 @@ For Build paths:
   contract: `/invocations` POST + `/ping` GET for AgentCore) + the model id.
   Write scaffolding under `$RUN_DIR/scaffold/`. Keep it minimal — heavy IaC hands off.
 
-## Step 4.5 — Write the mini-brief to `$RUN_DIR/mini-brief.md` (delivered by the Step 5.5 checkpoint)
+## Step 4.5 — Write the mini-brief to `$RUN_DIR/mini-brief.md` (delivered by the Step 5.5 sidebar)
 
 Compose the **mini-brief** — it is the deliverable of the whole advisor flow — and WRITE IT
 TO `$RUN_DIR/mini-brief.md` (a file, not just chat text; Step 5.5 re-reads it):
@@ -119,12 +119,12 @@ non-blocking — NOT the generation itself. So:
 - Never SKIP this step to reach Step 5.5 faster. Step 5.5 checks that the file exists
   (below) — if it is missing, you skipped Step 5 and must come back and do it.
 
-## Step 5.5 — Recommendation review checkpoint (BLOCKING — the user must see and confirm the recommendation before any gate)
+## Step 5.5 — Recommendation review sidebar (BLOCKING — the user must see and confirm the recommendation before any gate)
 
-**Precondition check (do this FIRST, before composing the checkpoint):** confirm
+**Precondition check (do this FIRST, before composing the sidebar):** confirm
 `$RUN_DIR/recommendation-report.html` exists on disk. If it does NOT, Step 5 was skipped —
 go back and run Step 5 now (generate the report + open it) before proceeding. Do not
-present this checkpoint without the report having been generated.
+present this sidebar without the report having been generated.
 
 This is its own turn, separate from every gate. Send ONE message whose body is the **full
 mini-brief pasted from `$RUN_DIR/mini-brief.md`**, followed in the SAME message by an
@@ -137,7 +137,7 @@ AskUserQuestion:
 >
 > - **Looks good — continue** → record the confirmation (below) and proceed to Step 6.
 > - **Explain more first** → answer the user's questions on the recommendation (from
->   recommendation.md / design.json — no new scoring), then re-ask this checkpoint.
+>   recommendation.md / design.json — no new scoring), then re-ask this sidebar.
 > - **Something's off — revisit an answer** → identify which clarify answer changed, update
 >   `answers.json`, re-run scoring, and redo Design → Generate. Do NOT proceed on a
 >   recommendation the user disputes.
@@ -147,12 +147,12 @@ On "Looks good — continue": read-merge-write `.phase-status.json` and set top-
 
 **Mechanical gate rule:** Steps 6 and 7 MUST NOT ask Gate 1 or Gate 2 unless
 `.phase-status.json` has `recommendation_reviewed == true`. If it is absent, you skipped
-this checkpoint — go back and run it. This ordering is not optional and does not collapse
+this sidebar — go back and run it. This ordering is not optional and does not collapse
 into the gate question: the user confirms they have SEEN the recommendation first, and only
 then is asked what to do next. (Resume-safe: if the session breaks after confirmation, the
-flag survives and the checkpoint is not re-asked.)
+flag survives and the sidebar is not re-asked.)
 
-Because the checkpoint delivered the brief, the gates below only need a one-line recap
+Because the sidebar delivered the brief, the gates below only need a one-line recap
 (runtime + deployment model + model), not the full brief.
 
 ## Step 6 — Migration-plan gate (Gate 1)
@@ -210,7 +210,7 @@ Set `phases.generate` = completed (read-merge-write). Then branch:
    >   `references/phases/poc/poc.md` (it asks which POC mode first).
    > - **No** → set `phases.poc = "skipped"`; the advisor flow is complete.
 
-3. **Otherwise** (migrate without a plan): the Step 5.5 checkpoint already delivered the
+3. **Otherwise** (migrate without a plan): the Step 5.5 sidebar already delivered the
    brief; close with a short completion message pointing at `recommendation.md` — the
    advisor flow is complete.
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/migration-plan/migration-plan-gcp-constraints.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/migration-plan/migration-plan-gcp-constraints.md
@@ -48,11 +48,11 @@ Conditional files (load ONLY when condition is true):
 
 All paths above are relative to `$GCP_BASE/references/` (defined in migration-plan.md).
 
-## Feedback checkpoint handling
+## Feedback sidebar handling
 
 gcp-to-aws's `discover.md` and `estimate.md` each offer a feedback prompt after their
 `HANDOFF_OK`. Because this execution runs inside agent-advisor's session, automatically
-choose "skip feedback" (option B) at both checkpoints and continue to the next phase. Do
+choose "skip feedback" (option B) at both sidebars and continue to the next phase. Do
 NOT load `$GCP_BASE/references/phases/feedback/feedback.md`.
 
 ## Hybrid stack warning

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/migration-plan/migration-plan.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/migration-plan/migration-plan.md
@@ -215,7 +215,7 @@ confirm with one keypress.
 Read `references/phases/migration-plan/migration-plan-gcp-constraints.md` and follow everything in it
 for the duration of this phase. It covers: design principles (dev sizing, no human costs,
 re-platform default, BigQuery gate), context loading budget, conditional file table,
-feedback checkpoint auto-skip, and hybrid stack warning.
+feedback sidebar auto-skip, and hybrid stack warning.
 
 ## Step 3 — Announce the transition
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/vendored/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/vendored/dsl/INTERPRETER.md
@@ -24,7 +24,7 @@ defaults. Where a skill declares a binding, the declaration is part of this cont
 | Resolved statuses | `pending` / `in_progress` / `completed`              | additional RESOLVED statuses (e.g. `skipped`, `not_applicable`) for phases its routing marks not-applicable. A resolved status satisfies `_requires_phase` and the backbone walk exactly like `completed`; state validation treats declared statuses as recognized.                                                     |
 | Backbone routing  | every backbone phase runs                            | conditional-routing prose (e.g. "entry-point routing"): rules that resolve a backbone phase WITHOUT running it. When the loop advances into such a phase, mark it per the rule (e.g. `skipped`) and continue along its `_advances_to` in the same step — never leave it `pending` behind a completed successor.         |
 
-Checkpoint PLACEMENT was already the skill's to declare (§ Backbone vs checkpoint);
+Sidebar PLACEMENT was already the skill's to declare (§ Backbone vs sidebar);
 these bindings extend the same principle to naming, state shape, and routing.
 
 ## The interpreter loop
@@ -48,32 +48,32 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    dispatched sub-agent never bootstraps state; it is handed an initialized
    `$MIGRATION_DIR`).
 2. **Determine the current phase (deterministic):**
-   - **Deferred-advance checkpoint resume (mandatory):** If `current_phase` is
+   - **Deferred-advance sidebar resume (mandatory):** If `current_phase` is
      set, `phases.<current_phase>` is already `"completed"`, and a skill-declared
-     checkpoint key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
-     that backbone phase defers advancing `current_phase` until the checkpoint
-     resolves (see SKILL.md checkpoint orchestration — what-if workshop after
+     sidebar key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
+     that backbone phase defers advancing `current_phase` until the sidebar
+     resolves (see SKILL.md sidebar orchestration — what-if workshop after
      Estimate is the canonical case), **do not re-run** the completed backbone
-     phase. Follow SKILL.md: re-present the checkpoint offer if `"pending"`, or
-     load `references/phases/<checkpoint>/<checkpoint>.md` if `"in_progress"`.
-     Explicit phrases that match the checkpoint `_trigger` also enter it when its
+     phase. Follow SKILL.md: re-present the sidebar offer if `"pending"`, or
+     load `references/phases/<sidebar>/<sidebar>.md` if `"in_progress"`.
+     Explicit phrases that match the sidebar `_trigger` also enter it when its
      `_requires_phase` artifacts exist — still without re-running Estimate (or
      whichever predecessor completed).
    - Else if `current_phase` is present in `.phase-status.json`, use it (it is
      authoritative). This is the normal WARM-START path.
    - Otherwise (state exists but has no `current_phase`) walk the backbone in order
-     (see § Backbone vs checkpoint) and pick the FIRST phase whose
+     (see § Backbone vs sidebar) and pick the FIRST phase whose
      `phases.<phase>` is not RESOLVED (`"completed"` or a skill-declared resolved
      status — § Skill bindings). If all backbone phases are resolved, the state is
      the terminal (`complete`). (On a cold start there is no state to read —
      step 1's declared entry phase is used directly.) When the skill gates a later
-     backbone phase on a checkpoint being `"completed"` (e.g. Generate requires
+     backbone phase on a sidebar being `"completed"` (e.g. Generate requires
      `phases.workshop == "completed"`), honor that gate while walking.
 3. **Validate state before proceeding.** See § State-file validation below. STOP
    on any inconsistency rather than guessing.
 4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
    `references/phases/<phase>/<phase>.md`. Load it in full and read its
-   frontmatter first. (Checkpoint resume from step 2 loads the checkpoint
+   frontmatter first. (Sidebar resume from step 2 loads the sidebar
    orchestrator instead — still never as `current_phase`.)
 5. **Run the phase.** Run its `_preconditions` entry gate (§ Gate protocol) in
    THIS (main) window; if it passes, set the phase `in_progress`, then run the
@@ -105,7 +105,7 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    phase not-applicable, resolve it per the routing rule (e.g. set it `skipped`)
    and continue along that phase's `_advances_to` — in the same state write.
 
-Checkpoint phases (§ Backbone vs checkpoint) are OFF this loop — they are entered
+Sidebar phases (§ Backbone vs sidebar) are OFF this loop — they are entered
 by their own `_trigger` at a point the skill's orchestrator (SKILL.md) chooses,
 and return control without changing `current_phase`.
 
@@ -159,19 +159,19 @@ guess) on any of:
 | Key                 | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `_phase` / `_title` | the phase's id and human title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `_kind`             | `backbone` (default when absent) or `checkpoint`. A **backbone** phase is a step on the linear lifecycle (see below). A **checkpoint** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a checkpoint.                                                                                                                                                                                                                                                                  |
-| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a checkpoint, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `_kind`             | `backbone` (default when absent) or `sidebar`. A **backbone** phase is a step on the linear lifecycle (see below). A **sidebar** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a sidebar.                                                                                                                                                                                                                                                                           |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a sidebar, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `_interactive`      | (optional) does the phase's WORK (fragments + assembler) prompt the user? Declare `false` to make the phase a dispatch candidate (required alongside `_exec`); a dispatched worker is file-only and cannot converse. Absent or `true` = the phase runs inline. Interactive phases (clarify, feedback) cannot be dispatched.                                                                                                                                                                                                                      |
 | `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_knowledge`        | the reference/data files the phase consults (`knowledge/**.json` sizing/mapping/pricing tables). Each entry is `{ file, _when? }`; each `file` must resolve on disk. Load a knowledge file ONLY when its `_when` holds — see § `_knowledge`.                                                                                                                                                                                                                                                                                                     |
-| `_trigger`          | (checkpoint phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                            |
+| `_trigger`          | (sidebar phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                               |
 | `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_produces`         | the artifact file(s) the phase writes. Each entry is either a bare filename (unconditional) or an inline conditional map `{ file: <path>, _when: <prose> }` — an artifact produced ONLY when the design predicate holds (e.g. `terraform/eks.tf` only when EKS is in the design). Same `{ file, _when }` shape as `_knowledge`; `_when` is opaque prose the interpreter reads at runtime and CI does NOT evaluate. A trailing-slash `file` (e.g. `kubernetes/`) names a produced DIRECTORY when the unit emits a set of dynamically-named files. |
-| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A sidebar has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `_exec`             | (optional) the phase's EXECUTION MODE. When present, the phase's WORK (fragments + assembler) is dispatched to a fresh isolated sub-agent window with file-only I/O, at the capability tier named by `_exec._agent`; the interpreter keeps the gates, `_init` setup, and the state transition in the MAIN window (see § `_exec`). Requires `_interactive: false`. Absent = the phase runs inline in the main window.                                                                                                                             |
-| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                                                                                                                                                                                                                                                                                     |
+| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and sidebars have none.                                                                                                                                                                                                                                                                                                                        |
 | `_preconditions`    | the entry gate — an ordered list of checks that MUST pass before the phase does any work (predecessor completed, single active phase, inputs present/valid). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                |
 | `_postconditions`   | the completion gate — an ordered list of checks that MUST pass before the phase is marked `completed` and control advances. See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `_forbids_files`    | a glob list of files/dirs this phase MUST NOT create (scope boundary). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -464,7 +464,7 @@ if any path matching a `_forbids_files` glob was written, that is a scope
 violation — treat it as a `_postconditions` failure. This encodes the per-phase
 "do not emit README.md / *.txt / downstream artifacts" boundaries.
 
-### Backbone vs checkpoint phases
+### Backbone vs sidebar phases
 
 A **backbone** phase (the default) is a step on the linear lifecycle: it is
 advanced into by its predecessor's `_advances_to`, and it advances to the next
@@ -477,20 +477,20 @@ the skill's entry phase and carries `_init: true`; the skill names it in SKILL.m
 so a cold start loads it directly rather than scanning to find it (see § The
 interpreter loop, step 1).
 
-A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
+A **sidebar** phase (`_kind: sidebar`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
 opts in), and it returns control to the flow rather than advancing `current_phase`
 — so it has no `_advances_to`, and it never appears as a `current_phase` value.
-WHERE a checkpoint is offered is orchestration prose (see SKILL.md), not part of
+WHERE a sidebar is offered is orchestration prose (see SKILL.md), not part of
 the phase contract.
 
-**Checkpoint status semantics (important):** marking a checkpoint's
-`phases.<checkpoint>` as `"completed"` means the checkpoint was RESOLVED (offered
-and dealt with) — NOT that the user participated. A declined checkpoint is still
+**Sidebar status semantics (important):** marking a sidebar's
+`phases.<sidebar>` as `"completed"` means the sidebar was RESOLVED (offered
+and dealt with) — NOT that the user participated. A declined sidebar is still
 `"completed"` (the lifecycle is resolved, so the migration can terminate cleanly).
 Whether the user actually participated is a SEPARATE signal, carried by the
-presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
-user engaged). Do not conflate "checkpoint resolved" with "user participated."
+presence of the sidebar's artifact (e.g. `feedback.json` exists only if the
+user engaged). Do not conflate "sidebar resolved" with "user participated."
 
 ## Fragment unit keys
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/SKILL.md
@@ -107,7 +107,7 @@ This is the execution controller. After completing each phase, consult this tabl
 
 **Clarify is mandatory:** Do not load `references/phases/design/design.md`, `references/phases/estimate/estimate.md`, or `references/phases/generate/generate.md` unless `$MIGRATION_DIR/.phase-status.json` exists and `phases.clarify` is exactly `"completed"`. A `preferences.json` file alone is **not** sufficient proof that Clarify ran. If the user asks to skip Clarify or jump straight to Design, cost estimate, or artifact generation, refuse briefly, then load `references/phases/clarify/clarify.md` and run Phase 2. There is no exception for "quick" or "obvious" migrations.
 
-**Feedback checkpoints**: Feedback is not a sequential phase — it is offered at two interleaved checkpoints (after Discover and after Estimate). See the **Feedback Checkpoints** section below for details.
+**Feedback sidebars**: Feedback is not a sequential phase — it is offered at two interleaved sidebars (after Discover and after Estimate). See the **Feedback Sidebars** section below for details.
 
 ### Handoff Gate Orchestration (Fail Closed)
 
@@ -131,9 +131,9 @@ When reading `$MIGRATION_DIR/.phase-status.json`, validate before proceeding:
 2. **Invalid JSON**: If `.phase-status.json` fails to parse, STOP. Output: "State file corrupted (invalid JSON). Delete the file and restart the current phase."
 3. **Unrecognized phase**: If `phases` object contains a phase not in {discover, clarify, design, estimate, workshop, generate, feedback}, STOP. Output: "Unrecognized phase: [value]. Valid phases: discover, clarify, design, estimate, workshop, generate, feedback."
 4. **Unrecognized status**: If any `phases.*` value is not in {pending, in_progress, completed}, STOP. Output: "Unrecognized status: [value]. Valid values: pending, in_progress, completed."
-5. **Invalid `current_phase`** (if present): If `current_phase` is not in {discover, clarify, design, estimate, generate, complete}, STOP. Output: "Unrecognized current_phase: [value]. Valid values: discover, clarify, design, estimate, generate, complete." (`workshop` and `feedback` are checkpoints — never `current_phase`.)
+5. **Invalid `current_phase`** (if present): If `current_phase` is not in {discover, clarify, design, estimate, generate, complete}, STOP. Output: "Unrecognized current_phase: [value]. Valid values: discover, clarify, design, estimate, generate, complete." (`workshop` and `feedback` are sidebars — never `current_phase`.)
 6. **Out-of-order completion**: For ordered phases [discover, clarify, design, estimate, generate], if any later phase is `"completed"` while an earlier phase is not `"completed"`, STOP. Output: "Inconsistent phase ordering detected. Reconcile `.phase-status.json` before resuming."
-7. **Multiple active phases**: Across core phases {discover, clarify, design, estimate, generate}, at most one phase may be `"in_progress"`. If >1, STOP. Output: "Multiple phases are in_progress. Keep only one active phase before resuming." (Checkpoint `workshop`/`feedback` may be `in_progress` while estimate is `completed`.)
+7. **Multiple active phases**: Across core phases {discover, clarify, design, estimate, generate}, at most one phase may be `"in_progress"`. If >1, STOP. Output: "Multiple phases are in_progress. Keep only one active phase before resuming." (Sidebar `workshop`/`feedback` may be `in_progress` while estimate is `completed`.)
 
 ---
 
@@ -162,7 +162,7 @@ Migration state lives in `$MIGRATION_DIR` (`.migration/[MMDD-HHMM]/`), created b
 
 **Status values:** `"pending"` → `"in_progress"` → `"completed"`. Never goes backward.
 For core phases (discover, clarify, design, estimate, generate), at most one phase may be `"in_progress"` at any time.
-`workshop` and `feedback` are optional checkpoints (never `current_phase`).
+`workshop` and `feedback` are optional sidebars (never `current_phase`).
 `current_phase` is optional but recommended; when present it is authoritative.
 
 The `.migration/` directory is automatically protected by a `.gitignore` file created in Phase 1.
@@ -208,7 +208,7 @@ Replace `MMDD-HHMM` with the actual migration ID, generate the `last_updated` IS
 | **Clarify**  | Discovery artifacts (`gcp-resource-inventory.json`, `gcp-resource-clusters.json`, `ai-workload-profile.json`, `billing-profile.json` — whichever exist)                  | `preferences.json`, `.phase-status.json` updated                                                                                                                                                                                              | `references/phases/clarify/clarify.md`   |
 | **Design**   | `preferences.json` + discovery artifacts                                                                                                                                 | `aws-design.json` (infra), `aws-design-ai.json` (AI), `aws-design-billing.json` (billing-only)                                                                                                                                                | `references/phases/design/design.md`     |
 | **Estimate** | `aws-design.json` or `aws-design-billing.json` or `aws-design-ai.json`, `preferences.json`                                                                               | `estimation-infra.json` or `estimation-ai.json` or `estimation-billing.json`, `.phase-status.json` updated                                                                                                                                    | `references/phases/estimate/estimate.md` |
-| **Workshop** | Post-Estimate infra artifacts (`gcp-resource-inventory.json`, `preferences.json`, `aws-design.json`, `estimation-infra.json`) — optional checkpoint                      | `scenarios/`, patched `preferences.json` / design / estimate; `.phase-status.json` (`workshop`)                                                                                                                                               | `references/phases/workshop/workshop.md` |
+| **Workshop** | Post-Estimate infra artifacts (`gcp-resource-inventory.json`, `preferences.json`, `aws-design.json`, `estimation-infra.json`) — optional sidebar                         | `scenarios/`, patched `preferences.json` / design / estimate; `.phase-status.json` (`workshop`)                                                                                                                                               | `references/phases/workshop/workshop.md` |
 | **Generate** | `estimation-infra.json` or `estimation-ai.json` or `estimation-billing.json`, `aws-design.json` or `aws-design-billing.json` or `aws-design-ai.json`, `preferences.json` | `generation-infra.json` or `generation-ai.json` or `generation-billing.json` + `terraform/`, `scripts/`, `ai-migration/`, `validation-report.json` (when infra route active), `MIGRATION_GUIDE.md`, `README.md`, `.phase-status.json` updated | `references/phases/generate/generate.md` |
 | **Feedback** | `.phase-status.json` (discover completed minimum), all existing migration artifacts                                                                                      | `feedback.json`, `trace.json`, `.phase-status.json` updated                                                                                                                                                                                   | `references/phases/feedback/feedback.md` |
 
@@ -255,11 +255,11 @@ gcp-to-aws/
 │   │   │   ├── estimate-ai.md                  # AI workload cost analysis
 │   │   │   └── estimate-billing.md             # Billing-only cost analysis
 │   │   ├── workshop/
-│   │   │   ├── workshop.md                     # Checkpoint: optional post-Estimate what-if
+│   │   │   ├── workshop.md                     # Sidebar: optional post-Estimate what-if
 │   │   │   ├── workshop-sheet.md               # Assumption sheet knobs
 │   │   │   ├── workshop-refresh.md             # Patch prefs → Design → Estimate → snapshot
 │   │   │   ├── workshop-compare.md             # Side-by-side scenarios
-│   │   │   └── workshop-assemble.md            # Resolve checkpoint → return to Generate
+│   │   │   └── workshop-assemble.md            # Resolve sidebar → return to Generate
 │   │   ├── generate/
 │   │   │   ├── generate.md                     # Phase 5: Generate orchestrator
 │   │   │   ├── generate-infra.md               # Infrastructure migration plan
@@ -348,7 +348,7 @@ When invoked, the agent **MUST follow this exact sequence**:
 
 7. **Update phase status**: Only after `HANDOFF_OK`. Use the Phase Status Update Protocol (read-merge-write) in the same turn as the phase's final output message.
 
-8. **Feedback checkpoint**: After a phase completes, check if feedback is due (see rules below). This runs **before** advancing to the next phase.
+8. **Feedback sidebar**: After a phase completes, check if feedback is due (see rules below). This runs **before** advancing to the next phase.
 
    - **After Discover** (if `phases.feedback` is `"pending"`): Output to user:
      "Would you like to share quick feedback (5 optional questions + anonymized usage data) to help improve this tool? Your data never includes resource names, file paths, or account IDs.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/design-ref-agentic-to-agentcore.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/design-ref-agentic-to-agentcore.md
@@ -63,7 +63,7 @@ Map the detected `agentic_profile.framework` and `orchestration_pattern` to Stra
 | `graph.add_conditional_edges("a", router_fn)` | `builder.add_edge("a", "b", condition=fn)` | Condition function receives state, returns bool.                                            |
 | `graph.set_entry_point("start")`              | `builder.set_entry_point("start")`         | Direct mapping.                                                                             |
 | `graph.compile()`                             | `builder.build()`                          | Returns executable graph.                                                                   |
-| `MemorySaver` / checkpointing                 | `SessionManager` with S3 or file backend   | Different API but same concept — durable state across invocations.                          |
+| `MemorySaver` / sidebaring                    | `SessionManager` with S3 or file backend   | Different API but same concept — durable state across invocations.                          |
 
 **Key difference:** LangGraph nodes are arbitrary functions; Strands graph nodes are Agents. For non-agent nodes (pure data transformation), wrap in a minimal Agent with a focused system prompt and no tools.
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/estimate/estimate.md
@@ -146,7 +146,7 @@ After outer-run `HANDOFF_OK`, use the Phase Status Update Protocol
 1. Set `phases.estimate` to `"completed"`
 2. Ensure `phases.workshop` exists (seed `"pending"` if missing)
 3. **Do not** set `current_phase` to `"generate"` yet — leave `current_phase` at
-   `"estimate"` until the workshop checkpoint is resolved (entered then exited,
+   `"estimate"` until the workshop sidebar is resolved (entered then exited,
    or declined)
 4. Offer the what-if workshop below (infra route only)
 
@@ -167,7 +167,7 @@ and compare priced scenarios without re-discovering inventory.
 - **A** → Load `references/phases/workshop/workshop.md`. Keep
   `current_phase: estimate`; set `phases.workshop` → `"in_progress"`.
 - **B** → Mark `phases.workshop` → `"completed"`. Set `current_phase` →
-  `"generate"`. Continue with Feedback/Generate checkpoints in `SKILL.md`.
+  `"generate"`. Continue with Feedback/Generate sidebars in `SKILL.md`.
 
 For AI-only / billing-only runs (no infra inventory), skip the workshop offer and
 set `phases.workshop` → `"completed"`, `current_phase` → `"generate"`.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/feedback/feedback.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/feedback/feedback.md
@@ -105,4 +105,4 @@ Use the Phase Status Update Protocol (read-merge-write) to update `.phase-status
 
 Output to user: "Thank you for helping improve this tool."
 
-After feedback completes, return control to the workflow execution in SKILL.md. The calling checkpoint determines whether to advance to the next phase or end the migration.
+After feedback completes, return control to the workflow execution in SKILL.md. The calling sidebar determines whether to advance to the next phase or end the migration.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/workshop/workshop-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/workshop/workshop-assemble.md
@@ -1,6 +1,6 @@
-# Workshop — Assemble (checkpoint resolve)
+# Workshop — Assemble (sidebar resolve)
 
-> Marks the workshop checkpoint resolved and returns control to the backbone.
+> Marks the workshop sidebar resolved and returns control to the backbone.
 > Does **not** set `current_phase` to `workshop`.
 
 ## When exiting to Generate

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/workshop/workshop.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/workshop/workshop.md
@@ -1,6 +1,6 @@
-# Phase: What-If Workshop (Optional Checkpoint)
+# Phase: What-If Workshop (Optional Sidebar)
 
-> **Checkpoint**, not a backbone step — same class as Feedback. Entered only when
+> **Sidebar**, not a backbone step — same class as Feedback. Entered only when
 > the user opts in after Estimate (or says what if / reprice / workshop mode /
 > compare scenarios). Never becomes `current_phase`. Returns control to the
 > Estimate→Generate flow. Contract:
@@ -57,4 +57,4 @@ file wins — fix this table.
 
 When Estimate offer **[B] Proceed toward Generate** is chosen, mark
 `phases.workshop` `"completed"` (resolved/declined), set `current_phase` to
-`"generate"`, then continue Feedback/Generate checkpoints in `SKILL.md`.
+`"generate"`, then continue Feedback/Generate sidebars in `SKILL.md`.

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/schema-phase-status.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/schema-phase-status.md
@@ -30,6 +30,6 @@ Lightweight phase tracking. This is the SINGLE source of truth for the `.phase-s
 
 - Phase status progresses: `"pending"` → `"in_progress"` → `"completed"`. Never goes backward.
 - Valid phase names: discover, clarify, design, estimate, workshop, generate, feedback.
-- `workshop` is an optional **checkpoint** (like feedback): never appears as
+- `workshop` is an optional **sidebar** (like feedback): never appears as
   `current_phase`; `"completed"` means resolved (entered or declined).
 - `migration_id` matches the `$MIGRATION_DIR` folder name (e.g., `0226-1430`).

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/vendored/workshop/workshop-invariants.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/vendored/workshop/workshop-invariants.md
@@ -23,9 +23,9 @@
   "Inventory changed since baseline. Re-run Discover before workshop reprice."
   on any difference.
 
-## 2. Checkpoint state semantics
+## 2. Sidebar state semantics
 
-- The workshop is a checkpoint: it NEVER becomes `current_phase`. Entry sets
+- The workshop is a sidebar: it NEVER becomes `current_phase`. Entry sets
   `phases.workshop: "in_progress"`; `current_phase` stays at `"estimate"`
   until exit/decline.
 - Exit to Generate (assembler): `phases.workshop: "completed"`,

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/SKILL.md
@@ -17,7 +17,7 @@ description: "Migrate workloads from Heroku to AWS. Triggers on: migrate from He
 - **Flat resource model**: Heroku resources are organized per-app without dependency graphs or clustering. No topological sorting, typed edges, or cluster formation logic. Resources are processed as a flat list in input order.
 - **Deterministic mappings**: Core services use fixed lookup tables (Dyno Type Table, Postgres Plan Table, Redis Plan Table, Kafka Plan Table). Common add-ons use the Fast-Path Table. Unknown add-ons hit the specialist gate.
 - **DMS has Heroku constraints**: AWS DMS cannot perform continuous replication (CDC) with Heroku Postgres because Heroku does not grant the REPLICATION role. DMS is for one-time bulk migration with a cutover window only. The skill must surface this constraint when DMS is selected.
-- **What-if after Estimate**: After costs are computed, SAs can enter an optional what-if workshop checkpoint (`references/phases/workshop/workshop.md`) to change region, HA, compute target, or CPU architecture (x86 vs Graviton), refresh Design + Estimate, and compare up to 5 priced scenarios — without re-running Discover. Region dollar deltas need awspricing MCP; without it, rates stay us-east-1-cache-based. Workshop arch defaults to **x86_64** here (EB tables historically x86-first); vercel-to-aws defaults workshop arch to **arm64**.
+- **What-if after Estimate**: After costs are computed, SAs can enter an optional what-if workshop sidebar (`references/phases/workshop/workshop.md`) to change region, HA, compute target, or CPU architecture (x86 vs Graviton), refresh Design + Estimate, and compare up to 5 priced scenarios — without re-running Discover. Region dollar deltas need awspricing MCP; without it, rates stay us-east-1-cache-based. Workshop arch defaults to **x86_64** here (EB tables historically x86-first); vercel-to-aws defaults workshop arch to **arm64**.
 
 ---
 
@@ -74,7 +74,7 @@ skill's entry phase (the one carrying `_init: true`). The interpreter loads THIS
 phase directly; it does not scan every phase's frontmatter to discover the root.
 All subsequent phases are reached by following each phase's `_advances_to`. On a
 warm start, `current_phase` in `.phase-status.json` is authoritative **except**
-when deferred-advance checkpoint resume applies (`INTERPRETER.md` § The
+when deferred-advance sidebar resume applies (`INTERPRETER.md` § The
 interpreter loop step 2 — Estimate completed + `workshop` pending/in_progress
 must not re-run Estimate).
 
@@ -128,11 +128,11 @@ heroku-to-aws/
 │   │   ├── estimate/
 │   │   │   └── estimate.md                     # Phase 4: Cost projection
 │   │   ├── workshop/
-│   │   │   ├── workshop.md                     # Checkpoint: optional post-Estimate what-if
+│   │   │   ├── workshop.md                     # Sidebar: optional post-Estimate what-if
 │   │   │   ├── workshop-sheet.md               # Assumption sheet knobs
 │   │   │   ├── workshop-refresh.md             # Patch prefs → Design → Estimate → snapshot
 │   │   │   ├── workshop-compare.md             # Side-by-side scenarios
-│   │   │   └── workshop-assemble.md            # Resolve checkpoint → return to Generate
+│   │   │   └── workshop-assemble.md            # Resolve sidebar → return to Generate
 │   │   ├── generate/
 │   │   │   ├── generate.md                     # Phase 5: Generate orchestrator
 │   │   │   ├── generate-terraform.md           # Terraform configurations
@@ -176,25 +176,25 @@ heroku-to-aws/
 - **Cost currency**: USD
 - **Timeline assumption**: 2-16 weeks depending on migration complexity — small (2-6 weeks), medium (6-12 weeks), large (12-18 weeks). Complexity tiers are classified per `references/vendored/estimate/complexity-tiers.json`.
 
-## Feedback & Sharing Checkpoints
+## Feedback & Sharing Sidebars
 
 The interpreter loop (`INTERPRETER.md` § The interpreter loop) drives phase
 sequencing, gates, and state. This section defines only the heroku-specific
-checkpoint orchestration: WHERE the optional `workshop` and `feedback`
-checkpoints are offered (placement is orchestration prose, not part of the phase
-contract). Both are `_kind: checkpoint` — off-backbone, trigger-entered, never
+sidebar orchestration: WHERE the optional `workshop` and `feedback`
+sidebars are offered (placement is orchestration prose, not part of the phase
+contract). Both are `_kind: sidebar` — off-backbone, trigger-entered, never
 `current_phase`.
 
 > **Plan-share links are GATED OFF.** The share landing page
 > (`https://aws.amazon.com/startups/migrate/connect`) is not yet live (404). Do
-> NOT offer, generate, or present a share link at any checkpoint. The share-link
+> NOT offer, generate, or present a share link at any sidebar. The share-link
 > spec is preserved in `references/phases/feedback/feedback-collect.md` Step 3
 > (itself gated) for when the page ships; restoring the share prompts here is the
 > un-gating change.
 
 - **After Discover**: No prompt. Proceed directly to Clarify.
 
-- **After Estimate**: First offer the what-if workshop checkpoint per
+- **After Estimate**: First offer the what-if workshop sidebar per
   `estimate-assemble.md` (Enter workshop / Proceed toward Generate). Outer
   Estimate keeps `current_phase: estimate` until workshop is resolved (entered
   then exited via `workshop-assemble.md`, or declined). If the user enters

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate-assemble.md
@@ -116,8 +116,8 @@ After outer-run `HANDOFF_OK` (not an inner workshop reprice):
 1. Mark `phases.estimate` → `"completed"`.
 2. Ensure `phases.workshop` exists (seed `"pending"` if the key is missing).
 3. **Do not** set `current_phase` to `"generate"` yet — leave `current_phase` at
-   `"estimate"` until the workshop checkpoint is resolved (entered then exited, or
-   declined). This matches checkpoint semantics: workshop never owns
+   `"estimate"` until the workshop sidebar is resolved (entered then exited, or
+   declined). This matches sidebar semantics: workshop never owns
    `current_phase`, and mid-workshop fixtures correctly stay on `estimate`.
 4. Offer the what-if workshop below.
 
@@ -137,12 +137,12 @@ and compare priced scenarios without re-discovering inventory.
 [B] Proceed toward Generate
 ```
 
-- **A** → Load `references/phases/workshop/workshop.md` (checkpoint) and follow it
+- **A** → Load `references/phases/workshop/workshop.md` (sidebar) and follow it
   (baseline capture if `scenarios/` missing, then the sheet). Keep
   `current_phase: estimate`; set `phases.workshop` → `"in_progress"`.
 - **B** → Mark `phases.workshop` → `"completed"` (resolved/declined — no
   `scenarios/` required). Set `current_phase` → `"generate"`. Continue with the
-  Feedback/Generate checkpoints in `SKILL.md`.
+  Feedback/Generate sidebars in `SKILL.md`.
 
 On first workshop entry after this Estimate, `workshop-refresh.md` baseline
 capture snapshots the current artifacts as `scenario-001` before any edits.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/estimate/estimate.md
@@ -76,8 +76,8 @@ Composed of a cost-engine fragment + one assembler (declared in the frontmatter
 and evaluates the `_knowledge` guards to load the pricing/defaults/tier data. The
 fragment selects the pricing mode and computes the financial picture; the assembler
 writes the final artifact, runs the completion gate, presents the summary, and
-**offers the optional what-if workshop checkpoint**
-(`references/phases/workshop/workshop.md`, `_kind: checkpoint`) before Generate —
+**offers the optional what-if workshop sidebar**
+(`references/phases/workshop/workshop.md`, `_kind: sidebar`) before Generate —
 read each unit file for its own contract. Outer Estimate defers
 `current_phase → generate` until workshop is resolved (see `estimate-assemble.md`).
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback-collect.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback-collect.md
@@ -95,7 +95,7 @@ Answer the 5 quick questions, then paste the trace into the
 > generated link would dead-end for the user. Skip directly to Step 4 and leave
 > `share_link_presented: false` in `feedback.json`. The spec below is preserved
 > so the feature can be re-enabled by removing this gate (here and in SKILL.md
-> § Feedback & Sharing Checkpoints) once the page is live and verified.
+> § Feedback & Sharing Sidebars) once the page is live and verified.
 
 Required artifacts: `preferences.json`, `estimation-infra.json`. If missing, output "Cannot generate share link — required artifacts not found." and skip to Step 4.
 
@@ -118,7 +118,7 @@ Required artifacts: `preferences.json`, `estimation-infra.json`. If missing, out
   "resource_names": [{ "type": "<resource_type>", "name": "<heroku_app>" }],
   "workload_types": ["infra"],
   "spend_band": "<under-10k|10k-50k|50k-100k|over-100k|unknown>",
-  "share_checkpoint": "<after_estimate|after_generate>",
+  "share_sidebar": "<after_estimate|after_generate>",
   "phases_completed": ["<completed phases>"]
 }
 ```
@@ -146,12 +146,12 @@ Write `$MIGRATION_DIR/feedback.json`:
   "trace_included": true,
   "share_link_presented": false,
   "share_link_generated_at": null,
-  "share_checkpoint": null
+  "share_sidebar": null
 }
 ```
 
 - If trace failed: `"trace_included": false`
-- If share link generated: `"share_link_presented": true`, populate `share_link_generated_at` and `share_checkpoint`
+- If share link generated: `"share_link_presented": true`, populate `share_link_generated_at` and `share_sidebar`
 
 When `feedback.json` (and `trace.json`, if `trace_included`) are written, control passes to
 the assembler (`feedback-assemble.md`) for the output gate and phase completion.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/feedback/feedback.md
@@ -1,10 +1,10 @@
 ---
 _phase: feedback
 _title: "Feedback (Optional)"
-_kind: checkpoint
+_kind: sidebar
 _requires_phase: discover
 _input: "**/.phase-status.json"
-_trigger: { _when: "the user opts in to providing feedback at a feedback checkpoint" }
+_trigger: { _when: "the user opts in to providing feedback at a feedback sidebar" }
 _fragments:
   - _id: collect
     _trigger: { _always: true }
@@ -41,7 +41,7 @@ Collects user feedback. Reuses the shared feedback infrastructure (trace builder
 - **feedback-collect.md** → the collection work: detect IDE/version, build the anonymized trace, present the survey link, and write `feedback.json` (share-link generation is gated off in its Step 3).
 - **feedback-assemble.md** → the assembler: output gate, phase-status update, and marking the migration complete.
 
-This is an **optional checkpoint phase** (`_kind: checkpoint`), not a step on the linear backbone. It is entered only when the user opts in at a feedback checkpoint (its `_trigger`), and it returns control to the flow rather than advancing a `current_phase` — so it has no `_advances_to`. SKILL.md decides where the feedback checkpoint is offered (see the Feedback & Sharing Checkpoints section there).
+This is an **optional sidebar phase** (`_kind: sidebar`), not a step on the linear backbone. It is entered only when the user opts in at a feedback sidebar (its `_trigger`), and it returns control to the flow rather than advancing a `current_phase` — so it has no `_advances_to`. SKILL.md decides where the feedback sidebar is offered (see the Feedback & Sharing Sidebars section there).
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/workshop/workshop-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/workshop/workshop-assemble.md
@@ -9,10 +9,10 @@ _produces:
   - scenarios/index.json
 ---
 
-# Workshop — Assemble (checkpoint resolve)
+# Workshop — Assemble (sidebar resolve)
 
-> Marks the workshop checkpoint resolved and returns control to the backbone.
-> Does **not** set `current_phase` to `workshop` (forbidden for checkpoints).
+> Marks the workshop sidebar resolved and returns control to the backbone.
+> Does **not** set `current_phase` to `workshop` (forbidden for sidebars).
 
 ## When exiting to Generate
 
@@ -20,7 +20,7 @@ _produces:
 2. Ensure `scenarios/index.json` exists (baseline-only is enough if user entered
    then exited without Apply).
 3. Update `.phase-status.json`:
-   - `phases.workshop` → `"completed"` (checkpoint resolved — participated)
+   - `phases.workshop` → `"completed"` (sidebar resolved — participated)
    - `current_phase` → `"generate"`
    - `last_updated` → now
 4. Emit:

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/workshop/workshop.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/workshop/workshop.md
@@ -1,7 +1,7 @@
 ---
 _phase: workshop
 _title: "What-If Workshop (Optional)"
-_kind: checkpoint
+_kind: sidebar
 _requires_phase: estimate
 _trigger:
   {
@@ -45,9 +45,9 @@ _postconditions:
     _on_failure: _warn_and_skip
 ---
 
-# Phase: What-If Workshop (Checkpoint)
+# Phase: What-If Workshop (Sidebar)
 
-> **Checkpoint** (`_kind: checkpoint`), not a backbone step — same class as
+> **Sidebar** (`_kind: sidebar`), not a backbone step — same class as
 > `feedback`. Entered only when its `_trigger` fires; has **no** `_advances_to`;
 > never becomes `current_phase`. Returns control to the Estimate→Generate flow.
 > Contract: `references/shared/schema-workshop-scenarios.md`.
@@ -60,7 +60,7 @@ _postconditions:
 2. If `phases.generate` (or later) is `completed`, apply Estimate `_re_entry_guard`
    confirm → `reset_downstream_to_pending` before refreshing.
 3. Set `phases.workshop` to `"in_progress"` (do not change `current_phase` —
-   checkpoints never own it). Prefer leaving `current_phase` at `estimate` until
+   sidebars never own it). Prefer leaving `current_phase` at `estimate` until
    the user exits workshop to Generate (see `estimate-assemble.md` deferred
    advance).
 
@@ -72,7 +72,7 @@ _postconditions:
    - **Apply & reprice** → `workshop-refresh.md` (inner Design/Estimate) →
      `workshop-compare.md`
    - **Compare scenarios** → `workshop-compare.md`
-   - **Exit to Generate** → `workshop-assemble.md` (resolve checkpoint) → return
+   - **Exit to Generate** → `workshop-assemble.md` (resolve sidebar) → return
    - **Exit to full Clarify** → danger; Clarify re-entry only on explicit confirm
 
 ## Hard rules
@@ -95,5 +95,5 @@ file wins — fix this table.
 
 When Estimate offer **[B] Proceed toward Generate** is chosen, do not enter this
 phase's fragments — mark `phases.workshop` `"completed"` (resolved/declined) per
-checkpoint semantics in `INTERPRETER.md`, then advance `current_phase` to
+sidebar semantics in `INTERPRETER.md`, then advance `current_phase` to
 `generate`.

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/dsl/INTERPRETER.md
@@ -24,7 +24,7 @@ defaults. Where a skill declares a binding, the declaration is part of this cont
 | Resolved statuses | `pending` / `in_progress` / `completed`              | additional RESOLVED statuses (e.g. `skipped`, `not_applicable`) for phases its routing marks not-applicable. A resolved status satisfies `_requires_phase` and the backbone walk exactly like `completed`; state validation treats declared statuses as recognized.                                                     |
 | Backbone routing  | every backbone phase runs                            | conditional-routing prose (e.g. "entry-point routing"): rules that resolve a backbone phase WITHOUT running it. When the loop advances into such a phase, mark it per the rule (e.g. `skipped`) and continue along its `_advances_to` in the same step — never leave it `pending` behind a completed successor.         |
 
-Checkpoint PLACEMENT was already the skill's to declare (§ Backbone vs checkpoint);
+Sidebar PLACEMENT was already the skill's to declare (§ Backbone vs sidebar);
 these bindings extend the same principle to naming, state shape, and routing.
 
 ## The interpreter loop
@@ -48,32 +48,32 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    dispatched sub-agent never bootstraps state; it is handed an initialized
    `$MIGRATION_DIR`).
 2. **Determine the current phase (deterministic):**
-   - **Deferred-advance checkpoint resume (mandatory):** If `current_phase` is
+   - **Deferred-advance sidebar resume (mandatory):** If `current_phase` is
      set, `phases.<current_phase>` is already `"completed"`, and a skill-declared
-     checkpoint key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
-     that backbone phase defers advancing `current_phase` until the checkpoint
-     resolves (see SKILL.md checkpoint orchestration — what-if workshop after
+     sidebar key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
+     that backbone phase defers advancing `current_phase` until the sidebar
+     resolves (see SKILL.md sidebar orchestration — what-if workshop after
      Estimate is the canonical case), **do not re-run** the completed backbone
-     phase. Follow SKILL.md: re-present the checkpoint offer if `"pending"`, or
-     load `references/phases/<checkpoint>/<checkpoint>.md` if `"in_progress"`.
-     Explicit phrases that match the checkpoint `_trigger` also enter it when its
+     phase. Follow SKILL.md: re-present the sidebar offer if `"pending"`, or
+     load `references/phases/<sidebar>/<sidebar>.md` if `"in_progress"`.
+     Explicit phrases that match the sidebar `_trigger` also enter it when its
      `_requires_phase` artifacts exist — still without re-running Estimate (or
      whichever predecessor completed).
    - Else if `current_phase` is present in `.phase-status.json`, use it (it is
      authoritative). This is the normal WARM-START path.
    - Otherwise (state exists but has no `current_phase`) walk the backbone in order
-     (see § Backbone vs checkpoint) and pick the FIRST phase whose
+     (see § Backbone vs sidebar) and pick the FIRST phase whose
      `phases.<phase>` is not RESOLVED (`"completed"` or a skill-declared resolved
      status — § Skill bindings). If all backbone phases are resolved, the state is
      the terminal (`complete`). (On a cold start there is no state to read —
      step 1's declared entry phase is used directly.) When the skill gates a later
-     backbone phase on a checkpoint being `"completed"` (e.g. Generate requires
+     backbone phase on a sidebar being `"completed"` (e.g. Generate requires
      `phases.workshop == "completed"`), honor that gate while walking.
 3. **Validate state before proceeding.** See § State-file validation below. STOP
    on any inconsistency rather than guessing.
 4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
    `references/phases/<phase>/<phase>.md`. Load it in full and read its
-   frontmatter first. (Checkpoint resume from step 2 loads the checkpoint
+   frontmatter first. (Sidebar resume from step 2 loads the sidebar
    orchestrator instead — still never as `current_phase`.)
 5. **Run the phase.** Run its `_preconditions` entry gate (§ Gate protocol) in
    THIS (main) window; if it passes, set the phase `in_progress`, then run the
@@ -105,7 +105,7 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    phase not-applicable, resolve it per the routing rule (e.g. set it `skipped`)
    and continue along that phase's `_advances_to` — in the same state write.
 
-Checkpoint phases (§ Backbone vs checkpoint) are OFF this loop — they are entered
+Sidebar phases (§ Backbone vs sidebar) are OFF this loop — they are entered
 by their own `_trigger` at a point the skill's orchestrator (SKILL.md) chooses,
 and return control without changing `current_phase`.
 
@@ -159,19 +159,19 @@ guess) on any of:
 | Key                 | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `_phase` / `_title` | the phase's id and human title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `_kind`             | `backbone` (default when absent) or `checkpoint`. A **backbone** phase is a step on the linear lifecycle (see below). A **checkpoint** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a checkpoint.                                                                                                                                                                                                                                                                  |
-| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a checkpoint, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `_kind`             | `backbone` (default when absent) or `sidebar`. A **backbone** phase is a step on the linear lifecycle (see below). A **sidebar** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a sidebar.                                                                                                                                                                                                                                                                           |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a sidebar, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `_interactive`      | (optional) does the phase's WORK (fragments + assembler) prompt the user? Declare `false` to make the phase a dispatch candidate (required alongside `_exec`); a dispatched worker is file-only and cannot converse. Absent or `true` = the phase runs inline. Interactive phases (clarify, feedback) cannot be dispatched.                                                                                                                                                                                                                      |
 | `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_knowledge`        | the reference/data files the phase consults (`knowledge/**.json` sizing/mapping/pricing tables). Each entry is `{ file, _when? }`; each `file` must resolve on disk. Load a knowledge file ONLY when its `_when` holds — see § `_knowledge`.                                                                                                                                                                                                                                                                                                     |
-| `_trigger`          | (checkpoint phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                            |
+| `_trigger`          | (sidebar phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                               |
 | `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_produces`         | the artifact file(s) the phase writes. Each entry is either a bare filename (unconditional) or an inline conditional map `{ file: <path>, _when: <prose> }` — an artifact produced ONLY when the design predicate holds (e.g. `terraform/eks.tf` only when EKS is in the design). Same `{ file, _when }` shape as `_knowledge`; `_when` is opaque prose the interpreter reads at runtime and CI does NOT evaluate. A trailing-slash `file` (e.g. `kubernetes/`) names a produced DIRECTORY when the unit emits a set of dynamically-named files. |
-| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A sidebar has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `_exec`             | (optional) the phase's EXECUTION MODE. When present, the phase's WORK (fragments + assembler) is dispatched to a fresh isolated sub-agent window with file-only I/O, at the capability tier named by `_exec._agent`; the interpreter keeps the gates, `_init` setup, and the state transition in the MAIN window (see § `_exec`). Requires `_interactive: false`. Absent = the phase runs inline in the main window.                                                                                                                             |
-| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                                                                                                                                                                                                                                                                                     |
+| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and sidebars have none.                                                                                                                                                                                                                                                                                                                        |
 | `_preconditions`    | the entry gate — an ordered list of checks that MUST pass before the phase does any work (predecessor completed, single active phase, inputs present/valid). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                |
 | `_postconditions`   | the completion gate — an ordered list of checks that MUST pass before the phase is marked `completed` and control advances. See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `_forbids_files`    | a glob list of files/dirs this phase MUST NOT create (scope boundary). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -464,7 +464,7 @@ if any path matching a `_forbids_files` glob was written, that is a scope
 violation — treat it as a `_postconditions` failure. This encodes the per-phase
 "do not emit README.md / *.txt / downstream artifacts" boundaries.
 
-### Backbone vs checkpoint phases
+### Backbone vs sidebar phases
 
 A **backbone** phase (the default) is a step on the linear lifecycle: it is
 advanced into by its predecessor's `_advances_to`, and it advances to the next
@@ -477,20 +477,20 @@ the skill's entry phase and carries `_init: true`; the skill names it in SKILL.m
 so a cold start loads it directly rather than scanning to find it (see § The
 interpreter loop, step 1).
 
-A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
+A **sidebar** phase (`_kind: sidebar`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
 opts in), and it returns control to the flow rather than advancing `current_phase`
 — so it has no `_advances_to`, and it never appears as a `current_phase` value.
-WHERE a checkpoint is offered is orchestration prose (see SKILL.md), not part of
+WHERE a sidebar is offered is orchestration prose (see SKILL.md), not part of
 the phase contract.
 
-**Checkpoint status semantics (important):** marking a checkpoint's
-`phases.<checkpoint>` as `"completed"` means the checkpoint was RESOLVED (offered
-and dealt with) — NOT that the user participated. A declined checkpoint is still
+**Sidebar status semantics (important):** marking a sidebar's
+`phases.<sidebar>` as `"completed"` means the sidebar was RESOLVED (offered
+and dealt with) — NOT that the user participated. A declined sidebar is still
 `"completed"` (the lifecycle is resolved, so the migration can terminate cleanly).
 Whether the user actually participated is a SEPARATE signal, carried by the
-presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
-user engaged). Do not conflate "checkpoint resolved" with "user participated."
+presence of the sidebar's artifact (e.g. `feedback.json` exists only if the
+user engaged). Do not conflate "sidebar resolved" with "user participated."
 
 ## Fragment unit keys
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/state/phase-status.schema.json
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/state/phase-status.schema.json
@@ -22,7 +22,7 @@
     },
     "phases": {
       "type": "object",
-      "description": "One entry per phase the skill declares (backbone and checkpoint). Keys are the skill's phase names — this schema does not enumerate them.",
+      "description": "One entry per phase the skill declares (backbone and sidebar). Keys are the skill's phase names — this schema does not enumerate them.",
       "minProperties": 1,
       "additionalProperties": {
         "type": "string",

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/workshop/workshop-invariants.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/vendored/workshop/workshop-invariants.md
@@ -23,9 +23,9 @@
   "Inventory changed since baseline. Re-run Discover before workshop reprice."
   on any difference.
 
-## 2. Checkpoint state semantics
+## 2. Sidebar state semantics
 
-- The workshop is a checkpoint: it NEVER becomes `current_phase`. Entry sets
+- The workshop is a sidebar: it NEVER becomes `current_phase`. Entry sets
   `phases.workshop: "in_progress"`; `current_phase` stays at `"estimate"`
   until exit/decline.
 - Exit to Generate (assembler): `phases.workshop: "completed"`,

--- a/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/SKILL.md
@@ -431,7 +431,7 @@ table, not the block location, decides where execution resumes.
   line 'partial_coverage: <completed>/<total> cases (throttled)'`. Then C4 runs normally.
 - **Abort** → stop; the files stay on disk for a later C0 resume.
 
-### C4 — Checkpoint (two gates) + persist decisions
+### C4 — Sidebar (two gates) + persist decisions
 
 **Gate (a) — Quality go/no-go.** Read `$PHASE_DIR/eval.json`. The threshold is
 **pass rate >= 0.9 AND `source_baseline_quality != 'poor'`** (with `no_golden_cases: true`
@@ -504,7 +504,7 @@ mandatory stop between phases:
    one phase's definition into context at once.
 2. Follow it start-to-finish; write and validate the same phase-result file.
 3. STOP. Report the phase outcome (validator CONTROL line + one-line summary) and ask the
-   user to confirm before loading the next phase's definition. This checkpoint is mandatory:
+   user to confirm before loading the next phase's definition. This sidebar is mandatory:
    it is the context-pressure release valve, and the phase-result file means nothing is lost
    if the user continues in a fresh session instead.
 

--- a/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/references/helpers/behavior-delta-detection/behavior-delta-detection.md
+++ b/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/references/helpers/behavior-delta-detection/behavior-delta-detection.md
@@ -51,7 +51,7 @@ For `resolution_kind: "impl_path"`, omit `option_set_id` (the schema enforces th
 
 ## How rewriter uses this
 
-For each `behavior_deltas` entry where `user_visible == true` AND `resolution_kind == "ux_choice"`, the rewriter does NOT ask the user — the user already chose at the orchestration checkpoint. The orchestration checkpoint presents the **option set** specified by that delta's `option_set_id` to the user; the rewriter receives the chosen resolution in its `Confirmed behavior-delta decisions` context and applies it. Each option set is fixed and ordered — do not reorder, do not invent new options. The option sets below define what the checkpoint offers.
+For each `behavior_deltas` entry where `user_visible == true` AND `resolution_kind == "ux_choice"`, the rewriter does NOT ask the user — the user already chose at the orchestration sidebar. The orchestration sidebar presents the **option set** specified by that delta's `option_set_id` to the user; the rewriter receives the chosen resolution in its `Confirmed behavior-delta decisions` context and applies it. Each option set is fixed and ordered — do not reorder, do not invent new options. The option sets below define what the sidebar offers.
 
 ### Option set: `range_narrowed`
 
@@ -112,12 +112,12 @@ After asking the user (or applying an `impl_path` default, or running the fallba
 
 ## Ambiguous user answers
 
-The orchestration checkpoint (not the rewriter) presents the options to the user and resolves ambiguity. If the user's answer does NOT map to one of the numbered options (they typed something freeform that doesn't match an option label or its semantic), the checkpoint:
+The orchestration sidebar (not the rewriter) presents the options to the user and resolves ambiguity. If the user's answer does NOT map to one of the numbered options (they typed something freeform that doesn't match an option label or its semantic), the sidebar:
 
 1. Asks one clarifying follow-up that restates the options.
 2. If the second answer is still ambiguous, falls back to **option 1 (Recommended)** for that delta.
 
-The rewriter then receives — and records — whatever resolution the checkpoint produced:
+The rewriter then receives — and records — whatever resolution the sidebar produced:
 
 - `resolution_chosen` = the chosen option's enum value (e.g., `"range_narrowed_1"`)
 - `source` = `"ambiguous_user_answer_recommended"` when the (Recommended) fallback fired

--- a/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/shared/dsl/INTERPRETER.md
@@ -24,7 +24,7 @@ defaults. Where a skill declares a binding, the declaration is part of this cont
 | Resolved statuses | `pending` / `in_progress` / `completed`              | additional RESOLVED statuses (e.g. `skipped`, `not_applicable`) for phases its routing marks not-applicable. A resolved status satisfies `_requires_phase` and the backbone walk exactly like `completed`; state validation treats declared statuses as recognized.                                                     |
 | Backbone routing  | every backbone phase runs                            | conditional-routing prose (e.g. "entry-point routing"): rules that resolve a backbone phase WITHOUT running it. When the loop advances into such a phase, mark it per the rule (e.g. `skipped`) and continue along its `_advances_to` in the same step — never leave it `pending` behind a completed successor.         |
 
-Checkpoint PLACEMENT was already the skill's to declare (§ Backbone vs checkpoint);
+Sidebar PLACEMENT was already the skill's to declare (§ Backbone vs sidebar);
 these bindings extend the same principle to naming, state shape, and routing.
 
 ## The interpreter loop
@@ -48,32 +48,32 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    dispatched sub-agent never bootstraps state; it is handed an initialized
    `$MIGRATION_DIR`).
 2. **Determine the current phase (deterministic):**
-   - **Deferred-advance checkpoint resume (mandatory):** If `current_phase` is
+   - **Deferred-advance sidebar resume (mandatory):** If `current_phase` is
      set, `phases.<current_phase>` is already `"completed"`, and a skill-declared
-     checkpoint key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
-     that backbone phase defers advancing `current_phase` until the checkpoint
-     resolves (see SKILL.md checkpoint orchestration — what-if workshop after
+     sidebar key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
+     that backbone phase defers advancing `current_phase` until the sidebar
+     resolves (see SKILL.md sidebar orchestration — what-if workshop after
      Estimate is the canonical case), **do not re-run** the completed backbone
-     phase. Follow SKILL.md: re-present the checkpoint offer if `"pending"`, or
-     load `references/phases/<checkpoint>/<checkpoint>.md` if `"in_progress"`.
-     Explicit phrases that match the checkpoint `_trigger` also enter it when its
+     phase. Follow SKILL.md: re-present the sidebar offer if `"pending"`, or
+     load `references/phases/<sidebar>/<sidebar>.md` if `"in_progress"`.
+     Explicit phrases that match the sidebar `_trigger` also enter it when its
      `_requires_phase` artifacts exist — still without re-running Estimate (or
      whichever predecessor completed).
    - Else if `current_phase` is present in `.phase-status.json`, use it (it is
      authoritative). This is the normal WARM-START path.
    - Otherwise (state exists but has no `current_phase`) walk the backbone in order
-     (see § Backbone vs checkpoint) and pick the FIRST phase whose
+     (see § Backbone vs sidebar) and pick the FIRST phase whose
      `phases.<phase>` is not RESOLVED (`"completed"` or a skill-declared resolved
      status — § Skill bindings). If all backbone phases are resolved, the state is
      the terminal (`complete`). (On a cold start there is no state to read —
      step 1's declared entry phase is used directly.) When the skill gates a later
-     backbone phase on a checkpoint being `"completed"` (e.g. Generate requires
+     backbone phase on a sidebar being `"completed"` (e.g. Generate requires
      `phases.workshop == "completed"`), honor that gate while walking.
 3. **Validate state before proceeding.** See § State-file validation below. STOP
    on any inconsistency rather than guessing.
 4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
    `references/phases/<phase>/<phase>.md`. Load it in full and read its
-   frontmatter first. (Checkpoint resume from step 2 loads the checkpoint
+   frontmatter first. (Sidebar resume from step 2 loads the sidebar
    orchestrator instead — still never as `current_phase`.)
 5. **Run the phase.** Run its `_preconditions` entry gate (§ Gate protocol) in
    THIS (main) window; if it passes, set the phase `in_progress`, then run the
@@ -105,7 +105,7 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    phase not-applicable, resolve it per the routing rule (e.g. set it `skipped`)
    and continue along that phase's `_advances_to` — in the same state write.
 
-Checkpoint phases (§ Backbone vs checkpoint) are OFF this loop — they are entered
+Sidebar phases (§ Backbone vs sidebar) are OFF this loop — they are entered
 by their own `_trigger` at a point the skill's orchestrator (SKILL.md) chooses,
 and return control without changing `current_phase`.
 
@@ -159,19 +159,19 @@ guess) on any of:
 | Key                 | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `_phase` / `_title` | the phase's id and human title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `_kind`             | `backbone` (default when absent) or `checkpoint`. A **backbone** phase is a step on the linear lifecycle (see below). A **checkpoint** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a checkpoint.                                                                                                                                                                                                                                                                  |
-| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a checkpoint, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `_kind`             | `backbone` (default when absent) or `sidebar`. A **backbone** phase is a step on the linear lifecycle (see below). A **sidebar** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a sidebar.                                                                                                                                                                                                                                                                           |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a sidebar, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `_interactive`      | (optional) does the phase's WORK (fragments + assembler) prompt the user? Declare `false` to make the phase a dispatch candidate (required alongside `_exec`); a dispatched worker is file-only and cannot converse. Absent or `true` = the phase runs inline. Interactive phases (clarify, feedback) cannot be dispatched.                                                                                                                                                                                                                      |
 | `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_knowledge`        | the reference/data files the phase consults (`knowledge/**.json` sizing/mapping/pricing tables). Each entry is `{ file, _when? }`; each `file` must resolve on disk. Load a knowledge file ONLY when its `_when` holds — see § `_knowledge`.                                                                                                                                                                                                                                                                                                     |
-| `_trigger`          | (checkpoint phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                            |
+| `_trigger`          | (sidebar phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                               |
 | `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_produces`         | the artifact file(s) the phase writes. Each entry is either a bare filename (unconditional) or an inline conditional map `{ file: <path>, _when: <prose> }` — an artifact produced ONLY when the design predicate holds (e.g. `terraform/eks.tf` only when EKS is in the design). Same `{ file, _when }` shape as `_knowledge`; `_when` is opaque prose the interpreter reads at runtime and CI does NOT evaluate. A trailing-slash `file` (e.g. `kubernetes/`) names a produced DIRECTORY when the unit emits a set of dynamically-named files. |
-| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A sidebar has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `_exec`             | (optional) the phase's EXECUTION MODE. When present, the phase's WORK (fragments + assembler) is dispatched to a fresh isolated sub-agent window with file-only I/O, at the capability tier named by `_exec._agent`; the interpreter keeps the gates, `_init` setup, and the state transition in the MAIN window (see § `_exec`). Requires `_interactive: false`. Absent = the phase runs inline in the main window.                                                                                                                             |
-| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                                                                                                                                                                                                                                                                                     |
+| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and sidebars have none.                                                                                                                                                                                                                                                                                                                        |
 | `_preconditions`    | the entry gate — an ordered list of checks that MUST pass before the phase does any work (predecessor completed, single active phase, inputs present/valid). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                |
 | `_postconditions`   | the completion gate — an ordered list of checks that MUST pass before the phase is marked `completed` and control advances. See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `_forbids_files`    | a glob list of files/dirs this phase MUST NOT create (scope boundary). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -464,7 +464,7 @@ if any path matching a `_forbids_files` glob was written, that is a scope
 violation — treat it as a `_postconditions` failure. This encodes the per-phase
 "do not emit README.md / *.txt / downstream artifacts" boundaries.
 
-### Backbone vs checkpoint phases
+### Backbone vs sidebar phases
 
 A **backbone** phase (the default) is a step on the linear lifecycle: it is
 advanced into by its predecessor's `_advances_to`, and it advances to the next
@@ -477,20 +477,20 @@ the skill's entry phase and carries `_init: true`; the skill names it in SKILL.m
 so a cold start loads it directly rather than scanning to find it (see § The
 interpreter loop, step 1).
 
-A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
+A **sidebar** phase (`_kind: sidebar`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
 opts in), and it returns control to the flow rather than advancing `current_phase`
 — so it has no `_advances_to`, and it never appears as a `current_phase` value.
-WHERE a checkpoint is offered is orchestration prose (see SKILL.md), not part of
+WHERE a sidebar is offered is orchestration prose (see SKILL.md), not part of
 the phase contract.
 
-**Checkpoint status semantics (important):** marking a checkpoint's
-`phases.<checkpoint>` as `"completed"` means the checkpoint was RESOLVED (offered
-and dealt with) — NOT that the user participated. A declined checkpoint is still
+**Sidebar status semantics (important):** marking a sidebar's
+`phases.<sidebar>` as `"completed"` means the sidebar was RESOLVED (offered
+and dealt with) — NOT that the user participated. A declined sidebar is still
 `"completed"` (the lifecycle is resolved, so the migration can terminate cleanly).
 Whether the user actually participated is a SEPARATE signal, carried by the
-presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
-user engaged). Do not conflate "checkpoint resolved" with "user participated."
+presence of the sidebar's artifact (e.g. `feedback.json` exists only if the
+user engaged). Do not conflate "sidebar resolved" with "user participated."
 
 ## Fragment unit keys
 

--- a/migrate/plugins/migration-to-aws/skills/shared/state/phase-status.schema.json
+++ b/migrate/plugins/migration-to-aws/skills/shared/state/phase-status.schema.json
@@ -22,7 +22,7 @@
     },
     "phases": {
       "type": "object",
-      "description": "One entry per phase the skill declares (backbone and checkpoint). Keys are the skill's phase names — this schema does not enumerate them.",
+      "description": "One entry per phase the skill declares (backbone and sidebar). Keys are the skill's phase names — this schema does not enumerate them.",
       "minProperties": 1,
       "additionalProperties": {
         "type": "string",

--- a/migrate/plugins/migration-to-aws/skills/shared/workshop/workshop-invariants.md
+++ b/migrate/plugins/migration-to-aws/skills/shared/workshop/workshop-invariants.md
@@ -23,9 +23,9 @@
   "Inventory changed since baseline. Re-run Discover before workshop reprice."
   on any difference.
 
-## 2. Checkpoint state semantics
+## 2. Sidebar state semantics
 
-- The workshop is a checkpoint: it NEVER becomes `current_phase`. Entry sets
+- The workshop is a sidebar: it NEVER becomes `current_phase`. Entry sets
   `phases.workshop: "in_progress"`; `current_phase` stays at `"estimate"`
   until exit/decline.
 - Exit to Generate (assembler): `phases.workshop: "completed"`,

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/SKILL.md
@@ -16,7 +16,7 @@ description: "Assess and plan migrations from Vercel to AWS for Next.js applicat
 - **Precedence, not judgment.** The Recommendation Engine evaluates a fixed, ordered set of rules and stops at the first that fires (`references/shared/vercel-recommendation-engine.md`). It is not a model deciding case-by-case; every recommendation is traceable to exactly one rule.
 - **Never a dialect mismatch.** SST/OpenNext is used ONLY for the Next.js app surface under Outcome A (and Outcome C's A-shaped backend recursion never triggers it — that recursion always emits Terraform). Outcome B and Outcome C never emit SST. This exception is documented inline wherever it appears, not left implicit.
 - **Report is a rendering, not the deliverable's completion.** A failed report validation does not mean the assessment failed — the underlying findings and recommendation remain valid. The Report phase retries up to 2 additional times on validation failure, then surfaces the incomplete report and stops; it never presents a stub as done.
-- **What-if after Estimate:** After costs are computed, SAs can enter a what-if workshop checkpoint (`references/phases/workshop/workshop.md`) to change traffic shape, outcome (A/B/C/stay), region, Balanced Multi-AZ, or CPU architecture, refresh Recommend when needed + Estimate, and compare up to 5 priced scenarios — without re-running Discover. Workshop arch defaults to **arm64** here (Graviton-first per `graviton.md`); heroku-to-aws defaults workshop arch to **x86_64**.
+- **What-if after Estimate:** After costs are computed, SAs can enter a what-if workshop sidebar (`references/phases/workshop/workshop.md`) to change traffic shape, outcome (A/B/C/stay), region, Balanced Multi-AZ, or CPU architecture, refresh Recommend when needed + Estimate, and compare up to 5 priced scenarios — without re-running Discover. Workshop arch defaults to **arm64** here (Graviton-first per `graviton.md`); heroku-to-aws defaults workshop arch to **x86_64**.
 
 ---
 
@@ -74,14 +74,14 @@ skill's entry phase (the one carrying `_init: true`). The interpreter loads THIS
 phase directly; it does not scan every phase's frontmatter to discover the root.
 All subsequent phases are reached by following each phase's `_advances_to`. On a
 warm start, `current_phase` in `.phase-status.json` is authoritative **except**
-when deferred-advance checkpoint resume applies (`INTERPRETER.md` § The
+when deferred-advance sidebar resume applies (`INTERPRETER.md` § The
 interpreter loop step 2 — Estimate completed + `workshop` pending/in_progress
 must not re-run Estimate).
 
 **Backbone:** `prescan` -> `discover` -> `clarify` -> `recommend` -> `estimate` -> `generate` -> `report` -> `complete`.
 
 > **Breaking change:** Assessments started before this version (with `scaffold`
-> as a checkpoint in `.phase-status.json`) are NOT compatible with the new
+> as a sidebar in `.phase-status.json`) are NOT compatible with the new
 > backbone. Re-run from `prescan` to benefit from the estimate and generate phases.
 
 **Clarify is mandatory.** Do not skip Clarify or jump straight to Recommend even if
@@ -184,11 +184,11 @@ vercel-to-aws/
 │   │   │   ├── estimate-cost-engine.md         # Three-tier AWS cost projection vs. Vercel spend
 │   │   │   └── estimate-assemble.md            # estimation-infra.json
 │   │   ├── workshop/
-│   │   │   ├── workshop.md                     # Checkpoint: optional post-Estimate what-if
+│   │   │   ├── workshop.md                     # Sidebar: optional post-Estimate what-if
 │   │   │   ├── workshop-sheet.md               # Assumption sheet knobs
 │   │   │   ├── workshop-refresh.md             # Patch → Recommend? → Estimate → snapshot
 │   │   │   ├── workshop-compare.md             # Side-by-side scenarios
-│   │   │   └── workshop-assemble.md            # Resolve checkpoint → return to Generate
+│   │   │   └── workshop-assemble.md            # Resolve sidebar → return to Generate
 │   │   ├── generate/
 │   │   │   ├── generate.md                     # Phase 6: Generate orchestrator
 │   │   │   ├── generate-baseline.md            # baseline.tf (GuardDuty, CloudTrail, IMDSv2, budget alerts)
@@ -250,8 +250,8 @@ vercel-to-aws/
 - **Cost currency**: USD, always labeled "estimated monthly cost/savings"
 - **Execution target**: OpenNext v3 (swappable for the verified Adapter-API AWS adapter behind an interface once it reaches GA)
 
-**What-if workshop checkpoint:** After Estimate, offer the optional `workshop`
-checkpoint (`_kind: checkpoint`, never `current_phase`) per
+**What-if workshop sidebar:** After Estimate, offer the optional `workshop`
+sidebar (`_kind: sidebar`, never `current_phase`) per
 `estimate-assemble.md`. Outer Estimate keeps `current_phase: estimate` until
 workshop is resolved (exited via `workshop-assemble.md` or declined).
 

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/discover/discover.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/discover/discover.md
@@ -253,7 +253,7 @@ FORBIDDEN — Do NOT include ANY of:
 - Filtering or reframing Pre-Flight Check findings by outcome (that is Phase 5 —
   Report's job; this phase computes unconditionally)
 - Clarify questions (that is Phase 3 — Clarify)
-- Terraform/SST generation (that is the Scaffold checkpoint)
+- Terraform/SST generation (that is the Scaffold sidebar)
 
 **Your ONLY job: Discover signals, compute Coupling Score and all 10 Pre-Flight
 Checks unconditionally. Nothing else.**

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/estimate/estimate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/estimate/estimate-assemble.md
@@ -170,7 +170,7 @@ After outer-run `HANDOFF_OK`:
 1. Mark `phases.estimate` → `"completed"`.
 2. Ensure `phases.workshop` exists (seed `"pending"` if missing).
 3. **Do not** set `current_phase` to `"generate"` yet — leave `current_phase` at
-   `"estimate"` until the workshop checkpoint is resolved (entered then exited,
+   `"estimate"` until the workshop sidebar is resolved (entered then exited,
    or declined).
 4. Offer the what-if workshop below.
 
@@ -221,7 +221,7 @@ change traffic shape, outcome (A/B/C), region, Multi-AZ, or CPU architecture
 [B] Proceed toward Generate
 ```
 
-- **A** → Load `references/phases/workshop/workshop.md` (checkpoint; baseline
+- **A** → Load `references/phases/workshop/workshop.md` (sidebar; baseline
   capture if `scenarios/` missing, then the sheet). Keep
   `current_phase: estimate`; set `phases.workshop` → `"in_progress"`.
 - **B** → Mark `phases.workshop` → `"completed"` (resolved/declined). Set

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/recommend/recommend.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/recommend/recommend.md
@@ -129,7 +129,7 @@ FORBIDDEN — Do NOT include ANY of:
 
 - Report rendering or outcome-based filtering of Pre-Flight Checks (that is
   Phase 5 — Report's job)
-- Scaffold/Terraform/SST generation (that is the Scaffold checkpoint's job)
+- Scaffold/Terraform/SST generation (that is the Scaffold sidebar's job)
 - Recommending EKS or Amplify as an `outcome` value (see the engine's own
   explicit prohibition)
 

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/report/report.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/report/report.md
@@ -111,7 +111,7 @@ message.
 Output to the founder: "Your assessment report is ready:
 `$MIGRATION_DIR/migration-report.html`. [one-sentence recommendation summary].
 Would you like a scaffold generated for this outcome?" (See `SKILL.md` §
-Scaffold Checkpoint for the exact prompt.)
+Scaffold Sidebar for the exact prompt.)
 
 ---
 
@@ -131,7 +131,7 @@ Scaffold Checkpoint for the exact prompt.)
 
 FORBIDDEN — Do NOT include ANY of:
 
-- Terraform/SST generation (that is the Scaffold checkpoint's job)
+- Terraform/SST generation (that is the Scaffold sidebar's job)
 - Re-running the Recommendation Engine or Discover's fragments
 - Presenting a validator-did-not-run result as a pass
 

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/workshop/workshop-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/workshop/workshop-assemble.md
@@ -9,10 +9,10 @@ _produces:
   - scenarios/index.json
 ---
 
-# Workshop — Assemble (checkpoint resolve)
+# Workshop — Assemble (sidebar resolve)
 
-> Marks the workshop checkpoint resolved and returns control to the backbone.
-> Does **not** set `current_phase` to `workshop` (forbidden for checkpoints).
+> Marks the workshop sidebar resolved and returns control to the backbone.
+> Does **not** set `current_phase` to `workshop` (forbidden for sidebars).
 
 ## When exiting to Generate
 
@@ -21,7 +21,7 @@ _produces:
 2. Ensure `scenarios/index.json` exists (baseline-only is enough if user entered
    then exited without Apply).
 3. Update `.phase-status.json`:
-   - `phases.workshop` → `"completed"` (checkpoint resolved — participated)
+   - `phases.workshop` → `"completed"` (sidebar resolved — participated)
    - `current_phase` → `"generate"`
    - `last_updated` → now
 4. Emit:

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/workshop/workshop.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/phases/workshop/workshop.md
@@ -1,7 +1,7 @@
 ---
 _phase: workshop
 _title: "What-If Workshop (Optional)"
-_kind: checkpoint
+_kind: sidebar
 _requires_phase: estimate
 _trigger:
   {
@@ -45,9 +45,9 @@ _postconditions:
     _on_failure: _warn_and_skip
 ---
 
-# Phase: What-If Workshop (Checkpoint)
+# Phase: What-If Workshop (Sidebar)
 
-> **Checkpoint** (`_kind: checkpoint`), not a backbone step — same class as
+> **Sidebar** (`_kind: sidebar`), not a backbone step — same class as
 > optional off-spine phases elsewhere. Entered only when its `_trigger` fires;
 > has **no** `_advances_to`; never becomes `current_phase`. Returns control to
 > the Estimate→Generate flow. Contract:
@@ -62,7 +62,7 @@ _postconditions:
 2. If `phases.generate` (or later) is `completed`, apply Estimate/Generate
    re-entry confirm → reset downstream to pending before refreshing.
 3. Set `phases.workshop` to `"in_progress"` (do not change `current_phase` —
-   checkpoints never own it). Prefer leaving `current_phase` at `estimate`
+   sidebars never own it). Prefer leaving `current_phase` at `estimate`
    until the user exits workshop to Generate (see `estimate-assemble.md`
    deferred advance).
 
@@ -74,7 +74,7 @@ _postconditions:
    - **Apply & reprice** → `workshop-refresh.md` (inner Recommend?/Estimate) →
      `workshop-compare.md`
    - **Compare scenarios** → `workshop-compare.md`
-   - **Exit to Generate** → `workshop-assemble.md` (resolve checkpoint) → return
+   - **Exit to Generate** → `workshop-assemble.md` (resolve sidebar) → return
    - **Exit to full Clarify** → danger; Clarify re-entry only on explicit confirm
 
 ## Hard rules
@@ -97,5 +97,5 @@ file wins — fix this table.
 
 When Estimate offer **[B] Proceed toward Generate** is chosen, do not enter this
 phase's fragments — mark `phases.workshop` `"completed"` (resolved/declined) per
-checkpoint semantics in `INTERPRETER.md`, then advance `current_phase` to
+sidebar semantics in `INTERPRETER.md`, then advance `current_phase` to
 `generate`.

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/shared/graviton.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/shared/graviton.md
@@ -16,7 +16,7 @@ _shared: graviton
 
 ## The Default
 
-Every compute resource this skill's Scaffold checkpoint emits (the SST/OpenNext
+Every compute resource this skill's Scaffold sidebar emits (the SST/OpenNext
 server function, the Terraform-only backend Lambda under Outcome C's A-shaped
 mode, the ECS Fargate task under Outcome B or C's B-shaped mode, and the
 EventBridge-Scheduler-triggered Lambda invoker for a detected Cron peripheral)
@@ -70,9 +70,9 @@ precondition.
   consequence to word carefully today; this constraint exists so a future v2
   Estimate phase inherits the same discipline gcp-to-aws's Graviton feature
   applies, not because v1 currently renders such a figure.
-- **Does not touch the report.** This is a Scaffold-checkpoint-only decision.
+- **Does not touch the report.** This is a Scaffold-sidebar-only decision.
   `report-render.md` never mentions architecture/Graviton — Scaffold is
-  optional and off-backbone; a founder who declines the checkpoint never sees
+  optional and off-backbone; a founder who declines the sidebar never sees
   this default at all.
 
 ## Terraform / SST Mechanics (Verified — Do Not Guess a Different Shape)

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/dsl/INTERPRETER.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/dsl/INTERPRETER.md
@@ -24,7 +24,7 @@ defaults. Where a skill declares a binding, the declaration is part of this cont
 | Resolved statuses | `pending` / `in_progress` / `completed`              | additional RESOLVED statuses (e.g. `skipped`, `not_applicable`) for phases its routing marks not-applicable. A resolved status satisfies `_requires_phase` and the backbone walk exactly like `completed`; state validation treats declared statuses as recognized.                                                     |
 | Backbone routing  | every backbone phase runs                            | conditional-routing prose (e.g. "entry-point routing"): rules that resolve a backbone phase WITHOUT running it. When the loop advances into such a phase, mark it per the rule (e.g. `skipped`) and continue along its `_advances_to` in the same step — never leave it `pending` behind a completed successor.         |
 
-Checkpoint PLACEMENT was already the skill's to declare (§ Backbone vs checkpoint);
+Sidebar PLACEMENT was already the skill's to declare (§ Backbone vs sidebar);
 these bindings extend the same principle to naming, state shape, and routing.
 
 ## The interpreter loop
@@ -48,32 +48,32 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    dispatched sub-agent never bootstraps state; it is handed an initialized
    `$MIGRATION_DIR`).
 2. **Determine the current phase (deterministic):**
-   - **Deferred-advance checkpoint resume (mandatory):** If `current_phase` is
+   - **Deferred-advance sidebar resume (mandatory):** If `current_phase` is
      set, `phases.<current_phase>` is already `"completed"`, and a skill-declared
-     checkpoint key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
-     that backbone phase defers advancing `current_phase` until the checkpoint
-     resolves (see SKILL.md checkpoint orchestration — what-if workshop after
+     sidebar key (e.g. `workshop`) is `"pending"` or `"in_progress"` because
+     that backbone phase defers advancing `current_phase` until the sidebar
+     resolves (see SKILL.md sidebar orchestration — what-if workshop after
      Estimate is the canonical case), **do not re-run** the completed backbone
-     phase. Follow SKILL.md: re-present the checkpoint offer if `"pending"`, or
-     load `references/phases/<checkpoint>/<checkpoint>.md` if `"in_progress"`.
-     Explicit phrases that match the checkpoint `_trigger` also enter it when its
+     phase. Follow SKILL.md: re-present the sidebar offer if `"pending"`, or
+     load `references/phases/<sidebar>/<sidebar>.md` if `"in_progress"`.
+     Explicit phrases that match the sidebar `_trigger` also enter it when its
      `_requires_phase` artifacts exist — still without re-running Estimate (or
      whichever predecessor completed).
    - Else if `current_phase` is present in `.phase-status.json`, use it (it is
      authoritative). This is the normal WARM-START path.
    - Otherwise (state exists but has no `current_phase`) walk the backbone in order
-     (see § Backbone vs checkpoint) and pick the FIRST phase whose
+     (see § Backbone vs sidebar) and pick the FIRST phase whose
      `phases.<phase>` is not RESOLVED (`"completed"` or a skill-declared resolved
      status — § Skill bindings). If all backbone phases are resolved, the state is
      the terminal (`complete`). (On a cold start there is no state to read —
      step 1's declared entry phase is used directly.) When the skill gates a later
-     backbone phase on a checkpoint being `"completed"` (e.g. Generate requires
+     backbone phase on a sidebar being `"completed"` (e.g. Generate requires
      `phases.workshop == "completed"`), honor that gate while walking.
 3. **Validate state before proceeding.** See § State-file validation below. STOP
    on any inconsistency rather than guessing.
 4. **Load the phase orchestrator.** A phase's orchestrator file is, by convention,
    `references/phases/<phase>/<phase>.md`. Load it in full and read its
-   frontmatter first. (Checkpoint resume from step 2 loads the checkpoint
+   frontmatter first. (Sidebar resume from step 2 loads the sidebar
    orchestrator instead — still never as `current_phase`.)
 5. **Run the phase.** Run its `_preconditions` entry gate (§ Gate protocol) in
    THIS (main) window; if it passes, set the phase `in_progress`, then run the
@@ -105,7 +105,7 @@ are all DERIVED from the phase files' frontmatter (never hardcoded here).
    phase not-applicable, resolve it per the routing rule (e.g. set it `skipped`)
    and continue along that phase's `_advances_to` — in the same state write.
 
-Checkpoint phases (§ Backbone vs checkpoint) are OFF this loop — they are entered
+Sidebar phases (§ Backbone vs sidebar) are OFF this loop — they are entered
 by their own `_trigger` at a point the skill's orchestrator (SKILL.md) chooses,
 and return control without changing `current_phase`.
 
@@ -159,19 +159,19 @@ guess) on any of:
 | Key                 | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `_phase` / `_title` | the phase's id and human title                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `_kind`             | `backbone` (default when absent) or `checkpoint`. A **backbone** phase is a step on the linear lifecycle (see below). A **checkpoint** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a checkpoint.                                                                                                                                                                                                                                                                  |
-| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a checkpoint, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `_kind`             | `backbone` (default when absent) or `sidebar`. A **backbone** phase is a step on the linear lifecycle (see below). A **sidebar** phase is off-backbone — optional, entered by a phase-level `_trigger`, returns control instead of advancing. `feedback` is a sidebar.                                                                                                                                                                                                                                                                           |
+| `_requires_phase`   | the phase that must be `completed` before this one may start (omitted for the first phase; on a sidebar, its minimum precondition)                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `_init`             | `true` only on the first phase — this phase establishes migration state before its fragments run (see below)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `_interactive`      | (optional) does the phase's WORK (fragments + assembler) prompt the user? Declare `false` to make the phase a dispatch candidate (required alongside `_exec`); a dispatched worker is file-only and cannot converse. Absent or `true` = the phase runs inline. Interactive phases (clarify, feedback) cannot be dispatched.                                                                                                                                                                                                                      |
 | `_input`            | what the phase reads — prior-phase artifacts, or `workspace` for the initial file scan                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_knowledge`        | the reference/data files the phase consults (`knowledge/**.json` sizing/mapping/pricing tables). Each entry is `{ file, _when? }`; each `file` must resolve on disk. Load a knowledge file ONLY when its `_when` holds — see § `_knowledge`.                                                                                                                                                                                                                                                                                                     |
-| `_trigger`          | (checkpoint phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                            |
+| `_trigger`          | (sidebar phases only) how the phase is ENTERED — same forms as a fragment `_trigger` (below). `feedback` uses `_when: "user opts in"`. Backbone phases have no phase-level `_trigger` (they are advanced INTO via a predecessor's `_advances_to`).                                                                                                                                                                                                                                                                                               |
 | `_fragments`        | the ordered units of work the phase composes. Each is `{ _id, _trigger, _file }`. Load + follow a fragment's `_file` when its `_trigger` fires                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `_assemble`         | the single terminal unit (`{ _file }`) that combines the fragment outputs into the phase's artifact(s)                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `_produces`         | the artifact file(s) the phase writes. Each entry is either a bare filename (unconditional) or an inline conditional map `{ file: <path>, _when: <prose> }` — an artifact produced ONLY when the design predicate holds (e.g. `terraform/eks.tf` only when EKS is in the design). Same `{ file, _when }` shape as `_knowledge`; `_when` is opaque prose the interpreter reads at runtime and CI does NOT evaluate. A trailing-slash `file` (e.g. `kubernetes/`) names a produced DIRECTORY when the unit emits a set of dynamically-named files. |
-| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A checkpoint has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `_advances_to`      | (backbone phases only) the phase that runs next on success — or a terminal (`complete`). A sidebar has NO `_advances_to`.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `_exec`             | (optional) the phase's EXECUTION MODE. When present, the phase's WORK (fragments + assembler) is dispatched to a fresh isolated sub-agent window with file-only I/O, at the capability tier named by `_exec._agent`; the interpreter keeps the gates, `_init` setup, and the state transition in the MAIN window (see § `_exec`). Requires `_interactive: false`. Absent = the phase runs inline in the main window.                                                                                                                             |
-| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and checkpoints have none.                                                                                                                                                                                                                                                                                                                     |
+| `_re_entry_guard`   | (backbone phases with a downstream only) the stale-downstream guard — STOP re-running this phase if its downstream phase already completed, unless the user confirms (see below). Terminal phases and sidebars have none.                                                                                                                                                                                                                                                                                                                        |
 | `_preconditions`    | the entry gate — an ordered list of checks that MUST pass before the phase does any work (predecessor completed, single active phase, inputs present/valid). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                |
 | `_postconditions`   | the completion gate — an ordered list of checks that MUST pass before the phase is marked `completed` and control advances. See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `_forbids_files`    | a glob list of files/dirs this phase MUST NOT create (scope boundary). See § Gate protocol.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -464,7 +464,7 @@ if any path matching a `_forbids_files` glob was written, that is a scope
 violation — treat it as a `_postconditions` failure. This encodes the per-phase
 "do not emit README.md / *.txt / downstream artifacts" boundaries.
 
-### Backbone vs checkpoint phases
+### Backbone vs sidebar phases
 
 A **backbone** phase (the default) is a step on the linear lifecycle: it is
 advanced into by its predecessor's `_advances_to`, and it advances to the next
@@ -477,20 +477,20 @@ the skill's entry phase and carries `_init: true`; the skill names it in SKILL.m
 so a cold start loads it directly rather than scanning to find it (see § The
 interpreter loop, step 1).
 
-A **checkpoint** phase (`_kind: checkpoint`, e.g. `feedback`) is OFF the backbone.
+A **sidebar** phase (`_kind: sidebar`, e.g. `feedback`) is OFF the backbone.
 It is optional, entered only when its phase-level `_trigger` fires (e.g. the user
 opts in), and it returns control to the flow rather than advancing `current_phase`
 — so it has no `_advances_to`, and it never appears as a `current_phase` value.
-WHERE a checkpoint is offered is orchestration prose (see SKILL.md), not part of
+WHERE a sidebar is offered is orchestration prose (see SKILL.md), not part of
 the phase contract.
 
-**Checkpoint status semantics (important):** marking a checkpoint's
-`phases.<checkpoint>` as `"completed"` means the checkpoint was RESOLVED (offered
-and dealt with) — NOT that the user participated. A declined checkpoint is still
+**Sidebar status semantics (important):** marking a sidebar's
+`phases.<sidebar>` as `"completed"` means the sidebar was RESOLVED (offered
+and dealt with) — NOT that the user participated. A declined sidebar is still
 `"completed"` (the lifecycle is resolved, so the migration can terminate cleanly).
 Whether the user actually participated is a SEPARATE signal, carried by the
-presence of the checkpoint's artifact (e.g. `feedback.json` exists only if the
-user engaged). Do not conflate "checkpoint resolved" with "user participated."
+presence of the sidebar's artifact (e.g. `feedback.json` exists only if the
+user engaged). Do not conflate "sidebar resolved" with "user participated."
 
 ## Fragment unit keys
 

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/state/phase-status.schema.json
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/state/phase-status.schema.json
@@ -22,7 +22,7 @@
     },
     "phases": {
       "type": "object",
-      "description": "One entry per phase the skill declares (backbone and checkpoint). Keys are the skill's phase names — this schema does not enumerate them.",
+      "description": "One entry per phase the skill declares (backbone and sidebar). Keys are the skill's phase names — this schema does not enumerate them.",
       "minProperties": 1,
       "additionalProperties": {
         "type": "string",

--- a/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/workshop/workshop-invariants.md
+++ b/migrate/plugins/migration-to-aws/skills/vercel-to-aws/references/vendored/workshop/workshop-invariants.md
@@ -23,9 +23,9 @@
   "Inventory changed since baseline. Re-run Discover before workshop reprice."
   on any difference.
 
-## 2. Checkpoint state semantics
+## 2. Sidebar state semantics
 
-- The workshop is a checkpoint: it NEVER becomes `current_phase`. Entry sets
+- The workshop is a sidebar: it NEVER becomes `current_phase`. Entry sets
   `phases.workshop: "in_progress"`; `current_phase` stays at `"estimate"`
   until exit/decline.
 - Exit to Generate (assembler): `phases.workshop: "completed"`,

--- a/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
+++ b/migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts
@@ -204,7 +204,7 @@ _contributes:
     );
   });
 
-  // ---- backbone / checkpoint + chain-consistency ----
+  // ---- backbone / sidebar + chain-consistency ----
 
   // A fully-declared 2-phase backbone (discover -> clarify -> complete) plus a
   // feedback CHECKPOINT (off-backbone, trigger-entered). Minimal but complete.
@@ -252,32 +252,32 @@ _produces:
       ...phase('clarify', '_requires_phase: discover\n_advances_to: complete'),
       ...phase(
         'feedback',
-        '_kind: checkpoint\n_requires_phase: discover\n_trigger: { _when: "user opts in" }',
+        '_kind: sidebar\n_requires_phase: discover\n_trigger: { _when: "user opts in" }',
       ),
     };
   }
 
-  it('accepts a valid backbone + a checkpoint phase', () => {
+  it('accepts a valid backbone + a sidebar phase', () => {
     const findings = validateFixture(chainSkill());
     assert.equal(findings.length, 0, `expected clean, got: ${JSON.stringify(findings)}`);
   });
 
-  it('rejects a checkpoint phase that declares _advances_to (must be off-backbone)', () => {
+  it('rejects a sidebar phase that declares _advances_to (must be off-backbone)', () => {
     const files = chainSkill();
     files['references/phases/feedback/feedback.md'] = files[
       'references/phases/feedback/feedback.md'
     ].replace('_trigger: { _when: "user opts in" }', '_trigger: { _when: "user opts in" }\n_advances_to: complete');
     const findings = validateFixture(files);
-    assert.match(findings.map((f) => f.message).join('\n'), /checkpoint phase 'feedback' must NOT declare _advances_to/);
+    assert.match(findings.map((f) => f.message).join('\n'), /sidebar phase 'feedback' must NOT declare _advances_to/);
   });
 
-  it('rejects a checkpoint phase with no phase-level _trigger', () => {
+  it('rejects a sidebar phase with no phase-level _trigger', () => {
     const files = chainSkill();
     files['references/phases/feedback/feedback.md'] = files[
       'references/phases/feedback/feedback.md'
     ].replace('\n_trigger: { _when: "user opts in" }', '');
     const findings = validateFixture(files);
-    assert.match(findings.map((f) => f.message).join('\n'), /checkpoint phase 'feedback' must declare a phase-level _trigger/);
+    assert.match(findings.map((f) => f.message).join('\n'), /sidebar phase 'feedback' must declare a phase-level _trigger/);
   });
 
   it('rejects a backbone phase that declares a phase-level _trigger', () => {
@@ -343,19 +343,19 @@ _produces:
     );
   });
 
-  it('rejects a checkpoint phase declaring _init: true (entry must be backbone)', () => {
+  it('rejects a sidebar phase declaring _init: true (entry must be backbone)', () => {
     const files = chainSkill();
-    // Strip _init from discover; put it on the feedback checkpoint.
+    // Strip _init from discover; put it on the feedback sidebar.
     files['references/phases/discover/discover.md'] = files[
       'references/phases/discover/discover.md'
     ].replace('_init: true\n', '');
     files['references/phases/feedback/feedback.md'] = files[
       'references/phases/feedback/feedback.md'
-    ].replace('_kind: checkpoint', '_kind: checkpoint\n_init: true');
+    ].replace('_kind: sidebar', '_kind: sidebar\n_init: true');
     const findings = validateFixture(files);
     assert.match(
       findings.map((f) => f.message).join('\n'),
-      /checkpoint phase 'feedback' declares '_init: true'/,
+      /sidebar phase 'feedback' declares '_init: true'/,
     );
   });
 

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/check.ts
@@ -44,26 +44,26 @@ export function check(skill: BoundSkill): Finding[] {
     // closed vocab
     for (const k of phase.unknownKeys) add(pf, `unknown phase frontmatter key '${k}'`);
 
-    // backbone/checkpoint contract (see INTERPRETER.md § _kind):
+    // backbone/sidebar contract (see INTERPRETER.md § _kind):
     //   backbone (default): MUST have _advances_to; MUST NOT have a phase-level _trigger.
-    //   checkpoint: MUST have a phase-level _trigger; MUST NOT have _advances_to
+    //   sidebar: MUST have a phase-level _trigger; MUST NOT have _advances_to
     //               (off-backbone — entered by its trigger, returns control).
-    if (phase.role === "checkpoint") {
+    if (phase.role === "sidebar") {
       if (!phase.trigger) {
-        add(pf, `checkpoint phase '${phase.phase}' must declare a phase-level _trigger (how it is entered)`);
+        add(pf, `sidebar phase '${phase.phase}' must declare a phase-level _trigger (how it is entered)`);
       } else if (phase.trigger.kind === "unknown") {
-        add(pf, `checkpoint phase '${phase.phase}' has an unrecognized phase _trigger form: ${phase.trigger.raw}`);
+        add(pf, `sidebar phase '${phase.phase}' has an unrecognized phase _trigger form: ${phase.trigger.raw}`);
       }
       if (phase.advancesTo) {
-        add(pf, `checkpoint phase '${phase.phase}' must NOT declare _advances_to (it is off-backbone; it returns control, it does not advance)`);
+        add(pf, `sidebar phase '${phase.phase}' must NOT declare _advances_to (it is off-backbone; it returns control, it does not advance)`);
       }
     } else {
       // backbone
       if (!phase.advancesTo) {
-        add(pf, `backbone phase '${phase.phase}' must declare _advances_to (or mark it '_kind: checkpoint' if it is an off-backbone checkpoint)`);
+        add(pf, `backbone phase '${phase.phase}' must declare _advances_to (or mark it '_kind: sidebar' if it is an off-backbone sidebar)`);
       }
       if (phase.trigger) {
-        add(pf, `backbone phase '${phase.phase}' must NOT declare a phase-level _trigger (only checkpoint phases are trigger-entered)`);
+        add(pf, `backbone phase '${phase.phase}' must NOT declare a phase-level _trigger (only sidebar phases are trigger-entered)`);
       }
     }
 
@@ -297,9 +297,9 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
 
-  // ---- Backbone chain-consistency (backbone phases only; checkpoints excluded) ----
+  // ---- Backbone chain-consistency (backbone phases only; sidebars excluded) ----
   // The backbone is the linear lifecycle wired by _advances_to (forward) and
-  // _requires_phase (backward). Checkpoints (_kind: checkpoint) are off-backbone and
+  // _requires_phase (backward). Sidebars (_kind: sidebar) are off-backbone and
   // are NOT part of this graph. Enforced only once >1 phase declares frontmatter AND
   // every backbone _advances_to target is either a terminal or a declared phase
   // (i.e. the backbone is fully present — tolerant of partial rollout).
@@ -364,10 +364,10 @@ export function check(skill: BoundSkill): Finding[] {
     }
   }
   for (const p of initPhases) {
-    //   (b) the `_init` phase must be a backbone phase (a checkpoint is off-backbone,
+    //   (b) the `_init` phase must be a backbone phase (a sidebar is off-backbone,
     //       trigger-entered — it can never be the entry).
-    if (p.role === "checkpoint") {
-      add(skill.rel(p.sourceFile), `checkpoint phase '${p.phase}' declares '_init: true' — only a backbone phase can be the entry (checkpoints are off-backbone, trigger-entered)`);
+    if (p.role === "sidebar") {
+      add(skill.rel(p.sourceFile), `sidebar phase '${p.phase}' declares '_init: true' — only a backbone phase can be the entry (sidebars are off-backbone, trigger-entered)`);
     }
     //   (c) the `_init` phase must be the backbone head (no _requires_phase) — the
     //       entry cannot depend on an upstream phase.

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/parse.ts
@@ -273,7 +273,7 @@ function parseChecks(fm: string, key: string): CheckItem[] {
 export function parsePhase(path: string, fm: string): PhaseFrontmatter {
   const assembleBlock = /_assemble:\s*\n\s*_file:\s*([^\n]+)/.exec(fm);
   const roleRaw = scalar(fm, "_kind");
-  const role = roleRaw === "checkpoint" ? "checkpoint" : "backbone";
+  const role = roleRaw === "sidebar" ? "sidebar" : "backbone";
   // phase-level _trigger: a `_trigger: { ... }` at column 0 (NOT a _fragments[] entry,
   // which is indented under a `- _id:`). Match only a top-of-line _trigger.
   const ptrig = /^_trigger:\s*\{([^}]*)\}/m.exec(fm);

--- a/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
+++ b/migrate/plugins/migration-to-aws/tools/frontmatter-validator/types.ts
@@ -73,8 +73,8 @@ export interface PhaseFrontmatter {
   sourceFile: string; // absolute path, for messages
   phase: string; // _phase
   title: string | null;
-  /** _kind: 'checkpoint' (off-backbone, trigger-entered) or 'backbone' (default when absent). */
-  role: "backbone" | "checkpoint";
+  /** _kind: 'sidebar' (off-backbone, trigger-entered) or 'backbone' (default when absent). */
+  role: "backbone" | "sidebar";
   requiresPhase: string | null;
   init: boolean; // _init
   /** _interactive: does this phase's WORK (fragments + assembler) prompt the user?
@@ -82,7 +82,7 @@ export interface PhaseFrontmatter {
    *  (a file-only worker cannot converse). null = the key is absent (unspecified). */
   interactive: boolean | null;
   fragments: FragmentRef[];
-  /** phase-level _trigger (checkpoint phases only) — how the phase is entered. null for backbone. */
+  /** phase-level _trigger (sidebar phases only) — how the phase is entered. null for backbone. */
   trigger: Trigger | null;
   assembleFile: string | null; // _assemble._file
   produces: string[]; // _produces filenames (bare + conditional, filename only)


### PR DESCRIPTION
## Summary

Pure **concept rename**, no behavior change: the DSL phase kind `_kind: checkpoint` becomes `_kind: sidebar`.

**Why.** "checkpoint" misleadingly implies a *mandatory inline gate you pass through* (its meaning in git/CI/DBs). The construct is the opposite: an **optional phase that hangs OFF the backbone** — entered only by its `_trigger`, returns control instead of advancing, never becomes `current_phase`. "sidebar" captures that step-off-and-return nature, and reads cleanly against `_kind: backbone`. It also matches the "side-visit" language the interpreter contract already uses to *explain* the construct.

## Changes (46 files, +239/−239 — symmetric, pure rename)

- **Validator** (`tools/frontmatter-validator/{parse,types,check}.ts`): the `_kind` role value and all error-message strings `checkpoint → sidebar`. `_kind: checkpoint` without a parser change would silently parse as `backbone` and fail — so this is a lockstep grammar-vocabulary change. Test suite (`frontmatter-validator.test.ts`) updated — **57 tests pass**.
- **All 18 `_kind: checkpoint` frontmatter declarations → `sidebar`** across every skill (heroku, vercel, gcp, agent-advisor, shared).
- **Construct prose** `checkpoint → sidebar` in canonical `INTERPRETER.md`, `workshop-invariants.md`, `phase-status.schema.json` (doc string), and per-skill files. Vendored copies re-synced byte-identical (`shared:check` OK across 4 trees).

## Protected — NOT renamed (external/unrelated terms)

Deliberately skipped 5 files whose "checkpoint" is not the DSL construct:
- **LangGraph `checkpointer`** — `retarget-gotchas.md`, `clarify-ai.md`
- **Temporal "checkpoint business state"** — `decision-refs/temporal.md`
- **"Go/No-Go checkpoint"** PM milestones — `migration-complexity.md`, `generate-infra.md`

## Deferred to follow-ups (intentionally out of scope)workshop` → `what-if` phase rename (phase id, dirs, `phases.workshop` state key, fixtures)
- `estimation_summary.workshop` metadata field rename
- **Tier 2 — structural `_gates`**: make the sidebar's "hold the backbone successor until it resolves" *declarative + validator-enforced* (today it lives in interpreter prose). That's where the real capability win is; this PR is vocabulary only.

## Test plan

- [x] `mise run build` green — frontmatter validator (all skills), `node --test` (57 pass), dprint fmt:check, markdownlint, `shared:check` (4 vendored trees byte-identical), security scanners.

## Note for reviewers

This is a plugin-wide vocabulary change, so it touches `**/SKILL.md` (→ `@startups-admins`) and the agent-advisor / llm-to-bedrock skills. The diff is mechanical and symmetric (+239/−239); no logic changes.