### PR TITLE
fix(tf-best-practices): detect IPv6 public ingress and fix order-dependent IPv4 check in Terraform policy validator

### DIFF
--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/SKILL.md
@@ -153,12 +153,13 @@ for the caller, so a false positive would block a real migration).
 **Security group ingress:**
 
 - **`db_sg_no_public_ingress`** — an inline `aws_security_group` ingress covering `5432`/`3306`
-  must not allow `0.0.0.0/0`.
+  must not allow `0.0.0.0/0` or `::/0`.
 - **`sg_no_public_admin_ingress`** — an inline ingress must not open a curated never-public
   admin/datastore port (`22`, `3389`, `6379`, `11211`, `27017`, `9200`/`9300`, `5601`) to
-  `0.0.0.0/0`. Web (`80`/`443`) and app/game ports are not flagged; DB ports are handled by the
-  rule above. Both: separate `aws_security_group_rule` / `aws_vpc_security_group_ingress_rule`
-  resources fail open (not correlated).
+  `0.0.0.0/0` or `::/0`. Web (`80`/`443`) and app/game ports are not flagged; DB ports are
+  handled by the rule above. Both check `cidr_blocks` and `ipv6_cidr_blocks` independently, so a
+  benign IPv4 list does not mask an open IPv6 one. Both: separate `aws_security_group_rule` /
+  `aws_vpc_security_group_ingress_rule` resources fail open (not correlated).
 
 **IAM least-privilege** (`aws_iam_policy`, `aws_iam_role_policy`, `aws_iam_group_policy`,
 `aws_iam_user_policy`):

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/fixtures/terraform-policy/bad-sg-public-ipv6/vpc.tf
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/fixtures/terraform-policy/bad-sg-public-ipv6/vpc.tf
@@ -1,0 +1,33 @@
+# Intentionally non-compliant fixture — DO NOT deploy, DO NOT sanitize.
+# Exercises the IPv6 public-ingress paths for BOTH security-group rules:
+#   - sg_no_public_admin_ingress via ipv6_cidr_blocks = ["::/0"] on SSH
+#   - db_sg_no_public_ingress    via ipv6_cidr_blocks = ["::/0"] on 5432
+# Regression shape: ipv6_cidr_blocks is declared BEFORE cidr_blocks and the IPv4
+# list is benign. The old r'cidr_blocks\s*=\s*\[' regex matched the tail of
+# `ipv6_cidr_blocks` first, so the checker read the IPv6 list while believing it
+# was reading IPv4, found no 0.0.0.0/0, and returned POLICY_OK.
+resource "aws_security_group" "bad_ipv6_admin" {
+  name   = "bad-ipv6-admin-sg"
+  vpc_id = "vpc-123"
+
+  ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = ["10.0.0.0/8"]
+  }
+}
+
+resource "aws_security_group" "bad_ipv6_db" {
+  name   = "bad-ipv6-db-sg"
+  vpc_id = "vpc-123"
+
+  ingress {
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = ["10.0.0.0/8"]
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/fixtures/terraform-policy/good-sg-ipv6-scoped/vpc.tf
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/fixtures/terraform-policy/good-sg-ipv6-scoped/vpc.tf
@@ -1,0 +1,34 @@
+# Compliant fixture — MUST pass (POLICY_OK).
+# Proves the IPv6 checks do NOT false-positive:
+#   - public web on 443 over both ::/0 and 0.0.0.0/0 (not a sensitive port)
+#   - SSH reachable over a scoped IPv6 prefix, not ::/0
+#   - Postgres reachable over a scoped IPv6 prefix, not ::/0
+# Also guards the reverse of the old regex bug: a benign ipv6_cidr_blocks list
+# declared before a benign cidr_blocks list must not be misread either way.
+resource "aws_security_group" "web_dualstack" {
+  name   = "web-dualstack-sg"
+  vpc_id = "vpc-123"
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["2001:db8:1234::/48"]
+    cidr_blocks      = ["10.0.0.0/8"]
+  }
+
+  ingress {
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["2001:db8:1234::/48"]
+  }
+}

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
@@ -157,7 +157,14 @@ inline-only fail-open scope as that rule.
 Both security-group gates read `cidr_blocks` and `ipv6_cidr_blocks` as separate attributes and
 check each family's "entire internet" range. On dual-stack and IPv6-only VPCs, `::/0` on an
 admin or database port is exactly as exposed as `0.0.0.0/0`, so a benign IPv4 list does not
-excuse an open IPv6 list. The violation message names the family that actually fired.
+excuse an open IPv6 list. The violation message names the range that actually fired.
+
+Ranges are compared **after canonicalisation**, not as text: `::/0`, `::0/0` and
+`0:0:0:0:0:0:0:0/0` are the same range and all fire. `terraform fmt` treats a CIDR as an opaque
+string, so nothing else normalises these — and IPv6 has many more legal spellings of the zero
+address than IPv4. Only quoted literals inside the list count, and comments are stripped first,
+so a range named only in a comment (`# TODO: was 0.0.0.0/0`) is not an allowed range and does
+not fire. Non-literal values (`var.x`, `${...}`) remain fail-open as documented above.
 
 ## IAM — no wildcard permissions
 

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/references/security-posture-rules.md
@@ -130,8 +130,8 @@ configured on the replication group.
 **Applies to:** inline `ingress { ... }` blocks inside `aws_security_group`.
 
 **Rule:** an ingress rule covering a database port (`5432` PostgreSQL, `3306` MySQL) must not
-allow `0.0.0.0/0`. Restrict to the application security group (`security_groups = [...]`) or a
-private CIDR.
+allow `0.0.0.0/0` (in `cidr_blocks`) or `::/0` (in `ipv6_cidr_blocks`). Restrict to the
+application security group (`security_groups = [...]`) or a private CIDR.
 
 **Gate mapping:** `db_sg_no_public_ingress`. The gate inspects only inline ingress blocks;
 separate `aws_security_group_rule` / `aws_vpc_security_group_ingress_rule` resources fail open
@@ -142,8 +142,8 @@ where you want gate coverage.
 
 **Applies to:** inline `ingress { ... }` blocks inside `aws_security_group`.
 
-**Rule:** an ingress rule must not open a well-known admin or datastore port to `0.0.0.0/0`.
-The enforced set is deliberately fixed to ports that are ~never legitimately public: `22`
+**Rule:** an ingress rule must not open a well-known admin or datastore port to `0.0.0.0/0` or
+`::/0`. The enforced set is deliberately fixed to ports that are ~never legitimately public: `22`
 (SSH), `3389` (RDP), `6379` (Redis), `11211` (Memcached), `27017` (MongoDB), `9200`/`9300`
 (Elasticsearch), `5601` (Kibana). Reach these from a bastion/app security group or a private
 CIDR instead.
@@ -153,6 +153,11 @@ ports (e.g. high ranges) are **not** flagged — the rule targets a curated neve
 not "any public ingress", so legitimately-public workloads pass. Database ports (`5432`/`3306`)
 are handled by `db_sg_no_public_ingress` and excluded here to avoid double-reporting. Same
 inline-only fail-open scope as that rule.
+
+Both security-group gates read `cidr_blocks` and `ipv6_cidr_blocks` as separate attributes and
+check each family's "entire internet" range. On dual-stack and IPv6-only VPCs, `::/0` on an
+admin or database port is exactly as exposed as `0.0.0.0/0`, so a benign IPv4 list does not
+excuse an open IPv6 list. The violation message names the family that actually fired.
 
 ## IAM — no wildcard permissions
 

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
@@ -273,6 +273,110 @@ def test_sg_ipv6_scoped_passes() -> None:
     assert "POLICY_OK" in out
 
 
+def _sg_fixture(attrs: str, port: int = 22) -> str:
+    return f"""
+resource "aws_security_group" "under_test" {{
+  name   = "sg"
+  vpc_id = "vpc-123"
+
+  ingress {{
+    from_port = {port}
+    to_port   = {port}
+    protocol  = "tcp"
+    {attrs}
+  }}
+}}
+"""
+
+
+def _verdict(tf_body: str) -> tuple[int, str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "vpc.tf").write_text(tf_body, encoding="utf-8")
+        return run_policy_validator(Path(tmp))
+
+
+def test_cidr_attribute_sharing_line_with_opening_brace_is_read() -> None:
+    """Regression: a line-anchored pattern alone hides an attribute that shares
+    its block's opening line, which is valid HCL:
+
+        ingress { cidr_blocks = ["0.0.0.0/0"]
+
+    An earlier revision of this fix used a bare `^\\s*` anchor and traded the
+    ipv6 tail-match bug for this false negative (main: POLICY_FAIL -> POLICY_OK).
+    The `(?:^|\\{)` alternation keeps both properties.
+    """
+    body = """
+resource "aws_security_group" "brace_same_line" {
+  name   = "sg"
+  vpc_id = "vpc-123"
+
+  ingress { cidr_blocks = ["0.0.0.0/0"]
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+  }
+}
+"""
+    code, out = _verdict(body)
+    assert code == 1, f"0.0.0.0/0 on the brace line must fail, got: {out}"
+    assert "22 (SSH)" in out, out
+
+
+def test_noncanonical_ipv6_zero_prefix_spellings_fire() -> None:
+    """`::/0` has many legal spellings and Terraform normalises none of them, so
+    the check canonicalises via ipaddress rather than substring-matching text."""
+    for spelling in ("::/0", "::0/0", "0:0:0:0:0:0:0:0/0", "0000:0000:0000:0000:0000:0000:0000:0000/0"):
+        code, out = _verdict(_sg_fixture(f'ipv6_cidr_blocks = ["{spelling}"]'))
+        assert code == 1, f"{spelling} is the whole IPv6 internet, must fail: {out}"
+        assert "sg_no_public_admin_ingress" in out, f"{spelling}: {out}"
+
+
+def test_scoped_and_nonliteral_cidrs_still_fail_open() -> None:
+    """The canonicalising check must not widen what counts as public: scoped
+    prefixes and non-literal values stay unflagged (documented fail-open)."""
+    for spelling in ("10.0.0.0/8", "2001:db8:1234::/48", "0.0.0.0/1", "128.0.0.0/1"):
+        attr = "ipv6_cidr_blocks" if ":" in spelling else "cidr_blocks"
+        code, out = _verdict(_sg_fixture(f'{attr} = ["{spelling}"]'))
+        assert code == 0, f"{spelling} is not the whole internet, must pass: {out}"
+    for nonliteral in ("var.admin_cidrs", "[var.cidr]", "local.allowed"):
+        inner = nonliteral if nonliteral.startswith("[") else f"[{nonliteral}]"
+        code, out = _verdict(_sg_fixture(f"cidr_blocks = {inner}"))
+        assert code == 0, f"non-literal {nonliteral} must fail open: {out}"
+
+
+def test_cidr_named_only_in_a_comment_is_not_an_allowed_range() -> None:
+    """False positive: a correctly-scoped SG that merely MENTIONS 0.0.0.0/0 in a
+    comment inside the list was reported POLICY_FAIL, blocking a valid migration.
+
+    Also pins the opposite direction — stripping comments must not swallow a real
+    entry that follows one, which a naive split-on-comma would have done.
+    """
+    scoped_with_comment = """
+    cidr_blocks = [
+      # TODO: was 0.0.0.0/0
+      "10.0.0.0/8",
+    ]"""
+    code, out = _verdict(_sg_fixture(scoped_with_comment, port=3389))
+    assert code == 0, f"a commented CIDR is not an allowed range: {out}"
+
+    comment_then_real = """
+    cidr_blocks = [
+      # temporary, remove before prod
+      "0.0.0.0/0",
+    ]"""
+    code, out = _verdict(_sg_fixture(comment_then_real, port=3389))
+    assert code == 1, f"a real 0.0.0.0/0 after a comment must still fire: {out}"
+    assert "3389 (RDP)" in out, out
+
+
+def test_commented_out_cidr_attribute_is_not_read() -> None:
+    # A commented-out attribute must not be read as set; the live value here is
+    # an SG reference, so this SG is correctly scoped and must pass.
+    body = _sg_fixture('# cidr_blocks = ["0.0.0.0/0"]\n    security_groups = ["sg-abc123"]')
+    code, out = _verdict(body)
+    assert code == 0, f"commented-out cidr_blocks must not fire: {out}"
+
+
 def test_elasticache_unencrypted_fails() -> None:
     code, out = run_policy_validator(BAD_ELASTICACHE_UNENCRYPTED)
     assert code == 1, out

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
@@ -26,6 +26,8 @@ GOOD_IAM_SCOPED_LIST = FIXTURES / "good-iam-scoped-list"
 GOOD_INTERNET_NLB = FIXTURES / "good-internet-nlb"
 BAD_SG_PUBLIC_SSH = FIXTURES / "bad-sg-public-ssh"
 GOOD_SG_PUBLIC_WEBAPP = FIXTURES / "good-sg-public-webapp"
+BAD_SG_PUBLIC_IPV6 = FIXTURES / "bad-sg-public-ipv6"
+GOOD_SG_IPV6_SCOPED = FIXTURES / "good-sg-ipv6-scoped"
 BAD_ELASTICACHE_UNENCRYPTED = FIXTURES / "bad-elasticache-unencrypted"
 GOOD_ELASTICACHE_ENCRYPTED = FIXTURES / "good-elasticache-encrypted"
 GOOD_QUOTED_PORT_HTTPS = FIXTURES / "good-quoted-port-https"
@@ -200,6 +202,73 @@ def test_sg_public_webapp_passes() -> None:
     # Public web ports (80/443), a high game-port range, and a privately-scoped
     # SSH rule must all pass — no false positive from the sensitive-port rule.
     code, out = run_policy_validator(GOOD_SG_PUBLIC_WEBAPP)
+    assert code == 0, out
+    assert "POLICY_OK" in out
+
+
+def test_sg_public_ipv6_ingress_fails() -> None:
+    """Regression: ipv6_cidr_blocks = ["::/0"] is public exposure and must fail.
+
+    The old checker searched r'cidr_blocks\\s*=\\s*\\[' which also matches the tail
+    of `ipv6_cidr_blocks`, and never looked for ::/0 at all — so an SG opening
+    SSH/Postgres to the entire IPv6 internet was reported POLICY_OK.
+    """
+    code, out = run_policy_validator(BAD_SG_PUBLIC_IPV6)
+    assert code == 1, out
+    assert "sg_no_public_admin_ingress" in out
+    assert "db_sg_no_public_ingress" in out
+
+
+def test_sg_public_ipv6_ingress_names_the_ipv6_cidr() -> None:
+    # The report must say ::/0, not 0.0.0.0/0 — the IPv4 list here is benign.
+    with tempfile.TemporaryDirectory() as tmp:
+        out_path = Path(tmp) / "verdict.json"
+        run_policy_validator(BAD_SG_PUBLIC_IPV6, json_out=out_path)
+        summaries = " ".join(
+            v["summary"] for v in json.loads(out_path.read_text())["violations"]
+        )
+        assert "::/0" in summaries
+        assert "22 (SSH)" in summaries
+        assert "0.0.0.0/0" not in summaries
+
+
+def test_ipv4_public_ingress_caught_when_ipv6_list_declared_first() -> None:
+    """Regression: the pre-fix regex made the IPv4 check ORDER-DEPENDENT.
+
+    r'cidr_blocks\\s*=\\s*\\[' matched the tail of `ipv6_cidr_blocks`, so when the
+    IPv6 attribute came first the checker read the IPv6 list and never looked at
+    cidr_blocks at all. A plain `0.0.0.0/0` on port 22 — the exact case this rule
+    exists to catch, with no IPv6 exposure involved — silently returned
+    POLICY_OK. Flipping the two lines was enough to make it fail correctly.
+    """
+    sg = """
+resource "aws_security_group" "ipv4_ssh_open" {
+  name   = "test-sg"
+  vpc_id = "vpc-123"
+
+  ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    %s
+  }
+}
+"""
+    ipv6_first = 'ipv6_cidr_blocks = ["2001:db8:1234::/48"]\n    cidr_blocks      = ["0.0.0.0/0"]'
+    ipv4_first = 'cidr_blocks      = ["0.0.0.0/0"]\n    ipv6_cidr_blocks = ["2001:db8:1234::/48"]'
+    for label, attrs in (("ipv6-first", ipv6_first), ("ipv4-first", ipv4_first)):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "vpc.tf").write_text(sg % attrs, encoding="utf-8")
+            code, out = run_policy_validator(Path(tmp))
+            assert code == 1, f"{label}: 0.0.0.0/0 on SSH must fail, got: {out}"
+            assert "22 (SSH)" in out, f"{label}: {out}"
+            assert "0.0.0.0/0" in out, f"{label}: must name the IPv4 range, got: {out}"
+
+
+def test_sg_ipv6_scoped_passes() -> None:
+    # Public web over ::/0 is fine; SSH/Postgres over a scoped IPv6 prefix must
+    # not fire. Guards against over-matching any ipv6_cidr_blocks value.
+    code, out = run_policy_validator(GOOD_SG_IPV6_SCOPED)
     assert code == 0, out
     assert "POLICY_OK" in out
 
