### PR TITLE
fix: replace github.io URLs and soften MCP install instructions in prompt-library-for-startups

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/aws-architecture-assessment-with-mcp-integration.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/aws-architecture-assessment-with-mcp-integration.md
@@ -12,7 +12,7 @@ Systematic roadmap for scaling infrastructure as you grow. Get phased architectu
 
 ## Scaling from 10K to 10M Users - AWS Architecture Assessment
 
-Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, then fetch the install instructions at <https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server/> and install it for me before re-running this prompt.
+Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, see the setup instructions at <https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server> and configure it before re-running this prompt.
 
 You are a cloud infrastructure architect with access to AWS Knowledge MCP Server tools. Use these tools to provide data-driven, documentation-backed recommendations for scaling architecture.
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/multi-region-assessment.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/multi-region-assessment.md
@@ -1063,7 +1063,7 @@ Prerequisites:
 - Active AWS account
 - AWS CLI configured with credentials
 - Kiro-CLI - https://kiro.dev/docs/cli/
-- AWS Well-Architected Security Assessment Tool MCP Server - https://awslabs.github.io/mcp/servers/well-architected-security-mcp-server
+- AWS Well-Architected Security Assessment Tool MCP Server - https://github.com/awslabs/mcp/tree/main/src/well-architected-security-mcp-server
 
 Use case examples:
 
