### PR TITLE
Update pr template with contribution licensing statement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,5 @@
 - [ ] I have run `mise run build` locally and it passes
 - [ ] I have updated documentation if needed
 - [ ] My changes are scoped to my team's folder only
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
## Problem

PR template missing Amazon Open Source contribution licensing statement. 

## Solution

Add the text

## Type of Change

- [ ] New plugin/power/tool
- [ ] Bug fix
- [ ] Enhancement to existing content
- [X] Documentation update
- [ ] Guardrail/CI update

## Team Folder

<!-- Which top-level folder does this PR affect? -->

- [ ] `advisor/`
- [ ] `migrate/`
- [X] Other: package wide template

## Checklist

- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] My changes do not include hardcoded secrets, credentials, or internal-only content
- [X] I have run `mise run build` locally and it passes
- [X] I have updated documentation if needed
- [X] My changes are scoped to my team's folder only