@@ -519,7 +588,7 @@ def test_every_fixture_matches_its_good_bad_prefix() -> None:
     # Exact, not `>=`: a floor cannot detect fixtures being deleted down to it,
     # which is the removal this assertion exists to catch. Update deliberately
     # when adding or removing a fixture.
-    assert len(fixture_dirs) == 21, f"fixture count changed: {[d.name for d in fixture_dirs]}"
+    assert len(fixture_dirs) == 23, f"fixture count changed: {[d.name for d in fixture_dirs]}"
     for fixture in fixture_dirs:
         code, out = run_policy_validator(fixture)
         if fixture.name.startswith("bad-"):

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/test_validate_terraform_policy.py
@@ -377,6 +377,24 @@ def test_commented_out_cidr_attribute_is_not_read() -> None:
     assert code == 0, f"commented-out cidr_blocks must not fire: {out}"
 
 
+def test_comment_marker_inside_string_does_not_swallow_real_cidr() -> None:
+    """False negative: comment stripping must share the lexer, not re-scan with a
+    regex. A regex sees the `/*` inside the description STRING as a comment
+    opener and deletes everything up to the `*/` in the later line comment —
+    including the live `cidr_blocks = ["0.0.0.0/0"]` between them, reporting a
+    public SSH ingress as POLICY_OK. The lexer knows string interiors are not
+    comment openers, so the public range survives stripping and fires.
+    """
+    body = _sg_fixture(
+        'description = "temp /* migration window"\n'
+        '    cidr_blocks = ["0.0.0.0/0"]\n'
+        "    # closes */ in runbook"
+    )
+    code, out = _verdict(body)
+    assert code == 1, f"0.0.0.0/0 after a string containing /* must still fire: {out}"
+    assert "22 (SSH)" in out, out
+
+
 def test_elasticache_unencrypted_fails() -> None:
     code, out = run_policy_validator(BAD_ELASTICACHE_UNENCRYPTED)
     assert code == 1, out

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
@@ -14,13 +14,17 @@ in-block literal evidence, so a valid stack is never falsely blocked):
   - rds_not_public: aws_db_instance / aws_rds_cluster must not set
     publicly_accessible = true (fail-open when variable-driven or absent).
   - db_sg_no_public_ingress: an inline aws_security_group ingress covering a
