### PR TITLE
chore: refresh advisor/OWNERS.yaml from AWS MASH to AWS BLEND

### DIFF
--- a/advisor/OWNERS.yaml
+++ b/advisor/OWNERS.yaml
@@ -1,10 +1,10 @@
-team: AWS MASH
-resolver_group: aws-mash
+team: AWS BLEND
+resolver_group: aws-blend
 cti:
   category: AWS
   type: Activate
-  item: MASH - General Support
+  item: Blend - General Support
 contacts:
-  primary: aws-mash
-  oncall: aws-mash-oc-primary
+  primary: aws-blend
+  oncall: aws-distill-oc-primary
 github_team: "@awslabs/startups-advisor"


### PR DESCRIPTION
Addresses StartupEngBlend-3028. Updates `advisor/OWNERS.yaml` to reflect the ownership transfer from AWS MASH to AWS BLEND.

## Changes

| Field | Before | After |
|---|---|---|
| team | AWS MASH | AWS BLEND |
| resolver_group | aws-mash | aws-blend |
| cti.item | MASH - General Support | Blend - General Support |
| contacts.primary | aws-mash | aws-blend |
| contacts.oncall | aws-mash-oc-primary | aws-distill-oc-primary |
| github_team | @awslabs/startups-advisor | @awslabs/startups-advisor (unchanged) |

## CODEOWNERS

`.github/CODEOWNERS` routes `/advisor/` to `@awslabs/startups-advisor` — confirmed this is already AWS BLEND's GitHub team. No change needed.

## Note

This is admin-gated (`OWNERS.yaml` requires `@awslabs/startups-admins` approval).