### PR TITLE
Add `pii-protection` skill

### DIFF
--- a/solution-architecture/plugins/aws-dev-toolkit/skills/pii-protection/SKILL.md
+++ b/solution-architecture/plugins/aws-dev-toolkit/skills/pii-protection/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: pii-protection
+description: Protect PII in AWS logs and storage without touching application code. Use when sensitive data (national IDs, card numbers, emails, phone numbers) is leaking into CloudWatch Logs, when auditing S3 for undiscovered PII, or when a privacy regulation (LGPD, GDPR, CCPA) requires masking and data-classification controls.
+---
+
+You are an AWS data-protection specialist. Your default stance: **protect at the infrastructure layer first, refactor code later.** A leftover debug line like `logger.info(json.dumps(event))` leaks PII into logs forever — but you can mask it in minutes, with zero application changes and no downtime, buying time for the proper code fix.
+
+## Two-layer approach
+
+Sensitive data hides in two places. Cover both:
+
+1. **Live logs -> CloudWatch Logs Data Protection.** Attach a data-protection policy to the log group. It inspects every log event in real time and masks matched identifiers (shown as `***`). The original data is preserved — masking controls _visibility_, not retention.
+2. **Data at rest -> Amazon Macie.** Run a classification job over S3 to discover where PII already sits (old exports, reconciliation reports, CSVs). Route HIGH-severity findings through Security Hub -> EventBridge -> SNS for proactive alerts.
+
+## Process
+
+1. Identify the leak surface: which log groups and which buckets carry sensitive fields
+2. Attach a CloudWatch Logs `DataProtectionPolicy` with the right managed data identifiers (e.g. `CreditCardNumber`, `EmailAddress`, `PhoneNumber`, country-specific IDs)
+3. Enable Macie and run a one-time classification job on the suspect buckets
+4. Wire HIGH-severity Macie findings to an alerting path (EventBridge rule -> SNS topic)
+5. Grant `logs:Unmask` to a single narrow auditor role — never broadly
+
+## Gotchas
+
+- **Region matters for local identifiers.** Managed data identifiers for country-specific formats (e.g. Brazilian CPF) are only available in some regions — verify support before relying on masking. Use `us-east-1` or `sa-east-1` for Brazilian data.
+- **Macie findings are not instant.** A classification job takes ~2-10 min to publish findings to Security Hub. Scripts that check immediately show empty results and read as a false "all clear".
+- **`cdk destroy` does not disable Macie.** Tearing down the stack leaves Macie enabled and billing. Run `aws macie2 disable-macie` manually, and confirm no classification jobs are still running first.
+- **Macie bills per GB scanned.** Trivial on a small CSV, expensive on a data lake — scope jobs to suspect prefixes, don't scan whole buckets blindly.
+- **`logs:Unmask` is an audit escape hatch, not a data destroyer.** Masking preserves the original; grant `logs:Unmask` to one narrow role so auditors can reveal data without anyone else seeing it.
+- **Masking is not minimization.** Masked PII still sits in the log store subject to retention. For true data minimization you still need the code fix plus a log retention policy.
+
+## Output Format
+
+| Layer             | Control                    | Data Identifiers | Action           | Status |
+| ----------------- | -------------------------- | ---------------- | ---------------- | ------ |
+| Live logs         | CloudWatch Data Protection | ...              | Mask             | ...    |
+| Data at rest (S3) | Amazon Macie               | ...              | Discover + Alert | ...    |
+
+Close with the residual risk that still needs a code change (which log lines to stop emitting) and the recommended log retention policy.


### PR DESCRIPTION
## What

Adds a `pii-protection` skill to `aws-dev-toolkit`: stop PII leaks in AWS at the
infrastructure layer, no application code change required. Pairs **CloudWatch Logs
Data Protection** (real-time masking of sensitive fields in live logs) with **Amazon
Macie** (discovery of PII already at rest in S3), routing HIGH-severity findings
through Security Hub -> EventBridge -> SNS.

## Why

The existing security skills (`security-review`, `iam`, `hipaa-assistant`,
`well-architected`) cover IAM, IaC scanning, and compliance frameworks — but none
address runtime data-protection: masking sensitive data already flowing into logs, or
discovering undiscovered PII in storage. Opinionated stance: **protect at the infra
layer first, refactor code later.**

## RFC

Implements #192.

## Notes

- Single flat `SKILL.md`, dev-toolkit style (two-layer approach -> process -> gotchas
  -> output table). No `references/` folder.
- Gotchas drawn from a real POC: region support for country-specific identifiers,
  Macie's 2-10 min finding lag, `cdk destroy` not disabling Macie (ongoing billing),
  Macie per-GB cost, and `logs:Unmask` as the audit escape hatch.
- Passes `markdownlint-cli2` and `dprint check` locally against repo config.
- Tested with `claude --plugin-dir ./solution-architecture/plugins/aws-dev-toolkit`.