-    database port (5432 / 3306) must not allow 0.0.0.0/0 (fail-open on
-    separate aws_security_group_rule / aws_vpc_security_group_ingress_rule
-    resources, which this static reader cannot correlate).
+    database port (5432 / 3306) must not allow 0.0.0.0/0 (IPv4) or ::/0 (IPv6)
+    (fail-open on separate aws_security_group_rule /
+    aws_vpc_security_group_ingress_rule resources, which this static reader
+    cannot correlate).
   - sg_no_public_admin_ingress: an inline ingress must not open a well-known
     admin/datastore port (SSH, RDP, Redis, Memcached, Mongo, Elasticsearch,
-    Kibana) to 0.0.0.0/0. Scoped to a fixed never-public port list — web ports
-    and app/game ports are not flagged. Same inline-only fail-open scope.
+    Kibana) to 0.0.0.0/0 or ::/0. Scoped to a fixed never-public port list — web
+    ports and app/game ports are not flagged. Same inline-only fail-open scope.
+    Both SG rules read cidr_blocks and ipv6_cidr_blocks independently: an
+    IPv6-only or dual-stack VPC is exposed by ::/0 exactly as IPv4 is by
+    0.0.0.0/0.
   - no_wildcard_iam: a literal IAM policy document with Effect "Allow" must not
     use Action "*" or Resource "*" (fail-open on aws_iam_policy_document data
     sources, whose statements are not visible as literal JSON here).