@@ -1268,5 +1268,5 @@ Do not skip, consolidate, or summarize any active regions.
 - Active AWS account
 - AWS CLI configured with credentials
 - Kiro-CLI - [https://kiro.dev/docs/cli/](https://kiro.dev/docs/cli/)
-- AWS Well-Architected Security Assessment Tool MCP Server - [https://awslabs.github.io/mcp/servers/well-architected-security-mcp-server](https://awslabs.github.io/mcp/servers/well-architected-security-mcp-server)
+- AWS Well-Architected Security Assessment Tool MCP Server - [https://github.com/awslabs/mcp/tree/main/src/well-architected-security-mcp-server](https://github.com/awslabs/mcp/tree/main/src/well-architected-security-mcp-server)
 ```

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/open-source-llm-inference.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/open-source-llm-inference.md
@@ -97,11 +97,7 @@ aws secretsmanager create-secret \
   --region $AWS_REGION
 ```
 
-Then install the Secrets Store CSI driver and AWS provider. Follow the official Helm install instructions in the upstream chart README: <https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/README.md>
-
-```bash
-helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace kube-system
-```
+Then install the Secrets Store CSI driver and AWS provider by following the official Helm install instructions in the upstream chart README: <https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/README.md>
 
 Create a SecretProviderClass that maps the Secrets Manager secret to a Kubernetes secret:
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/open-source-llm-inference.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/open-source-llm-inference.md
@@ -97,10 +97,9 @@ aws secretsmanager create-secret \
   --region $AWS_REGION
 ```
 
-Then install the Secrets Store CSI driver and AWS provider:
+Then install the Secrets Store CSI driver and AWS provider. Follow the official Helm install instructions in the upstream chart README: <https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/README.md>
 
 ```bash
-helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace kube-system
 ```
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/openapi-to-agentcore-gateway-deployment.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/openapi-to-agentcore-gateway-deployment.md
@@ -278,7 +278,7 @@ Example Usage:
    b. Review the Quick Cloud Cost Optimization guide for early-stage startups to set up budgets, monitor spend, and turn off unused resources
 1. Install the AWS CLI
    a. Download and install the AWS CLI for your operating system.
-1. Configure AgentCore MCP https://awslabs.github.io/mcp/servers/amazon-bedrock-agentcore-mcp-server in your AI tool (e.g. Kiro-CLI)
+1. Configure AgentCore MCP https://github.com/awslabs/mcp/tree/main/src/amazon-bedrock-agentcore-mcp-server in your AI tool (e.g. Kiro-CLI)
 1. Enter a working folder. Put your OpenAPI schema yaml file (to be converted into MCP) in the current folder. Also put the API implementation code files in the same folder as well (to be hosted in AWS Lambda function)
 1. Copy the prompt
    a. Click "Copy Prompt" to copy the prompt into your clipboard.

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/resiliency-baseline-evaluation.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/resiliency-baseline-evaluation.md
@@ -12,7 +12,7 @@ AWS resilience baseline assessment framework with RTO/RPO gap analysis, prioriti
 
 ## AWS Startup Resiliency Baseline (AWS SRB) Evaluation
 
-Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, then fetch the install instructions at <https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server/> and install it for me before re-running this prompt.
+Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, see the setup instructions at <https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server> and configure it before re-running this prompt.
 
 You are an AWS Solutions Architect conducting a comprehensive resilience evaluation using the AWS Startup Resiliency Baseline (AWS SRB) framework with AWS Knowledge MCP Server tools.
 

--- a/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/security-baseline-evaluation.md
+++ b/advisor/plugins/aws-startup-advisor/skills/prompt-library-for-startups/references/prompt-library/security-baseline-evaluation.md
@@ -12,7 +12,7 @@ AWS security baseline assessment framework with risk scoring and remediation roa
 
 ## AWS Startup Security Baseline (AWS SSB) Evaluation - Comprehensive Security Posture Assessment
 
-Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, then fetch the install instructions at <https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server/> and install it for me before re-running this prompt.
+Prerequisite: This prompt requires the AWS Knowledge MCP server. If it isn't already installed and available to you, see the setup instructions at <https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server> and configure it before re-running this prompt.
 
 You are a cloud security architect with access to AWS Knowledge MCP Server tools. Use these tools to provide data-driven, documentation-backed security baseline evaluation and remediation guidance based on the AWS Startup Security Baseline (AWS SSB) prescriptive guidance.
 


### PR DESCRIPTION
Replaces all 7 *.github.io URLs in the prompt-library-for-startups skill with github.com equivalents (or upstream README pointers), and softens three agent-directed MCP install instructions to a review-first phrasing. These URLs trigger Gen Digital's Agent Trust Hub URL reputation scanner, contributing to a Critical Risk rating on skills.sh.

## Changes

### URL replacements (docs links -> github.com)
- `multi-region-assessment.md` (x2): `awslabs.github.io/mcp/servers/well-architected-security-mcp-server` -> `github.com/awslabs/mcp/tree/main/src/well-architected-security-mcp-server`
- `openapi-to-agentcore-gateway-deployment.md`: `awslabs.github.io/mcp/servers/amazon-bedrock-agentcore-mcp-server` -> `github.com/awslabs/mcp/tree/main/src/amazon-bedrock-agentcore-mcp-server`

### Install-instruction rewording (3 prompt files)
- `aws-architecture-assessment-with-mcp-integration.md`, `resiliency-baseline-evaluation.md`, `security-baseline-evaluation.md`: the AWS Knowledge MCP prerequisite line changed from "fetch the install instructions at <github.io URL> and install it for me" to "see the setup instructions at <github.com URL> and configure it". Removes the agent-directed auto-install pattern and points at the canonical repo. (Note: the old `aws-knowledge-mcp-server/` github.io URL was a 404; the other two swapped github.io docs pages were live 200s, so those two swaps are scanner-driven rather than broken-link fixes.)

### Helm chart repo (open-source-llm-inference.md)
- Removed the `helm repo add ... kubernetes-sigs.github.io ...` line and the dependent `helm install` command, replacing them with a pointer to the upstream chart README (`github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/README.md`). Unlike the docs links above, this is a functional Helm chart-repo endpoint and this chart is only published via that GitHub Pages repo, so there is no non-github.io form of the command; rather than leave a github.io URL or a broken `<alias>/<chart>` install with no `repo add`, the section now defers entirely to the upstream README.

## Scope
This PR is intentionally scoped to the `prompt-library-for-startups` skill. Other *.github.io URLs remain elsewhere in the repo (e.g. `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` boilerplate, `migration-to-aws` schema `$id` identifiers, and `heroku-to-aws/.../generate-eks.md`). If the scanner reads the whole repo rather than the published skill, those would need a separate change.

## Verification
- All github.com destination URLs verified live (HTTP 200)
- No *.github.io URLs remain in the prompt-library-for-startups skill
- `markdownlint-cli2`: 0 errors
- No broken commands left in the changeset (the previously non-runnable `helm install` was removed)