### PR TITLE
Update prompt-library prompts, add Bedrock Model Availability and AWS DB Advisor agents, bump to 1.5.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "aws-startup-advisor",
       "source": "./advisor/plugins/aws-startup-advisor",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "description": "Three sibling skills for startups building on AWS: knowledge-base-for-startups (Activate FAQ, credits, programs, partner offers, sample architectures, learn articles), prompt-library-for-startups (copy-paste prompts + downloadable installable agents), and start-building-for-startups (interactive discovery workflow that scaffolds an AWS architecture)"
     },
     {

--- a/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
   "author": {
     "name": "Amazon Web Services"

--- a/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-startup-advisor",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
   "author": {
     "name": "Amazon Web Services",

--- a/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
   "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/advisor/plugins/aws-startup-advisor/skills/knowledge-base-for-startups/SKILL.md
+++ b/advisor/plugins/aws-startup-advisor/skills/knowledge-base-for-startups/SKILL.md
@@ -7,7 +7,7 @@ description: "AWS Startups reference content — Activate FAQ, credits guide, pr
 
 Reference content from [aws.amazon.com/startups](https://aws.amazon.com/startups) for AWS Activate programs, credits, partner offers, sample build architectures, and a large learn-article corpus covering technical guides, business strategy, and real-world case studies.
 
-**Last updated:** 2026-06-12
+**Last updated:** 2026-07-22
 
 ---
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/SKILL.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: prompt-library-for-startups
-description: "AWS-curated copy-paste prompts for AI coding agents (MVP scaffolding, RAG chatbot with Claude on Bedrock, security baseline evaluation, cost anomaly detection, GPU quota requests, EKS deployment, Well-Architected review, etc.) plus downloadable installable agents (Multi-Account Transition Advisor, Bill Shock Preventer, Service Quota Agent). Use when the user asks for a prompt to do X on AWS, wants an installable agent for multi-account / cost monitoring / quota management, or asks how to use AWS prompts. For migration intent (GCP to AWS, OpenAI/Gemini to Bedrock), route to the migration-to-aws skill. Do not use for: factual AWS Activate / programs / credits questions, learn articles, sample architectures, or for prompts that are not in the bundled `references/prompt-library/` tree."
+description: "AWS-curated copy-paste prompts for AI coding agents (MVP scaffolding, RAG chatbot with Claude on Bedrock, security baseline evaluation, cost anomaly detection, GPU quota requests, EKS deployment, Well-Architected review, etc.) plus downloadable installable agents (Multi-Account Transition Advisor, Bill Shock Preventer, Service Quota Agent, Bedrock Model Availability Agent, AWS DB Advisor). Use when the user asks for a prompt to do X on AWS, wants an installable agent for multi-account / cost monitoring / quota management / Bedrock model availability / database selection, or asks how to use AWS prompts. For migration intent (GCP to AWS, OpenAI/Gemini to Bedrock), route to the migration-to-aws skill. Do not use for: factual AWS Activate / programs / credits questions, learn articles, sample architectures, or for prompts that are not in the bundled `references/prompt-library/` tree."
 ---
 
 # AWS Startups Prompt & Agent Library
 
 Searchable index of AWS-curated prompts for AI coding tools (Kiro, Claude Code, Cursor, etc.) plus downloadable installable agents. Content is verbatim from [aws.amazon.com/startups/prompt-library](https://aws.amazon.com/startups/prompt-library).
 
-**Last updated:** 2026-05-12
+**Last updated:** 2026-07-22
 
 ---
 
@@ -47,8 +47,10 @@ The **Downloadable agents** section of `references/prompt-library.md` lists **in
 - **AWS Multi-Account Transition Advisor** — guides single-account → multi-account (AWS Organizations + OUs).
 - **AWS Bill Shock Preventer** — proactive cost-spike detection and alerting.
 - **AWS Service Quota Agent** — auditing and requesting quota increases.
+- **Bedrock Model Availability Agent** — finds Amazon Bedrock model availability across AWS regions.
+- **AWS DB Advisor** — selecting and operating the right AWS database (selection, HA/DR, cost, migrations).
 
-When the user's intent matches one of these — _"set up multi-account"_, _"prevent bill shock"_, _"audit service quotas"_ — recommend the matching agent **by title and use-case**, then hand over the GitHub repo / install link from the index file. Make clear it installs **separately from this skill** into the user's AI coding agent.
+When the user's intent matches one of these — _"set up multi-account"_, _"prevent bill shock"_, _"audit service quotas"_, _"which Bedrock model / region"_, _"which database should I use"_ — recommend the matching agent **by title and use-case**, then hand over the GitHub repo / install link from the index file. Make clear it installs **separately from this skill** into the user's AI coding agent.
 
 For migration intent — _"help me migrate to AWS"_, _"GCP to AWS"_, _"move off OpenAI to Bedrock"_ — route to the **`migration-to-aws`** skill in the `aws-startup-advisor` plugin.
 
@@ -74,6 +76,8 @@ For migration intent — _"help me migrate to AWS"_, _"GCP to AWS"_, _"move off 
 | _"Set up multi-account on AWS Organizations"_        | Downloadable: Multi-Account Transition Advisor                                         |
 | _"Stop bill shock / detect cost spikes proactively"_ | Downloadable: AWS Bill Shock Preventer                                                 |
 | _"Manage / request service quotas"_                  | Downloadable: Service Quota Agent                                                      |
+| _"Which Bedrock model is available in which region"_ | Downloadable: Bedrock Model Availability Agent                                         |
+| _"Which AWS database should I use"_                  | Downloadable: AWS DB Advisor                                                           |
 
 For anything else, filter `references/prompt-library.md` by keyword.
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library.md
@@ -102,6 +102,40 @@ always with your explicit confirmation before taking any action. The output is a
 to your team or include in operational reviews.
 You can download the agent from here: https://github.com/aws-samples/sample-genai-startups/tree/main/agentic-coding-library/agents/service-quota-agent
 
+### [Bedrock Model Availability Agent](https://aws.amazon.com/startups/prompt-library/bedrock-model-agent)
+
+Tags: GenAI Bedrock ModelSelection Beginner MCP
+
+A Kiro CLI custom agent that finds Amazon Bedrock model availability across AWS regions using a custom MCP server.
+
+Agent Details: Choosing where to deploy a foundation model means knowing which models are actually available in which
+AWS regions — information that changes as new models launch and expand. This agent answers regional availability
+questions directly (for example, whether a given model is available in `us-west-2`, where a model is offered, or which
+models run on-demand in a region), so you can make cross-region deployment and model-selection decisions with current
+data instead of guesswork. It runs on Kiro CLI and is backed by a custom `bedrock-model-mcp` server (Python 3.10+, the
+`uv` package manager) that queries Bedrock model data; running it requires AWS credentials with Bedrock permissions.
+You can download the agent from here: https://github.com/aws-samples/sample-genai-startups/tree/main/agentic-coding-library/agents/bedrock-model-agent
+
+### [AWS DB Advisor](https://aws.amazon.com/startups/prompt-library/aws-db-advisor)
+
+Tags: Databases Architecture Cost-Optimization Migration Intermediate
+
+A Kiro CLI agent that helps startup developers select and operate the right AWS database, from initial choice through
+production use.
+
+Agent Details: Picking a database is one of the highest-stakes early decisions a startup makes, because changing it
+later is costly. This agent maps your application type, access patterns, and scale to the right service across the full
+AWS portfolio — Aurora, RDS, DynamoDB, ElastiCache/Valkey, OpenSearch, Neptune, MemoryDB, Timestream, DocumentDB, and
+DSQL. It guides vector-database selection for AI features (pgvector for small workloads, OpenSearch for scale, S3 Vectors
+for massive corpora), high availability and disaster recovery from multi-AZ through multi-region active-active with cost
+trade-offs, cost optimization (Savings Plans, Reserved Instances, I/O-Optimized storage, scale-to-zero), heterogeneous
+migrations (Oracle to RDS, MSSQL to Aurora PostgreSQL) using DMS patterns, and operational concerns like RDS Proxy
+connection pooling, PostgreSQL tuning, partitioning, CDC/zero-ETL pipelines, and multi-tenant isolation. It queries the
+AWS Knowledge MCP server for live documentation so answers reflect current service capabilities rather than stale
+training data. Best results require Claude Sonnet 4.6 or higher. It installs as a Kiro CLI agent, a Kiro Power, or a
+Claude Code Skill (invoke with `/aws-db-advisor`).
+You can download the agent from here: https://github.com/aws-samples/sample-genai-startups/tree/main/agentic-coding-library/agents/aws-db-advisor
+
 ---
 
 ## Frequently Asked Questions

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/aws-ecs-express-deployment-assistant.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/aws-ecs-express-deployment-assistant.md
@@ -34,9 +34,18 @@ IAM Role Configuration
 3.1 Please ask the user if they want to create a task execution role or give an existing iam role arn instead. In case the user ask to create it please create the iam role according to the details in this aws documentation web page https://docs.aws.amazon.com/AmazonECS/latest/developerguide/express-service-getting-started.html
 3.2 Please ask the user if they want to create a task infrastructure role or give an existing iam role arn instead. In case the user ask to create it please create the iam role according to the details in this aws documentation web page https://docs.aws.amazon.com/AmazonECS/latest/developerguide/express-service-getting-started.html
 3.3 Please ask the user for task role arn. The user can provide iam role arn or you can scan the folder with all files and generate the required iam permissions that are required. Make sure not to miss any required permission and find all api calls that required permissions. Then, generate an iam role with the require permission.
+
+IAM Safety Rules for generated policies:
+
+- You MUST use specific resource ARNs in all policies. Never use `Resource: "*"` unless the AWS API explicitly requires it (e.g., sts:GetCallerIdentity).
+- You MUST only grant permissions for AWS API calls that are actually present in the code. Do not add speculative permissions.
+- You MUST present the generated IAM policy to the user for review before creating the role.
+- You MUST NOT include overly broad actions like `s3:*` or `dynamodb:*`. Use the specific actions found in the code (e.g., s3:GetObject, dynamodb:PutItem).
+
 Make the ECS allow inbound connection from the load balancer on port 443 to the ECS container port
 Additional Configuration (Optional)
-Environment Variables: [KEY=VALUE pairs, comma-separated]Memory Allocation: [e.g., 512, 1024, 2048 MB - default: 2048]
+Environment Variables: [KEY=VALUE pairs, comma-separated]
+Memory Allocation: [e.g., 512, 1024, 2048 MB - default: 2048]
 CPU Allocation: [e.g., 256, 512, 1024 - default: 1024]
 Health Check Path: [e.g., /health, /api/health - default: /]
 Instructions:

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/gpu-instance-quota-assistant.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/gpu-instance-quota-assistant.md
@@ -229,7 +229,7 @@ aws service-quotas get-requested-service-quota-change \
 
 - Each quota is **per region** - must request separately for each region
 - Some instances (P6) have limited regional availability
-- Always verify instance availability before requesting quotas
+- Always verify instance availability before requesting quotas. New GPU instance families may launch after this prompt was written — if a customer asks about an instance type not listed above, use `aws service-quotas list-service-quotas --service-code ec2` to find the current quota code.
 
 ### SageMaker Specifics
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/openapi-to-agentcore-gateway-deployment.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/openapi-to-agentcore-gateway-deployment.md
@@ -22,15 +22,15 @@ You are an AWS Bedrock AgentCore Gateway architect specializing in deploying API
 
 ## MCP Integration Strategy
 
-**MANDATORY**: Use the AgentCore MCP server tools to inform all decisions:
+**MANDATORY**: Use the AgentCore MCP server to inform all decisions:
 
 1. **Pre-Deployment Research**
-   - Search: `search_agentcore_docs("gateway deployment patterns")`
-   - Search: `search_agentcore_docs("lambda integration mcp")`
+   - Search AgentCore MCP documentation for gateway deployment patterns
+   - Search AgentCore MCP documentation for target integration (Lambda and REST API)
    - Fetch detailed guides from search results
 2. **During Deployment**
    - Reference MCP docs for Gateway configuration
-   - Use MCP examples for Lambda integration
+   - Use MCP examples for target setup
    - Cite MCP sources in generated documentation
 3. **Post-Deployment**
    - Search MCP for troubleshooting guides
@@ -39,18 +39,26 @@ You are an AWS Bedrock AgentCore Gateway architect specializing in deploying API
 ## Input Requirements
 
 - OpenAPI 3.0+ specification (.yaml/.yml/.json file in current folder)
-- Python implementation code (.py file) for Lambda deployment in current folder
+- Optional: Python implementation code (.py file) for Lambda-backed targets
+- Optional: Existing REST API endpoint URL (for direct REST API targets)
 - Optional: API key or authentication requirements
 - Optional: Performance/cost constraints
 
 ## Goal
 
-Enable users to access API capabilities through local MCP clients using MCP protocol, with:
+Enable users to access API capabilities through MCP clients, with:
 
 - MCP hosted on Bedrock AgentCore Gateway
-- Gateway invoking AWS Lambda function for API operations
-- OAuth 2.0 authentication via Cognito
+- Gateway invoking targets (Lambda function OR REST API) for API operations
+- OAuth 2.0 inbound authentication (Cognito EZ Auth or any OIDC-compliant provider)
 - Semantic search enabled for tool discovery
+
+## Safety Boundaries
+
+- You MUST NOT create IAM roles with `Action: "*"` or `Resource: "*"`. Always scope permissions to the specific Lambda ARN or API resource.
+- You MUST NOT hardcode secrets, client IDs, or tokens in code. Use environment variables or AWS Secrets Manager.
+- You MUST confirm the user's AWS region and account context before creating resources.
+- You MUST present the IAM trust policy and permissions to the user for review before creating the execution role.
 
 ## Transformation Process
 
@@ -59,55 +67,91 @@ Enable users to access API capabilities through local MCP clients using MCP prot
 Analyze OpenAPI spec to identify:
 
 - Core operations and their HTTP methods
-- Authentication mechanisms
+- Authentication mechanisms the target API requires
 - Request/response patterns
 - Rate limits and constraints
 
-### Step 2: Lambda Deployment
+### Step 2: Choose Target Type
 
-Deploy API implementation to AWS Lambda:
+Determine the appropriate target type based on the user's situation:
 
-- Package Python code with dependencies
-- Configure IAM execution role
-- Set appropriate timeout and memory
-- **CRITICAL**: Ensure Lambda returns correct format:
+- **REST API target**: Use when the API is already deployed and accessible via HTTPS. Provide the OpenAPI schema (inline or via S3 URI) and configure outbound auth if needed.
+- **Lambda target**: Use when deploying a new serverless implementation. Package Python code with dependencies, configure IAM execution role, set appropriate timeout and memory.
 
-  ```python
-  return {
-      'messageVersion': '1.0',
-      'response': {
-          'actionGroup': event.get('actionGroup', ''),
-          'apiPath': event.get('apiPath', ''),
-          'httpMethod': event.get('httpMethod', ''),
-          'httpStatusCode': 200,
-          'responseBody': {
-              'application/json': {
-                  'body': json.dumps(your_data_here)
-              }
-          }
-      }
-  }
-  ```
+### Step 3: Gateway Creation
 
-### Step 3: Gateway Configuration
+Create AgentCore Gateway using the SDK:
 
-Create AgentCore Gateway with:
+```python
+from bedrock_agentcore_starter_toolkit.operations.gateway.client import GatewayClient
 
-- OAuth 2.0 authorization (Cognito)
-- Lambda target with tool schema
-- Semantic search enabled
-- MCP protocol support
+client = GatewayClient(region_name="<REGION>")
+cognito_result = client.create_oauth_authorizer_with_cognito("<gateway-name>")
 
-### Step 4: Optimization
+gateway = client.create_mcp_gateway(
+    name="<gateway-name>",
+    authorizer_config=cognito_result["authorizer_config"],
+    enable_semantic_search=True,
+)
+```
+
+Or using CLI:
+
+```bash
+agentcore create_mcp_gateway \
+  --name <gateway-name> \
+  --target <LAMBDA_ARN_OR_API_URL> \
+  --execution-role <IAM_ROLE_ARN>
+```
+
+### Step 4: Add Target
+
+**For REST API targets:**
+
+```python
+client.create_gateway_target(
+    gatewayIdentifier=gateway_id,
+    name="<target-name>",
+    targetConfiguration={
+        "mcp": {
+            "openApiSchema": {
+                "s3Uri": "s3://<bucket>/<path>/openapi.json"
+            }
+        }
+    }
+)
+```
+
+**For Lambda targets:**
+
+```python
+client.create_gateway_target(
+    gatewayIdentifier=gateway_id,
+    name="<target-name>",
+    targetConfiguration={
+        "mcp": {
+            "lambdaArn": "arn:aws:lambda:<REGION>:<ACCOUNT>:function:<NAME>"
+        }
+    }
+)
+```
+
+### Step 5: Configure Outbound Authentication (if target API requires credentials)
+
+- **OAuth**: Configure client credentials flow with token endpoint
+- **API Key**: Reference via Secrets Manager
+- **Custom headers**: Configure static header injection
+
+### Step 6: Optimization
 
 - **Token Efficiency**: Compress tool descriptions (30-50% reduction)
 - **Cost Optimization**: Estimate per-request costs (~$0.00001/request)
 - **Error Handling**: Configure retry logic and fallbacks
-- **Performance**: Set appropriate Lambda timeout/memory
+- **Performance**: Set appropriate Lambda timeout/memory (if Lambda target)
 
 ## Outputs
 
-Generate deployment script, deploy the MCP into Bedrock AgentCore Gateway with the implementation in AWS Lambda all in working condition, client test script, documentation, and cost estimate
+Generate deployment script, deploy the MCP into Bedrock AgentCore Gateway with the target fully configured, client test script, documentation, and cost estimate.
 
 ## Documentation Generation
 
@@ -124,9 +168,9 @@ Generate deployment script, deploy the MCP into Bedrock AgentCore Gateway with t
 
 ### 2-deploy.md
 
-- Lambda deployment commands
-- Gateway deployment commands
-- Actual AWS resource names (Lambda ARN, Gateway URL)
+- Gateway creation commands used
+- Target configuration commands
+- Actual AWS resource names (Gateway ID, MCP Endpoint URL, Lambda ARN if applicable)
 - IAM permissions needed
 - Verification commands
 - Troubleshooting for this API
@@ -135,7 +179,7 @@ Generate deployment script, deploy the MCP into Bedrock AgentCore Gateway with t
 
 - API-specific test queries (5-10 examples)
 - Expected responses based on actual data model
-- MCP client test commands
+- MCP client test commands (tools/list, tools/call)
 - Performance metrics
 - Success criteria
 
@@ -153,7 +197,7 @@ Generate deployment script, deploy the MCP into Bedrock AgentCore Gateway with t
 - Configuration accuracy: >95%
 - Token efficiency: 30-50% reduction vs raw OpenAPI
 - Cost per request: ~$0.00001
-- Lambda cold start: <3 seconds
+- Lambda cold start: <3 seconds (if Lambda target)
 
 ## Cost Estimate Template
 
@@ -164,7 +208,7 @@ One-Time Setup:
 - Lambda deployment: $0.00
 Ongoing Costs:
 - Gateway requests: ~$0.00001/request
-- Lambda invocations: $0.0000002/request
+- Lambda invocations: $0.0000002/request (if Lambda target)
 - Cognito MAU: Free tier (50,000 MAU)
 Example Usage:
 - 1,000 requests/month: ~$0.01
@@ -174,21 +218,23 @@ Example Usage:
 
 ## Validation Checklist
 
-- [ ] Lambda deployed with correct response format
-- [ ] Gateway created with OAuth
+- [ ] Target configured (Lambda deployed OR REST API target added)
+- [ ] Gateway created with OAuth inbound auth
 - [ ] Tools generated from OpenAPI operations
-- [ ] MCP endpoint accessible
-- [ ] OAuth tokens obtainable
-- [ ] Test queries successful
+- [ ] MCP endpoint accessible at https://{gatewayId}.gateway.{region}.amazonaws.com/mcp
+- [ ] OAuth tokens obtainable from identity provider
+- [ ] Test queries successful (tools/list and tools/call)
 - [ ] Documentation complete
 - [ ] Cost estimates provided
 
 ## Best Practices
 
+- **Semantic search**: Enable at creation time — cannot be added to an existing gateway later
+- **Auth**: Gateway supports any OIDC-compliant provider, not just Cognito
 - **Lambda**: Use layers for dependencies, set timeout ≥30s
-- **Gateway**: Enable semantic search for natural language queries
-- **OAuth**: Token expires in 3600s, implement refresh logic
-- **Error Handling**: Return user-friendly messages in Lambda
+- **VPC targets**: Use privateEndpoint with VPC Lattice for private APIs
+- **No custom response format needed**: Gateway handles MCP protocol translation automatically — Lambda functions return standard responses
+- **1-click integrations**: Gateway offers pre-built connectors for Salesforce, Slack, Jira, Asana, Zendesk — check these before building custom targets
 - **Monitoring**: Enable CloudWatch logs for debugging
 
 ## Example Transformation
@@ -196,26 +242,28 @@ Example Usage:
 **Input**: Pet Store API with 3 endpoints
 **Output**:
 
-- Lambda: `PetStoreAPIHandler` (deployed)
 - Gateway: `PetStoreGateway` (MCP endpoint)
+- Target: REST API with OpenAPI schema in S3
 - Tools: 3 (listPets, createPet, getPet)
 - Cost: $0.01 per 1,000 requests
 - Deployment time: 3 minutes
 
 ## Troubleshooting Guide
 
-| Issue                       | Solution                                                    |
-| --------------------------- | ----------------------------------------------------------- |
-| "dependencyFailedException" | Check Lambda response format (use messageVersion structure) |
-| "Invalid OAuth scope"       | Use scope from Cognito resource server                      |
-| "Gateway not responding"    | Wait 30-60s for DNS propagation                             |
-| "Lambda timeout"            | Increase timeout in Lambda configuration                    |
+| Issue                    | Solution                                                             |
+| ------------------------ | -------------------------------------------------------------------- |
+| "Invalid OAuth scope"    | Use scope from Cognito resource server or check OIDC provider config |
+| "Gateway not responding" | Wait 30-60s for DNS propagation after creation                       |
+| "Lambda timeout"         | Increase timeout in Lambda configuration                             |
+| "Target not found"       | Verify target was added to gateway (check gateway_id matches)        |
+| "Unauthorized"           | Verify access token audience matches gateway's allowed audiences     |
 
 ## Key Differences from Traditional Bedrock Agents
 
-- **No action groups**: Gateway handles tool generation
-- **No manual schemas**: Auto-generated from OpenAPI
+- **No action groups**: Gateway handles tool generation from OpenAPI
+- **No manual schemas**: Auto-generated from OpenAPI spec
 - **MCP protocol**: Standard protocol vs proprietary
+- **Multiple target types**: REST API, Lambda, or 1-click integrations
 - **Faster deployment**: 3 min vs 30+ min
 - **Lower cost**: Pay-per-request vs always-on
 
@@ -228,16 +276,15 @@ Example Usage:
 1. Set up your AWS environment and cost controls
    a. Follow the Getting Started on AWS for Startups guide to create your account and configure access.
    b. Review the Quick Cloud Cost Optimization guide for early-stage startups to set up budgets, monitor spend, and turn off unused resources
-
 1. Install the AWS CLI
    a. Download and install the AWS CLI for your operating system.
 1. Configure AgentCore MCP https://awslabs.github.io/mcp/servers/amazon-bedrock-agentcore-mcp-server in your AI tool (e.g. Kiro-CLI)
 1. Enter a working folder. Put your OpenAPI schema yaml file (to be converted into MCP) in the current folder. Also put the API implementation code files in the same folder as well (to be hosted in AWS Lambda function)
 1. Copy the prompt
-   a. Click “Copy Prompt” to copy the prompt into your clipboard.
+   a. Click "Copy Prompt" to copy the prompt into your clipboard.
 1. Test your prompt
    a. Paste the prompt into your AI tool (e.g., Kiro-CLI) and run it to generate the results.
 1. Review, deploy, and monitor
    a. Review the generated resources and estimated costs
    b. Deploy to a development environment first.
-   c. Monitor performance and spend before moving to production.1f:T
+   c. Monitor performance and spend before moving to production.


### PR DESCRIPTION
## Summary

Refreshes prompt-library content with the latest published prompts and adds two new downloadable agents. Bumps the `aws-startup-advisor` plugin to **1.5.4**.

### Updated prompts (3)
- **AWS ECS Express Deployment Assistant** — adds IAM safety rules for generated policies (specific ARNs, no wildcard actions, present-in-code permissions only, user review before role creation).
- **OpenAPI to AgentCore Gateway Deployment** — supports REST API targets (not just Lambda), SDK/CLI gateway-creation examples, Safety Boundaries, any OIDC-compliant provider, 1-click integrations, and updated troubleshooting/validation.
- **AWS EC2 & SageMaker GPU Instance Quota Increase Assistant** — adds guidance to look up current quota codes for newly launched GPU instance families.

_(The AWS Security Baseline: Terraform Deployment Kit prompt was reviewed and required no change — its published content is unchanged.)_

### New downloadable agents (2)
- **Bedrock Model Availability Agent** — finds Amazon Bedrock model availability across AWS regions via a custom MCP server.
- **AWS DB Advisor** — helps select and operate the right AWS database (selection, vector/AI use cases, HA/DR, cost, migrations, operations).

### Housekeeping
- Updated the prompt-library and knowledge-base skill `Last updated` dates.
- Refreshed the prompt-library skill's agent list and routing hints for the two new agents.
- Bumped plugin version to 1.5.4 across the Claude/Cursor/Codex manifests and `marketplace.json`.

## Validation
- `mise run lint:md` — 0 errors
- `mise run fmt:check` — clean
- `mise run lint:frontmatter` — OK
- `mise run security:semgrep` / `security:gitleaks` — pass (no new findings)