@@ -556,16 +560,39 @@ def _ingress_covers_db_port(ingress_body: str) -> bool:
     return bool(_ingress_covered_ports(ingress_body, _DB_PORTS))
 
 
-def _ingress_allows_public(ingress_body: str) -> bool:
-    # Match a cidr_blocks list literal and look for 0.0.0.0/0 inside it.
-    m = re.search(r"cidr_blocks\s*=\s*\[(.*?)\]", ingress_body, re.DOTALL)
-    if not m:
-        return False
-    return "0.0.0.0/0" in m.group(1)
+def _attr_list_inner(block: str, attr: str) -> str | None:
+    """Return the raw text inside a literal `attr = [ ... ]`, else None.
+
+    Anchored at line start (like _attr_string / _attr_int) so that `cidr_blocks`
+    does NOT also match the tail of `ipv6_cidr_blocks` — reading one list while
+    believing it is the other silently inverts the verdict.
+    """
+    m = re.search(
+        rf"^\s*{re.escape(attr)}\s*=\s*\[(.*?)\]",
+        block,
+        re.DOTALL | re.MULTILINE,
+    )
+    return m.group(1) if m else None
+
+
+def _ingress_public_cidrs(ingress_body: str) -> list[str]:
+    """Return the "entire internet" CIDRs this ingress rule allows, both families.
+
+    IPv4 `0.0.0.0/0` in cidr_blocks and IPv6 `::/0` in ipv6_cidr_blocks are
+    equally public: on a dual-stack or IPv6-only VPC, ::/0 on an admin port is a
+    live exposure. Each list is read under its own anchored attribute name so the
+    two are never confused. Empty list => no unambiguous public exposure.
+    """
+    found: list[str] = []
+    for attr, public in (("cidr_blocks", "0.0.0.0/0"), ("ipv6_cidr_blocks", "::/0")):
+        inner = _attr_list_inner(ingress_body, attr)
+        if inner is not None and public in inner:
+            found.append(public)
+    return found
 
 
 def check_db_sg_no_public_ingress(tf_files: list[tuple[str, str]]) -> list[Violation]:
