### PR TITLE
Rewrite AWS Startup Advisor listing description to lead with concrete claim

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "aws-startup-advisor",
       "source": "./advisor/plugins/aws-startup-advisor",
       "version": "1.5.4",
-      "description": "Three sibling skills for startups building on AWS: knowledge-base-for-startups (Activate FAQ, credits, programs, partner offers, sample architectures, learn articles), prompt-library-for-startups (copy-paste prompts + downloadable installable agents), and start-building-for-startups (interactive discovery workflow that scaffolds an AWS architecture)"
+      "description": "Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, from day-one account setup to production-ready infrastructure. Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support."
     },
     {
       "name": "aws-dev-toolkit",

--- a/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
   "version": "1.5.4",
-  "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
+  "description": "Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, from day-one account setup to production-ready infrastructure. Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support.",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-startup-advisor",
   "version": "1.5.4",
-  "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
+  "description": "Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, from day-one account setup to production-ready infrastructure. Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support.",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com"
@@ -45,7 +45,10 @@
     "longDescription": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.\n\nFeatures\nVetted prompts for startups at every stage:\n\n\nDay-one account setup, security baseline, least-privilege roles\nScaffold a production architecture for your stack\nSet up GuardDuty, Security Hub, and a vulnerability scanner\nMigrate from GCP or OpenAI or Gemini\n\n\nAWS Activate Benefits\nCheck eligibility and explore offers available to startups on AWS:\n\n\nAWS Activate Credits: Check eligibility and learn how to apply for credits to offset costs across 200+ services, including infrastructure, data services, and AI/ML models on Bedrock.\nExclusive Startup Offers: Access discounts and extended trials on dozens of tools for payments, analytics, communications, and developer productivity.",
     "developerName": "Amazon Web Services",
     "category": "Developer Tools",
-    "capabilities": ["Read", "Write"],
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
     "websiteURL": "https://github.com/awslabs/startups/tree/main/advisor",
     "defaultPrompt": [
       "Help me build an MVP on AWS",

--- a/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
+++ b/advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-startup-advisor",
   "displayName": "AWS Startup Advisor",
-  "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
+  "description": "Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, from day-one account setup to production-ready infrastructure. Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support.",
   "version": "1.5.4",
   "author": {
     "name": "Amazon Web Services"


### PR DESCRIPTION
Rewrites the plugin listing description so the '350,000+ startups' scale claim and all four capability areas (architecture, cost, security, migration) land above the ~110-character truncation point on the plugin card.

**Files updated:**
- `.claude-plugin/marketplace.json` — aws-startup-advisor entry
- `advisor/plugins/aws-startup-advisor/.claude-plugin/plugin.json`
- `advisor/plugins/aws-startup-advisor/.cursor-plugin/plugin.json`
- `advisor/plugins/aws-startup-advisor/.codex-plugin/plugin.json`

All four surfaces now carry the identical canonical description:

> Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, from day-one account setup to production-ready infrastructure. Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support.

**First ~110 chars rendered:**
> Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration

Copy-only change; no runtime impact.