### PR TITLE
docs: lead with /plugin install path in advisor README and setup.md

### DIFF
--- a/advisor/README.md
+++ b/advisor/README.md
@@ -22,6 +22,18 @@ The other three skills do not require MCP servers.
 
 ## Install
 
+### Claude Code (recommended)
+
+Install as a registered plugin in one command — no Node.js required:
+
+```bash
+/plugin install aws-startup-advisor@claude-plugins-official
+```
+
+This installs all 5 skills and registers the plugin in the Claude Code directory.
+
+### All other agents (Kiro, Cursor, Codex, Copilot, etc.)
+
 **Prerequisite:** Node.js 18+ (ships with `npx`). Grab the LTS or current release for your OS from [nodejs.org/en/download](https://nodejs.org/en/download). Verify with `node -v && npx -v`.
 
 Install all skills at once into a single agent:

--- a/advisor/plugins/aws-startup-advisor/setup.md
+++ b/advisor/plugins/aws-startup-advisor/setup.md
@@ -2,9 +2,26 @@
 
 You are an AI coding agent. Follow these instructions exactly.
 
-## Step 1: Check for Node.js
+## Step 1: Detect your environment
+
+Determine which agent you are running as:
+
+- If you are **Claude Code** (you have access to the `/plugin` command), go to **Step 2A**.
+- If you are **any other agent** (Kiro, Cursor, Codex, Copilot, etc.), go to **Step 2B**.
+
+## Step 2A: Install via Claude Code plugin (preferred)
 
 Run:
+
+```bash
+/plugin install aws-startup-advisor@claude-plugins-official
+```
+
+This installs AWS Startup Advisor as a registered Claude Code plugin. Skip to **Step 3** to confirm success.
+
+## Step 2B: Install via npx (non-Claude agents)
+
+Check for Node.js:
 
 ```bash
 node -v
@@ -15,8 +32,6 @@ If this fails with "command not found", tell the user:
 > "Node.js is required but not installed. Download it from https://nodejs.org (LTS recommended), install it, then ask me to try again."
 
 Stop here until Node.js is available. Do not proceed without it.
-
-## Step 2: Install the skills
 
 Run:
 


### PR DESCRIPTION
Addresses StartupEngBlend-3023. Both `advisor/README.md` and `advisor/plugins/aws-startup-advisor/setup.md` previously documented only the `npx skills add` install path. This change leads with the Claude Code plugin-install path so that installs through the documented flow register in the Claude Code plugin metric.

## Changes

### advisor/README.md
Added a "Claude Code (recommended)" section above the existing npx instructions:
```
/plugin install aws-startup-advisor@claude-plugins-official
```
The existing `npx skills add` content is preserved under a new "All other agents" subheading.

### advisor/plugins/aws-startup-advisor/setup.md
Restructured the agent-facing install flow:
- **Step 1:** Detect environment (Claude Code vs. other)
- **Step 2A:** Claude Code → `/plugin install aws-startup-advisor@claude-plugins-official` (preferred)
- **Step 2B:** All others → Node.js check + `npx skills add` (unchanged)
- **Step 3:** Confirm success (unchanged)

## What's preserved
- The `npx skills add` path is fully documented for non-Claude agents (Kiro, Cursor, Codex, Copilot)
- All per-agent examples, global install, and single-skill install instructions are unchanged

## Verification
- `markdownlint-cli2`: 0 errors
- Documentation-only change, no runtime impact