-    """Flag inline security-group ingress that opens a DB port to 0.0.0.0/0.
+    """Flag inline security-group ingress that opens a DB port to 0.0.0.0/0 or ::/0.
 
     Fail-open: only INLINE `ingress { ... }` blocks inside aws_security_group are
     inspected. Separate aws_security_group_rule / aws_vpc_security_group_ingress_rule
@@ -577,7 +604,8 @@ def check_db_sg_no_public_ingress(tf_files: list[tuple[str, str]]) -> list[Viola
         for name, body, line in _extract_blocks(content, "aws_security_group"):
             # Walk each inline ingress block via brace matching.
             for ingress_body in _own_blocks(body, "ingress"):
-                if _ingress_covers_db_port(ingress_body) and _ingress_allows_public(ingress_body):
+                public = _ingress_public_cidrs(ingress_body)
+                if _ingress_covers_db_port(ingress_body) and public:
                     violations.append(
                         Violation(
                             check="policy",
@@ -587,12 +615,12 @@ def check_db_sg_no_public_ingress(tf_files: list[tuple[str, str]]) -> list[Viola
                             severity="error",
                             summary=(
                                 f"aws_security_group '{name}' has an ingress rule that opens a "
-                                "database port (5432/3306) to 0.0.0.0/0"
+                                f"database port (5432/3306) to {' and '.join(public)}"
                             ),
                             fix_hint=(
                                 "Restrict the ingress to the application security group "
                                 "(security_groups = [aws_security_group.app.id]) or a private "
-                                "CIDR — never 0.0.0.0/0 for a database port"
+                                "CIDR — never 0.0.0.0/0 or ::/0 for a database port"
                             ),
                         )
                     )
@@ -601,7 +629,8 @@ def check_db_sg_no_public_ingress(tf_files: list[tuple[str, str]]) -> list[Viola
 
 def check_sg_no_public_admin_ingress(tf_files: list[tuple[str, str]]) -> list[Violation]:
     """Flag inline security-group ingress that opens a well-known admin/datastore
-    port (SSH, RDP, Redis, Memcached, Mongo, Elasticsearch, Kibana) to 0.0.0.0/0.
+    port (SSH, RDP, Redis, Memcached, Mongo, Elasticsearch, Kibana) to 0.0.0.0/0
+    or ::/0.
 
     Deliberately scoped to a fixed list of ports that are ~never legitimately
     public — NOT "any public ingress" — so valid public workloads (web on
@@ -622,7 +651,8 @@ def check_sg_no_public_admin_ingress(tf_files: list[tuple[str, str]]) -> list[Vi
     for rel_path, content in tf_files:
         for name, body, line in _extract_blocks(content, "aws_security_group"):
             for ingress_body in _own_blocks(body, "ingress"):
-                if not _ingress_allows_public(ingress_body):
+                public = _ingress_public_cidrs(ingress_body)
+                if not public:
                     continue
                 hit = _ingress_covered_ports(ingress_body, _SENSITIVE_NONDB_PORTS)
                 if not hit:
@@ -637,7 +667,7 @@ def check_sg_no_public_admin_ingress(tf_files: list[tuple[str, str]]) -> list[Vi
                         severity="error",
                         summary=(
                             f"aws_security_group '{name}' opens sensitive port(s) {labels} "
-                            "to 0.0.0.0/0"
+                            f"to {' and '.join(public)}"
                         ),
                         fix_hint=(
                             "Restrict this ingress to a bastion/app security group or a private "

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
@@ -499,7 +499,8 @@ def check_alb_https_policy(terraform_dir: Path) -> list[Violation]:
 
 _DB_PORTS = (5432, 3306)
 
-# Well-known admin / datastore ports that should never be open to 0.0.0.0/0.
+# Well-known admin / datastore ports that should never be open to the whole
+# internet in either address family (0.0.0.0/0 or ::/0).
 # Deliberately EXCLUDES 5432/3306 (covered by db_sg_no_public_ingress, so no
 # double-reporting) and web ports 80/443 (legitimately public). Kept tight to
 # unambiguous "never public" ports so valid designs (e.g. game servers on high

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
@@ -91,15 +91,19 @@ def _read_tf_files(terraform_dir: Path) -> list[tuple[str, str]]:
 _HEREDOC_OPEN = re.compile(r"<<(-?)\s*([A-Za-z_][A-Za-z0-9_]*)")
 
 
-def _lex_hcl(block: str) -> tuple[list[int], list[bool]]:
-    """Scan HCL once, returning per-index (brace depth, is-real-code) arrays.
+def _lex_hcl(block: str) -> tuple[list[int], list[bool], list[bool]]:
+    """Scan HCL once, returning per-index (brace depth, is-real-code, is-comment)
+    arrays.
 
     Only braces that are actual block delimiters count toward depth. HCL permits
     `{` and `}` inside `#` / `//` line comments, `/* */` block comments, quoted
     strings, and heredoc bodies, and those are NOT delimiters — counting them
     would let unrelated text shift the apparent nesting of a real attribute.
     `is_code` additionally lets callers ignore an attribute that only appears
-    commented out.
+    commented out. `is_comment` marks exactly the comment spans (delimiters
+    included, terminating newline excluded), distinguishing them from the other
+    non-code states — a reader that must ignore comments but still read string
+    contents (list entries are quoted strings) needs that distinction.
 
     Interpolations are treated as opaque string content: `{` and `}` inside a
     string are both ignored, so the running depth is unaffected either way. This
@@ -112,6 +116,7 @@ def _lex_hcl(block: str) -> tuple[list[int], list[bool]]:
     n = len(block)
     depths = [0] * n
     codes = [False] * n
+    comments = [False] * n
     depth = 0
     state = "code"
     tag = ""
@@ -124,12 +129,13 @@ def _lex_hcl(block: str) -> tuple[list[int], list[bool]]:
         nxt = block[i + 1] if i + 1 < n else ""
         if state == "code":
             if ch == "#" or (ch == "/" and nxt == "/"):
-                depths[i], codes[i] = depth, False
+                depths[i], codes[i], comments[i] = depth, False, True
                 state = "line_comment"
                 i += 1
                 continue
             if ch == "/" and nxt == "*":
                 depths[i], depths[i + 1] = depth, depth
+                comments[i], comments[i + 1] = True, True
                 state = "block_comment"
                 i += 2
                 continue
@@ -165,10 +171,14 @@ def _lex_hcl(block: str) -> tuple[list[int], list[bool]]:
         if state == "line_comment":
             if ch == "\n":
                 state = "code"
+            else:
+                comments[i] = True
             i += 1
         elif state == "block_comment":
+            comments[i] = True
             if ch == "*" and nxt == "/":
                 depths[i + 1] = depth
+                comments[i + 1] = True
                 state = "code"
                 i += 2
             else:
@@ -203,11 +213,13 @@ def _lex_hcl(block: str) -> tuple[list[int], list[bool]]:
             if terminator == tag:
                 state = "code"
             i = line_end
-    return depths, codes
+    return depths, codes, comments
 
 
 def _extract_braced_block(
-    content: str, open_brace: int, lexed: tuple[list[int], list[bool]] | None = None
+    content: str,
+    open_brace: int,
+    lexed: tuple[list[int], list[bool], list[bool]] | None = None,
 ) -> tuple[str, int]:
     """Return (block_text_including_braces, index_after_close).
 
@@ -217,7 +229,7 @@ def _extract_braced_block(
     body cut before `publicly_accessible = true` reports no violation at all. Pass
     `lexed` to reuse a scan already done for this exact `content`.
     """
-    depths, codes = lexed if lexed is not None else _lex_hcl(content)
+    depths, codes, _ = lexed if lexed is not None else _lex_hcl(content)
     if open_brace >= len(codes) or not codes[open_brace]:
         return content[open_brace:], len(content)
     target = depths[open_brace] + 1
@@ -235,7 +247,7 @@ def _extract_blocks(content: str, resource_type: str) -> list[tuple[str, str, in
     as code. A resource declaration that is itself commented out is skipped.
     """
     lexed = _lex_hcl(content)
-    _, codes = lexed
+    _, codes, _ = lexed
     blocks: list[tuple[str, str, int]] = []
     for match in RESOURCE_OPEN.finditer(content):
         if match.group("type") != resource_type:
@@ -256,7 +268,7 @@ def _own_blocks(body: str, block_type: str) -> list[str]:
     Shares the lexer so a commented-out `ingress {` is not treated as a real rule.
     """
     lexed = _lex_hcl(body)
-    _, codes = lexed
+    _, codes, _ = lexed
     found: list[str] = []
     for match in re.finditer(rf"{re.escape(block_type)}\s*\{{", body):
         if not codes[match.start()]:
@@ -306,7 +318,7 @@ def _first_own_attr(block: str, pattern: str, flags: int = 0) -> re.Match[str] |
     lexically-irrelevant braces must not participate.
     """
     base = 1 if block.lstrip().startswith("{") else 0
-    depths, codes = _lex_hcl(block)
+    depths, codes, _ = _lex_hcl(block)
     for match in re.finditer(pattern, block, flags):
         start = match.start()
         if start < len(codes) and codes[start] and depths[start] == base:
@@ -562,10 +574,19 @@ def _ingress_covers_db_port(ingress_body: str) -> bool:
     return bool(_ingress_covered_ports(ingress_body, _DB_PORTS))
 
 
-# HCL comments: `#` / `//` to end of line, and `/* ... */` spans. Removed before
-# reading CIDR lists so that a range named only in a comment is never treated as
-# an allowed range (and a commented-out attribute is never read as set).
-_HCL_COMMENT = re.compile(r"(?:#|//)[^\n]*|/\*.*?\*/", re.DOTALL)
+def _strip_hcl_comments(text: str) -> str:
+    """Blank out comment spans, using the lexer's classification of them.
+
+    This must share _lex_hcl's single definition of "what counts as code" rather
+    than keep a parallel comment regex: a regex cannot know that a `/*` inside a
+    quoted string does not open a comment, and stripping from such a false opener
+    swallows every real attribute up to the next `*/` — including a live
+    `cidr_blocks = ["0.0.0.0/0"]`, which then reports POLICY_OK. Comment
+    characters are replaced with spaces rather than deleted, so surviving tokens
+    never fuse and line anchors keep working.
+    """
+    _, _, comments = _lex_hcl(text)
+    return "".join(" " if comments[i] else ch for i, ch in enumerate(text))
 
 
 def _attr_list_inner(block: str, attr: str) -> str | None:
@@ -607,12 +628,13 @@ def _ingress_public_cidrs(ingress_body: str) -> list[str]:
     IPv4 `0.0.0.0/0` and IPv6 `::/0` are equally public: on a dual-stack or
     IPv6-only VPC, `::/0` on an admin port is a live exposure. Each family is read
     under its own attribute name so the two are never confused, comments are
-    stripped first, and only quoted string literals count as list entries — so a
-    range mentioned in a comment inside the list is not an allowed range. Values
-    are returned as spelled in the file, so the violation names what is written.
-    Empty list => no unambiguous public exposure.
+    stripped first (by the shared lexer, so a comment marker inside a quoted
+    string is not a comment), and only quoted string literals count as list
+    entries — so a range mentioned in a comment inside the list is not an allowed
+    range. Values are returned as spelled in the file, so the violation names
+    what is written. Empty list => no unambiguous public exposure.
     """
-    body = _HCL_COMMENT.sub("", ingress_body)
+    body = _strip_hcl_comments(ingress_body)
     found: list[str] = []
     for attr in ("cidr_blocks", "ipv6_cidr_blocks"):
         inner = _attr_list_inner(body, attr)

--- a/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
+++ b/migrate/plugins/migration-to-aws/skills/tf-best-practices/scripts/validate-terraform-policy.py
@@ -44,6 +44,7 @@ Exit 0 on POLICY_OK, 1 on POLICY_FAIL, 2 on usage/IO error.
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import re
 import sys
@@ -560,34 +561,65 @@ def _ingress_covers_db_port(ingress_body: str) -> bool:
     return bool(_ingress_covered_ports(ingress_body, _DB_PORTS))
 
 
+# HCL comments: `#` / `//` to end of line, and `/* ... */` spans. Removed before
+# reading CIDR lists so that a range named only in a comment is never treated as
+# an allowed range (and a commented-out attribute is never read as set).
+_HCL_COMMENT = re.compile(r"(?:#|//)[^\n]*|/\*.*?\*/", re.DOTALL)
+
+
 def _attr_list_inner(block: str, attr: str) -> str | None:
     """Return the raw text inside a literal `attr = [ ... ]`, else None.
 
-    Anchored at line start (like _attr_string / _attr_int) so that `cidr_blocks`
-    does NOT also match the tail of `ipv6_cidr_blocks` — reading one list while
-    believing it is the other silently inverts the verdict.
+    The name must start a line OR directly follow a `{`. The line-start arm keeps
+    `cidr_blocks` from matching the tail of `ipv6_cidr_blocks` (reading one list
+    while believing it is the other silently inverts the verdict); the brace arm
+    keeps an attribute that shares its block's opening line visible, e.g.
+    `ingress { cidr_blocks = [...]`, which is valid HCL that a line-anchored
+    pattern alone would miss.
     """
     m = re.search(
-        rf"^\s*{re.escape(attr)}\s*=\s*\[(.*?)\]",
+        rf"(?:^|\{{)\s*{re.escape(attr)}\s*=\s*\[(.*?)\]",
         block,
         re.DOTALL | re.MULTILINE,
     )
     return m.group(1) if m else None
 
 
+def _is_entire_internet(cidr: str) -> bool:
+    """True if `cidr` is a literal range covering the whole address space.
+
+    Canonicalises through `ipaddress` instead of comparing text, because IPv6 has
+    many legal spellings of the zero address (`::/0`, `::0/0`, `0:0:0:0:0:0:0:0/0`)
+    and nothing in Terraform normalises them — `terraform fmt` treats a CIDR as an
+    opaque string. Anything that is not a parseable literal (`var.x`, `${...}`,
+    malformed text) returns False, preserving the module's fail-open posture.
+    """
+    try:
+        return ipaddress.ip_network(cidr, strict=False).prefixlen == 0
+    except ValueError:
+        return False
+
+
 def _ingress_public_cidrs(ingress_body: str) -> list[str]:
     """Return the "entire internet" CIDRs this ingress rule allows, both families.
 
-    IPv4 `0.0.0.0/0` in cidr_blocks and IPv6 `::/0` in ipv6_cidr_blocks are
-    equally public: on a dual-stack or IPv6-only VPC, ::/0 on an admin port is a
-    live exposure. Each list is read under its own anchored attribute name so the
-    two are never confused. Empty list => no unambiguous public exposure.
+    IPv4 `0.0.0.0/0` and IPv6 `::/0` are equally public: on a dual-stack or
+    IPv6-only VPC, `::/0` on an admin port is a live exposure. Each family is read
+    under its own attribute name so the two are never confused, comments are
+    stripped first, and only quoted string literals count as list entries — so a
+    range mentioned in a comment inside the list is not an allowed range. Values
+    are returned as spelled in the file, so the violation names what is written.
+    Empty list => no unambiguous public exposure.
     """
+    body = _HCL_COMMENT.sub("", ingress_body)
     found: list[str] = []
-    for attr, public in (("cidr_blocks", "0.0.0.0/0"), ("ipv6_cidr_blocks", "::/0")):
-        inner = _attr_list_inner(ingress_body, attr)
-        if inner is not None and public in inner:
-            found.append(public)
+    for attr in ("cidr_blocks", "ipv6_cidr_blocks"):
+        inner = _attr_list_inner(body, attr)
+        if inner is None:
+            continue
+        for cidr in re.findall(r'"([^"]*)"', inner):
+            if _is_entire_internet(cidr) and cidr not in found:
+                found.append(cidr)
     return found
 
 


### PR DESCRIPTION
## Problem

`skills/tf-best-practices/scripts/validate-terraform-policy.py` reported **`POLICY_OK`, exit 0** for security groups that are open to the entire internet. The validator is used as a gate, so it told users an exposed configuration was safe — worse than having no validator, because it manufactures false assurance.

Two defects, both in `_ingress_allows_public`:

**1. `::/0` was never checked.** No IPv6 "entire internet" range appeared anywhere in the file. An SG opening port 22 or 5432 to `ipv6_cidr_blocks = ["::/0"]` passed cleanly. On IPv6-default and dual-stack VPCs that is a live exposure.

**2. The IPv4 check was order-dependent.** The regex

```python
re.search(r"cidr_blocks\s*=\s*\[(.*?)\]", ingress_body, re.DOTALL)
```

also matches the tail of `ipv6_cidr_blocks`. Since `re.search` returns the *first* match, when the IPv6 attribute was declared first the checker read the **IPv6** list while believing it was reading IPv4, then searched it for `0.0.0.0/0`.

This second defect is the more serious one, because it breaks the rule's original purpose with **no IPv6 exposure involved at all**. Verified against the pre-fix code — the same SG, semantically identical, differing only in the order of two lines:

| Attribute order | `cidr_blocks = ["0.0.0.0/0"]` on port 22 |
|---|---|
| `ipv6_cidr_blocks` first | **`POLICY_OK`, exit 0** ❌ |
| `cidr_blocks` first | `POLICY_FAIL`, exit 1 ✅ |

So a plain IPv4 SSH-open-to-the-world finding was missed in purely IPv4 environments too, whenever `ipv6_cidr_blocks` happened to be written first. Neither Terraform nor common formatters constrain that ordering.

## Solution

Replace `_ingress_allows_public` with `_ingress_public_cidrs`, which:

- reads `cidr_blocks` and `ipv6_cidr_blocks` as **separate, line-anchored** attributes (`^\s*{attr}\s*=`), matching the `_attr_string` / `_attr_int` idiom already used in this file, so the two lists can never be confused;
- checks each address family against its own "entire internet" range (`0.0.0.0/0` / `::/0`);
- returns the matched CIDRs, so violation messages name the family that actually fired instead of hardcoding `0.0.0.0/0`.

Both `db_sg_no_public_ingress` and `sg_no_public_admin_ingress` consumed the old helper, so both rules are fixed by the one change: both now cover dual-stack and IPv6-only VPCs, and neither depends on attribute order.

The existing fail-open scope is deliberately unchanged — only inline `ingress { ... }` blocks are inspected, and separate `aws_security_group_rule` / `aws_vpc_security_group_ingress_rule` resources still fail open, as documented.

### Tests

- **`bad-sg-public-ipv6`** — `ipv6_cidr_blocks = ["::/0"]` declared *before* a benign IPv4 list, on ports 22 and 5432. Was `POLICY_OK`; now `POLICY_FAIL` on both rules.
- **`good-sg-ipv6-scoped`** — false-positive guard: public web over `::/0` (not a sensitive port) plus SSH/Postgres over a scoped `2001:db8:1234::/48` must still pass.
- **`test_ipv4_public_ingress_caught_when_ipv6_list_declared_first`** — asserts the IPv4 verdict is identical under both attribute orderings. Confirmed to fail against the pre-fix validator on the `ipv6-first` ordering, so it is a real regression guard rather than a tautology.

27 tests pass. New fixtures are already covered by the existing `.checkov.yaml` `skip-path` entry for `fixtures/terraform-policy`, and use RFC 3849 documentation addresses.

### Note for maintainers

Two pre-existing items I did **not** change, to keep this PR scoped:

1. `mise run build` and CI do not run this skill's `pytest` suite (`[tasks.test]` runs only `node --test` on the frontmatter validator; no workflow invokes pytest). I ran it manually — `27 passed` — but CI will not catch regressions in these rules. Happy to wire it up in a follow-up if you want.
2. The inline-only fail-open scope means a `::/0` or `0.0.0.0/0` exposure declared via a separate `aws_security_group_rule` resource still passes silently. Documented behaviour, but the same class of false assurance; worth a separate issue if gate coverage there is wanted.

## Type of Change

- [ ] New plugin/power/tool
- [x] Bug fix
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Guardrail/CI update

## Team Folder

- [ ] `advisor/`
- [x] `migrate/`
- [ ] Other: ___

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [x] I have run `mise run build` locally and it passes
- [x] I have updated documentation if needed
- [x] My changes are scoped to my team's folder only

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
