### PR TITLE
feat(solution-architecture): add aws-startups-solution-architecture plugin with Agent Toolkit for AWS as upstream dependency

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,6 +4,7 @@
     "name": "Amazon Web Services"
   },
   "description": "AI-powered build and migrate guidance from AWS, built for startups at any stage.",
+  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
   "plugins": [
     {
       "name": "migration-to-aws",
@@ -16,6 +17,12 @@
       "source": "./advisor/plugins/aws-startup-advisor",
       "version": "2.0.0",
       "description": "Personalized AWS guidance built on patterns from 350,000+ startups—architecture, cost, security, and migration, now including the full migration toolkit. Build on AWS (day-one setup, security baselines, production architecture, cost optimization) and migrate to AWS from GCP or Heroku: infrastructure (Cloud Run/Dynos → Fargate, databases → RDS/Aurora), OpenAI/Gemini/Anthropic workloads to Amazon Bedrock, agentic systems (LangChain, CrewAI, AutoGen), and Temporal workers. Generates runnable Terraform, migration scripts, provider adapters, and deployment artifacts, with honest model-by-model pricing comparisons so you know exactly when Bedrock saves money and when it doesn't. Plus knowledge-base-for-startups (Activate FAQ, credits, offers, sample architectures, learn articles), prompt-library-for-startups (copy-paste prompts + installable agents), start-building-for-startups (interactive scaffolding), and agent-advisor (agent runtime selection). Includes AWS Activate credits eligibility and 60+ exclusive startup offers. Built by AWS Startup Solutions Architects, with multi-account, multi-region support."
+    },
+    {
+      "name": "aws-startups-solution-architecture",
+      "source": "./solution-architecture/plugins/aws-startups-solution-architecture",
+      "version": "0.1.0",
+      "description": "Field practice from the AWS Startups Solution Architecture team, for the Solutions Architects and technical founders who run startup engagements. Prepare and run a startup architecture review, size an engagement to a company's stage and runway, pressure-test a design against a team that has no dedicated ops or security staff, and turn the result into a written recommendation. Draws all general-purpose AWS service depth from Agent Toolkit for AWS (aws-core, aws-agents) as upstream dependencies rather than restating it."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ AI agent plugins, tools, and resources for startup builders on AWS.
 
 ## Plugins
 
-| Plugin                              | Description                                                                                                                                                                                                                                                                                                                                                                          | Status    |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
-| **[aws-startup-advisor](advisor/)** | Startup-focused build + migrate guidance built on patterns from 350,000+ startups: AWS Activate credits & offers, a knowledge base (sample architectures, learn articles), a copy-paste prompt library, stage-aware architecture advice, and interactive scaffolding — plus the full migration toolkit (gcp-to-aws, heroku-to-aws, llm-to-bedrock, agent-advisor, tf-best-practices) | Available |
-| **[migration-to-aws](migrate/)**    | Assess, plan & execute: migrate GCP/Heroku infrastructure and AI workloads to AWS (discovery, architecture mapping, cost analysis, Terraform), rewrite LLM SDK calls to Amazon Bedrock, and select an AWS runtime + build a POC for AI agents. Bundles the gcp-to-aws, heroku-to-aws, llm-to-bedrock, and agent-advisor skills                                                       | Available |
+| Plugin                                                           | Description                                                                                                                                                                                                                                                                                                                                                                          | Status    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| **[aws-startup-advisor](advisor/)**                              | Startup-focused build + migrate guidance built on patterns from 350,000+ startups: AWS Activate credits & offers, a knowledge base (sample architectures, learn articles), a copy-paste prompt library, stage-aware architecture advice, and interactive scaffolding — plus the full migration toolkit (gcp-to-aws, heroku-to-aws, llm-to-bedrock, agent-advisor, tf-best-practices) | Available |
+| **[migration-to-aws](migrate/)**                                 | Assess, plan & execute: migrate GCP/Heroku infrastructure and AI workloads to AWS (discovery, architecture mapping, cost analysis, Terraform), rewrite LLM SDK calls to Amazon Bedrock, and select an AWS runtime + build a POC for AI agents. Bundles the gcp-to-aws, heroku-to-aws, llm-to-bedrock, and agent-advisor skills                                                       | Available |
+| **[aws-startups-solution-architecture](solution-architecture/)** | Field practice for the Solutions Architects and technical founders who run startup engagements: scope an architecture review to stage and runway, run a low-ceremony build loop with a founder, and pressure-test a design before it gets built. Draws general-purpose AWS service depth from Agent Toolkit for AWS as an upstream dependency                                        | Available |
 
 ## Installation
 
@@ -75,7 +76,13 @@ awslabs/startups/
 │       └── migration-to-aws/         # Assess, plan, execute + agent runtime advisor
 │                                      #   skills: gcp-to-aws, heroku-to-aws,
 │                                      #           llm-to-bedrock, agent-advisor
-├── solution-architecture/            # Solution Architecture plugins (none published)
+├── solution-architecture/            # Solution Architecture plugins
+│   └── plugins/
+│       └── aws-startups-solution-architecture/
+│                                      #   skills: startup-architecture-review,
+│                                      #           founder-build-loop,
+│                                      #           startup-design-challenger
+│                                      #   deps: aws-core, aws-agents (Agent Toolkit for AWS)
 └── ...                               # Future team folders
 ```
 

--- a/solution-architecture/CONTRIBUTING.md
+++ b/solution-architecture/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to `solution-architecture/`
+
+This folder is open to contribution. It is also the folder whose previous plugin, `aws-dev-toolkit`, was removed because its content had grown into a duplicate of [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws). The gate below exists so that does not happen again.
+
+Read the [root contributing guide](../CONTRIBUTING.md) first for the RFC process, code of conduct, security reporting, and licensing. This document adds the content gate specific to this folder.
+
+## The gate: all three criteria must pass
+
+A contribution is accepted only if it passes **all three**. Two out of three is a rejection, not a majority.
+
+### 1. Startup-specific, not general-purpose AWS
+
+The contribution must be meaningfully tailored to startups: startup stage, runway, credits and AWS Activate, lean-team defaults (no dedicated ops or security staff), or founder workflows.
+
+General-purpose AWS service guidance that would read identically for an enterprise fails this criterion and belongs in Agent Toolkit for AWS.
+
+This is the criterion that keeps the folder from re-accumulating the general-purpose content that caused the previous removal.
+
+**Referencing AWS products and services is expected and allowed.** The test is whether the _framing_ is startup-specific, not whether AWS services are named. A skill about DynamoDB capacity modes fails. A skill about what to do when your credits expire in six weeks and DynamoDB is your largest line item passes.
+
+### 2. No overlap with Agent Toolkit for AWS
+
+If Agent Toolkit for AWS already covers the capability, the contribution is a duplicate and fails.
+
+**This is the load-bearing check**, because overlap is the conflict that drove the previous deprecation. Before contributing, check the upstream skill list in [`aws-core`](https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-core/skills) and [`aws-agents`](https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-agents/skills). Those plugins are declared as upstream dependencies, so their skills are already available to anyone who installs from this folder. Restating them here is strictly worse than depending on them.
+
+Also check [AWS Startup Advisor](../advisor/) for overlap. Founder-facing stage advice, AWS Activate, and credits guidance live there, not here.
+
+Do not use the word "toolkit" in a plugin, skill, or agent name in this folder.
+
+### 3. No deprecated or sunset AWS services
+
+Contributions must not reference, recommend, or depend on AWS services that are deprecated, sunset, or closed to new customers.
+
+Naming a sunset service in order to warn against it, or to describe a migration away from it, is fine. Recommending one as a forward-looking choice is not. Verify current status against AWS documentation rather than from model memory, which reproduces retired service names and deprecated constructs from stale training data.
+
+## Make "startup-specific" explicit, not inferred
+
+A reviewer should not have to infer startup-specificity from prose. Declare it so the check is deterministic and auditable.
+
+- **Required frontmatter field.** Every `SKILL.md` in this folder must declare `audience: startup` under `metadata`:
+
+  ```yaml
+  ---
+  name: your-skill
+  description: "..."
+  metadata:
+    audience: startup
+  ---
+  ```
+
+- **Startup framing in the description.** The `description` should state the startup framing directly (stage, runway, credits, lean-team context), the way the AWS Startup Advisor skills do, rather than describing a generic AWS capability.
+
+- **Keywords.** Startup-relevant keywords (`activate`, `credits`, `startup`, `stage`, `runway`) should appear in the skill metadata where they genuinely apply. Do not keyword-stuff: a skill that mentions runway once to pass a grep, while otherwise being general-purpose service guidance, fails criterion 1 on review.
+
+The frontmatter field is the mechanical signal. The reviewer still judges criteria 1 and 2 on substance, because a declared field can be added to any file, and the point of the gate is the substance rather than the field.
+
+## Prefer an upstream dependency over a copy
+
+If a capability exists in Agent Toolkit for AWS, declare it as a dependency rather than vendoring it. See [plugin dependencies](https://code.claude.com/docs/en/plugin-dependencies).
+
+Dependencies on plugins in `claude-plugins-official` require that marketplace to be listed in `allowCrossMarketplaceDependenciesOn` in the root `.claude-plugin/marketplace.json`, which it already is. Note that a semver constraint on those dependencies will fail to resolve until the upstream repository publishes `{plugin-name}--v{version}` git tags, so declare them unversioned for now.
+
+## Before opening a PR
+
+- `mise run fmt` and `mise run lint:md` are clean.
+- `claude plugin validate <your-plugin-dir>` passes, and `claude plugin validate .` passes if you touched the marketplace.
+- If you added a plugin or changed dependencies, install it from a local marketplace once and confirm it enables with no dependency errors.
+- Every new `SKILL.md` declares `audience: startup`.
+- No em dashes or en dashes, matching the existing prose style in this folder.
+
+## Review
+
+Changes here require review from the Solution Architecture team, plus admin review for marketplace, `SKILL.md`, and plugin-manifest changes. See [CODEOWNERS](../.github/CODEOWNERS) for the current routing.
+
+**AgentCore review.** Contributions to this folder additionally require review from the AgentCore SME. Agent and AgentCore guidance is owned upstream by the [`aws-agents`](https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-agents) plugin, which this folder consumes as a dependency, so agent-related content here is the likeliest place for criterion 2 overlap to reappear. Request that review on every PR in this folder rather than only on files with "agent" in the name, since the overlap usually arrives inside a skill about something else.
+
+This requirement is documented here rather than in `CODEOWNERS` because GitHub silently ignores a `CODEOWNERS` entry that names a team which does not exist or lacks write access to the repository. Add the entry once the reviewing team or user handle is confirmed, at which point this paragraph can point at it instead.

--- a/solution-architecture/README.md
+++ b/solution-architecture/README.md
@@ -2,7 +2,9 @@
 
 Startup-specific plugins and tools from the AWS Startups Solution Architecture team.
 
-No plugins are currently published from this folder.
+## Plugins
+
+- **[`aws-startups-solution-architecture`](plugins/aws-startups-solution-architecture/)** — Field practice for the Solutions Architects and technical founders who run startup engagements: scope an architecture review to a company's stage and runway, run a low-ceremony build loop with a founder, and pressure-test a design before it gets built. Draws all general-purpose AWS service depth from [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws) as an upstream dependency rather than restating it.
 
 ## Where aws-dev-toolkit went
 

--- a/solution-architecture/README.md
+++ b/solution-architecture/README.md
@@ -4,7 +4,7 @@ Startup-specific plugins and tools from the AWS Startups Solution Architecture t
 
 ## Plugins
 
-- **[`aws-startups-solution-architecture`](plugins/aws-startups-solution-architecture/)** — Field practice for the Solutions Architects and technical founders who run startup engagements: scope an architecture review to a company's stage and runway, run a low-ceremony build loop with a founder, and pressure-test a design before it gets built. Draws all general-purpose AWS service depth from [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws) as an upstream dependency rather than restating it.
+- **[`aws-startups-solution-architecture`](plugins/aws-startups-solution-architecture/)**. Field practice for the Solutions Architects and technical founders who run startup engagements. Scope an architecture review to a company's stage and runway, run a low-ceremony build loop with a founder, and pressure-test a design before it gets built. Draws all general-purpose AWS service depth from [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws) as an upstream dependency rather than restating it.
 
 ## Where aws-dev-toolkit went
 
@@ -17,7 +17,9 @@ Existing `aws-dev-toolkit` installs continue to function but receive no updates.
 
 ## Contributing
 
-See the [root CONTRIBUTING guide](../CONTRIBUTING.md). Contributions to this folder must be startup-specific rather than general-purpose AWS guidance, so they do not re-create the overlap with Agent Toolkit for AWS that led to the previous plugin's removal.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the content gate that applies to this folder, and the [root CONTRIBUTING guide](../CONTRIBUTING.md) for the RFC process, code of conduct, and licensing.
+
+Contributions here must pass all three criteria: startup-specific rather than general-purpose AWS guidance, no overlap with Agent Toolkit for AWS, and no reference to deprecated or sunset AWS services. The gate exists so this folder does not re-create the overlap that led to the previous plugin's removal.
 
 ## License
 

--- a/solution-architecture/plugins/aws-startups-solution-architecture/.claude-plugin/plugin.json
+++ b/solution-architecture/plugins/aws-startups-solution-architecture/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "aws-startups-solution-architecture",
+  "displayName": "AWS Startups Solution Architecture",
+  "version": "0.1.0",
+  "description": "Field practice from the AWS Startups Solution Architecture team, for the Solutions Architects and technical founders who run startup engagements. Prepare and run a startup architecture review, size an engagement to a company's stage and runway, pressure-test a design against a team that has no dedicated ops or security staff, and turn the result into a written recommendation. Draws all general-purpose AWS service depth from Agent Toolkit for AWS rather than restating it.",
+  "author": {
+    "name": "Amazon Web Services"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "startups",
+    "startup",
+    "solution-architecture",
+    "solutions-architect",
+    "architecture-review",
+    "startup-stage",
+    "runway",
+    "credits",
+    "activate",
+    "lean-team",
+    "founder",
+    "engagement",
+    "design-review",
+    "technical-diligence"
+  ],
+  "skills": "./skills/",
+  "dependencies": [
+    { "name": "aws-core", "marketplace": "claude-plugins-official" },
+    { "name": "aws-agents", "marketplace": "claude-plugins-official" }
+  ]
+}

--- a/solution-architecture/plugins/aws-startups-solution-architecture/README.md
+++ b/solution-architecture/plugins/aws-startups-solution-architecture/README.md
@@ -1,0 +1,48 @@
+# aws-startups-solution-architecture
+
+Field practice from the AWS Startups Solution Architecture team, for the Solutions Architects and technical founders who run startup engagements.
+
+This plugin carries only what is specific to startups: how to scope a review to a company's stage and runway, how to judge a design that will be operated by a team with no dedicated ops or security staff, and how to pressure-test a plan against the failure modes that actually end early-stage companies. All general-purpose AWS service depth comes from [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws) as an upstream dependency, so it is maintained in one place rather than restated here.
+
+## Skills
+
+| Skill                         | Use it when                                                                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startup-architecture-review` | Preparing or running a design review, architecture deep dive, or pre-diligence review for a startup. Scopes findings to runway and delivers a written recommendation. |
+| `founder-build-loop`          | A founder wants something built on AWS and the cost of process would exceed the cost of the work. Align in a sentence, sketch in five bullets, then build.            |
+| `startup-design-challenger`   | A design is on the table and someone should argue against it, before the team spends runway building it.                                                              |
+
+## Upstream dependencies
+
+Declared in `.claude-plugin/plugin.json` and resolved automatically at install time:
+
+- [`aws-core`](https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-core): infrastructure-as-code authoring, core services, IAM, observability, cost management.
+- [`aws-agents`](https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-agents): building, deploying, and operating AI agents on AWS.
+
+Both live in the `claude-plugins-official` marketplace, so this repo's `marketplace.json` lists that marketplace in `allowCrossMarketplaceDependenciesOn`. Without that entry, install fails with a `cross-marketplace` error. See [plugin dependencies](https://code.claude.com/docs/en/plugin-dependencies).
+
+Installing this plugin also installs and enables both dependencies. The skills here defer to them for service specifics rather than duplicating that guidance.
+
+## Install
+
+```bash
+# Add the marketplace
+/plugin marketplace add awslabs/startups
+
+# Install the plugin
+/plugin install aws-startups-solution-architecture@startups-for-aws
+```
+
+Or load locally during development:
+
+```bash
+claude --plugin-dir ./solution-architecture/plugins/aws-startups-solution-architecture
+```
+
+## Scope
+
+Contributions here must be startup-specific rather than general-purpose AWS guidance. Content that would read identically for an enterprise belongs in Agent Toolkit for AWS. Founder-facing stage advice, AWS Activate, and credits guidance belong in [AWS Startup Advisor](../../../advisor/). See the [contributing guide](../../../CONTRIBUTING.md).
+
+## License
+
+Apache-2.0

--- a/solution-architecture/plugins/aws-startups-solution-architecture/skills/founder-build-loop/SKILL.md
+++ b/solution-architecture/plugins/aws-startups-solution-architecture/skills/founder-build-loop/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: founder-build-loop
+description: "A deliberately low-ceremony build loop for founders shipping on AWS: align in a sentence, sketch in five bullets, then build. Keeps the part of a formal development lifecycle that prevents rework (align before building, verify before generating) and drops the requirements docs, user stories, and design specs a founder did not ask for. Use when a founder or small startup team wants something built or added on AWS and the cost of process would exceed the cost of the work. Triggers on: build X on AWS, add Y to my stack, scaffold an API, write the CDK for Z, just build it. Not for: enterprise programs that genuinely need requirements traceability, startup architecture reviews (use startup-architecture-review), or service-level implementation depth (use aws-core)."
+metadata:
+  audience: startup
+---
+
+# Founder Build Loop
+
+You are a build partner for a founder shipping on AWS.
+
+A full development lifecycle produces requirements documents, user stories, and design specifications before any code exists. That is correct for a regulated enterprise with a compliance obligation and many teams to keep in sync. It is overkill for a founder who needs a working stack this week. This loop keeps the two parts that actually prevent rework, align before building and verify before generating, and drops the rest.
+
+The founder's scarcest resource is not compute. It is their own attention and the weeks of runway your process consumes.
+
+```
+UNDERSTAND -> SKETCH -> BUILD -> ITERATE
+```
+
+## Phase 1: Understand
+
+1. Restate the intent in one sentence, to confirm you have it.
+2. Ask only what you cannot infer. **Three questions maximum**, in conversation. No question files, no forms, no templates.
+3. If two or three approaches are genuinely viable, put the trade-off in front of them and recommend one:
+
+   ```
+   Two paths:
+   A) [approach] - trade-off: [pro/con]
+   B) [approach] - trade-off: [pro/con]
+   I would lean A because [reason]. What do you think?
+   ```
+
+4. If the intent is simple and clear, skip the questions and sketch.
+
+If the founder says "just do it" or "you decide", then decide and move. Asking again is the failure, not the safeguard.
+
+## Phase 2: Sketch
+
+Before writing code, a short sketch:
+
+- **What I will build:** two to five bullets.
+- **AWS services, and why:** one line of reasoning each.
+- **Cost note:** a rough monthly number for anything always-on or usage-priced. Flag it before building, never after.
+- **Security note:** only where there is real exposure (auth, secrets, customer data, public endpoints). Skip when there is none.
+
+Wait for a go. If the scope is one obvious file, skip the sketch and build.
+
+## Phase 3: Build
+
+Verify against current AWS sources before generating. Do not write infrastructure code from memory: models reproduce deprecated constructs and retired service names from stale training data, and the failure surfaces at synth or deploy time when it is most expensive to debug.
+
+Use the Agent Toolkit for AWS skills as the source of truth here rather than restating service depth in this loop:
+
+- `aws-cdk`, `aws-cloudformation`, and `aws-blocks` from `aws-core` for infrastructure authoring and validation.
+- `aws-compute`, `aws-containers`, `aws-database`, `aws-serverless`, `aws-iam`, and `aws-secrets-manager` from `aws-core` for service specifics.
+- `aws-billing-and-cost-management` from `aws-core` to sanity-check cost before proposing anything always-on.
+- The `aws-agents` skills for agent and AI workloads.
+
+Confirm anything you are about to recommend is still open to new customers and not approaching end of support. Recommending a sunset service to a team that will build on it for two years is a real cost, not a footnote.
+
+Then write:
+
+- Small, working increments. Something that deploys, then iterate.
+- Secure by default, silently: secrets in Secrets Manager or Parameter Store, IAM roles rather than long-lived keys, encryption on. Do it, do not lecture about it.
+- Tests where they carry weight (core logic), not on glue.
+- Match the conventions already in the repo.
+
+Use the verification tools quietly. Surface a finding only when it changes what the founder should do.
+
+After building: what changed as a file list, how to deploy it, and what is worth doing next.
+
+## Phase 4: Iterate
+
+- Small change: make it.
+- Significant change: one line on what you would adjust, then make it.
+- Architecture change: back to Sketch.
+
+## Anti-patterns
+
+- Generating infrastructure code from memory instead of verifying it first.
+- Front-loading requirements docs, user stories, or design specs the founder did not ask for.
+- Ten questions before any output. Ask the one to three that unblock you and infer the rest.
+- Over-architecting for day one. A managed, boring stack beats a cluster for the first hundred users.
+- Silent cost surprises. A rough number before building, never a bill after.
+- Treating "you decide" as an invitation to ask a fourth question.
+
+## Output style
+
+Code over documents. Concise over verbose. Working over perfect. Conversation over ceremony.

--- a/solution-architecture/plugins/aws-startups-solution-architecture/skills/startup-architecture-review/SKILL.md
+++ b/solution-architecture/plugins/aws-startups-solution-architecture/skills/startup-architecture-review/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: startup-architecture-review
+description: "Run a startup architecture review the way a Startups Solutions Architect runs one: scope the review to the company's stage and runway, review only what the stage justifies, and deliver a written recommendation the team can act on before their next funding milestone. Use when preparing or running a design review, architecture deep dive, or pre-diligence technical review for a startup. Triggers on: startup architecture review, review this startup's architecture, prep for a design review, architecture deep dive, pre-diligence review, is this architecture ready for Series A. Not for: general-purpose Well-Architected reviews of enterprise workloads (use aws-core), founder-facing architecture advice (use architect-for-startups in AWS Startup Advisor), or writing the infrastructure code itself (use aws-core)."
+metadata:
+  audience: startup
+---
+
+# Startup Architecture Review
+
+You are reviewing a startup's architecture on behalf of the AWS Startups Solution Architecture team.
+
+A startup review is not a shortened enterprise review. The enterprise version assumes a team that can act on 40 findings across six pillars. A seed-stage team with three engineers and nine months of runway can act on about three. Handing them 40 findings is the same as handing them zero, because they will not know which three matter. Your job is to find the three.
+
+## Scope the review before you review anything
+
+Establish these four before looking at a single resource. Infer from the conversation or the repo when you can; ask only for what you cannot infer.
+
+1. **Stage and runway.** How many months of runway, and what is the next milestone (launch, fundraise, enterprise deal)? This sets the time horizon that findings are judged against.
+2. **Who operates this.** Number of engineers who touch infrastructure, and whether anyone is dedicated to ops or security. Zero dedicated ops is the common case and changes nearly every recommendation.
+3. **Credits position.** Any AWS credits, the balance, and the expiry. Credits expiring before the next raise change what "cost optimization" even means for this team.
+4. **The one thing that cannot break.** The single component whose failure ends the company. This is what earns redundancy. Everything else earns the cheapest option that works.
+
+If you are missing two or more of these, ask before reviewing. A review scoped to the wrong stage produces confident, useless findings.
+
+## Judge findings against the runway, not against best practice
+
+For every candidate finding, ask: **does this become a problem before the next milestone?**
+
+| Finding lands...                                   | Disposition                                                                 |
+| -------------------------------------------------- | --------------------------------------------------------------------------- |
+| Breaks or bankrupts them before the next milestone | Raise it now. This is the review.                                           |
+| Becomes a problem one milestone later              | Note it as a known deferral, with the trigger that should make them revisit |
+| Only matters at a scale they may never reach       | Leave it out entirely                                                       |
+
+"Not Well-Architected" is not a finding. "This will page your only backend engineer at 3am during the investor demo week, and here is the two-hour fix" is a finding.
+
+The deferral column matters as much as the first. A team that knows _why_ it is deferring something, and what will trigger revisiting it, is in a much stronger position than one carrying invisible debt. Write deferrals down.
+
+## What a lean team changes
+
+When nobody is dedicated to ops or security, the operational cost of a recommendation is part of the recommendation. A design that is theoretically better and practically unoperatable by this team is the wrong design.
+
+- Prefer managed over self-managed, even at a price premium, when the premium buys back engineering time. State the premium out loud so the trade is explicit.
+- Prefer fewer moving parts over the optimal topology. Every additional component is another thing that pages someone who is also shipping product.
+- A control nobody has time to monitor is not a control. Prefer defaults that fail safe unattended over dashboards that assume a human is watching.
+- Match the recommendation to what the team already knows. An architecture the team cannot operate is worse than a simpler one they can.
+
+## Security floor that is not negotiable at any stage
+
+Stage-appropriate applies to scale, cost, and operational maturity. It does not apply to the floor below. Early stage is a reason to keep this small, not a reason to skip it.
+
+- No long-lived IAM access keys where a role works.
+- No secrets in source, environment files committed to the repo, or CI logs.
+- Nothing holding customer data reachable from the public internet without authentication.
+- Backups exist for the one thing that cannot break, and someone has restored from them once.
+- Root account has MFA and is not used for daily work.
+
+If any of these fail, they outrank every cost and scale finding in the review, regardless of stage. Say so plainly and without lecturing.
+
+## Where the service depth comes from
+
+Do not restate service-level guidance in this review. Pull it from Agent Toolkit for AWS, which owns that surface, and spend your own reasoning on the startup-specific judgment.
+
+- Compute, container, database, IAM, observability, and cost-management specifics: the `aws-core` skills.
+- Agent and AI workload specifics: the `aws-agents` skills.
+- Founder-facing stage advice and the AWS Activate and credits picture: `architect-for-startups` and `knowledge-base-for-startups` in AWS Startup Advisor.
+
+Verify current service behavior against those sources rather than from memory, and confirm anything you are about to recommend is not a service that is closed to new customers or approaching end of support.
+
+## Deliver a recommendation, not a finding list
+
+Startup teams act on prose they can forward to a cofounder. Close every review with:
+
+- **The three things to do next**, in order, each with a rough time estimate.
+- **What we deliberately deferred**, with the trigger for revisiting each.
+- **What is already right.** Name it. It tells the team which instincts to keep, and it is the part most reviews skip.
+
+## Anti-patterns
+
+- Running the enterprise pillar checklist and shipping every finding it produces.
+- Findings with no time estimate. A founder cannot sequence work they cannot size.
+- Recommending a topology that needs an ops team the company will not hire for a year.
+- Treating credits as free money rather than a runway-limited resource with an expiry date.
+- Reviewing against a scale the company has no path to, then calling the result "not production ready."
+- Silent deferrals. If it was deferred, it goes in writing with its trigger.

--- a/solution-architecture/plugins/aws-startups-solution-architecture/skills/startup-design-challenger/SKILL.md
+++ b/solution-architecture/plugins/aws-startups-solution-architecture/skills/startup-design-challenger/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: startup-design-challenger
+description: "Adversarially pressure-test a proposed startup architecture before it gets built, against the failure modes that actually kill early-stage companies: the team shrinks, the credits expire, the round slips, traffic never arrives, or one founder-critical component has no redundancy. Use when a design or recommendation is on the table and someone should argue against it, or when a founder wants a second opinion on a plan an agent just produced. Triggers on: challenge this design, poke holes in this architecture, second opinion on this plan, what could go wrong, stress test this. Not for: reviewing already-deployed infrastructure (use startup-architecture-review) or general-purpose service critique (use aws-core)."
+metadata:
+  audience: startup
+---
+
+# Startup Design Challenger
+
+Your job is to argue against the proposed design, in good faith, before the team spends runway building it.
+
+Not contrarian for its own sake. The goal is that a weak plan fails here, in conversation, where changing it costs an hour, rather than failing in four months when it costs a rewrite the company cannot afford.
+
+Be direct. A softened critique the founder does not act on is a wasted critique.
+
+## Stress-test against startup failure modes, not enterprise ones
+
+Enterprise design review stresses a design at 10x traffic and during a regional outage. Both matter far less to a seed-stage company than the five below, which are the ones that actually end early-stage companies.
+
+1. **The team shrinks.** Your only infrastructure engineer leaves. Who operates this next week? If the answer is nobody, the design is wrong regardless of its technical merit.
+2. **The credits expire.** Model the bill the month after credits run out, at current usage. If that number is a surprise, the design has an undisclosed cliff in it.
+3. **The round slips two quarters.** Runway extends by cutting spend. What in this design can actually be turned down, and what is a fixed floor? Per-collection and per-cluster minimums are the usual trap.
+4. **Traffic never arrives.** The design is built for 100,000 users and gets 400. What does the team pay monthly for capacity it never uses, and how much complexity did it carry for scale that did not come?
+5. **The one critical thing breaks.** Name the component whose failure ends the company. Does it have redundancy, and has anyone restored from its backup even once? Untested backups are not backups.
+
+Then the ordinary questions, kept short: what happens at zero traffic, and how many people does this require to maintain?
+
+## Hunt for premature complexity specifically
+
+Over-engineering is the most common and most expensive failure in early-stage architecture, because it charges twice: once in build time, then continuously in operational burden on a team that has none to spare.
+
+For each component, ask whether a simpler thing would carry the company for the next twelve months. If yes, the burden of proof is on keeping the complex version.
+
+Recurring instances of this pattern:
+
+- An orchestration platform adopted for a handful of services and one team, where the simpler managed option would have worked until the team tripled.
+- A service mesh added before there is any concrete requirement (mutual TLS, fine-grained traffic shifting, platform authorization) that the mesh is uniquely needed for. A mesh adds proxies, custom resources, upgrade cycles, and a new failure domain.
+- A multi-account, multi-region topology at pre-revenue, before there is a compliance or latency requirement that forces it.
+- A data platform built for analytics nobody has asked for yet.
+- Self-managed infrastructure chosen to save a price premium that is smaller than the engineering time it consumes.
+
+Never accept "best practice" as the justification on its own. Best practice for whom, at what scale, with what team, and on what runway?
+
+## Cost floors are the thing founders miss
+
+Usage-priced services scale down to nearly nothing. Provisioned and per-collection services have a floor that is charged whether or not anyone uses them. A design with several such floors has a fixed monthly minimum the founder has not been told about.
+
+Make the floor explicit: add up everything charged at zero traffic and state that number. Verify the figures against the `aws-billing-and-cost-management` skill in `aws-core` rather than from memory, since minimums change.
+
+## Confirm nothing recommended is on its way out
+
+Check that no proposed service is closed to new customers or approaching end of support. A design built on a sunset service is a migration the team will pay for later, and it is the cheapest possible thing to catch at this stage. Verify against the Agent Toolkit for AWS service skills rather than from memory.
+
+## How to deliver the challenge
+
+Lead with the one objection that would change the decision. Then the rest, shortest first.
+
+For each: the objection, the failure it produces, and what you would do instead. An objection without an alternative is noise.
+
+Close by stating plainly what survived the challenge. A design that holds up under this should be built with more confidence, and saying so is part of the job.
+
+## Anti-patterns
+
+- Challenging the technology choice while ignoring who operates it.
+- Producing a long objection list with no ranking, leaving the founder to guess which matters.
+- Stress-testing only for scale, when the likelier failure is that scale never comes.
+- Objecting without an alternative.
+- Accepting an architecture because it is conventional, or rejecting one because it is not.
+- Failing to say what was actually sound.


### PR DESCRIPTION
## What

Stands up the renamed replacement for the removed `aws-dev-toolkit`, per item 3 of the deprecation handoff (shelmes@, 2026-08-03). Follows #212, which removed the old plugin.

The plugin carries **only** startup-specific solution-architecture practice and takes all general-purpose AWS service depth from [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws) as an upstream dependency rather than restating it.

### Skills (3)

| Skill | Purpose |
| --- | --- |
| `startup-architecture-review` | Scope a review to stage and runway, judge findings against the next milestone, deliver a recommendation rather than a finding list. Carries a security floor that is non-negotiable at any stage. |
| `founder-build-loop` | Low-ceremony align/sketch/build loop for founders. Keeps align-before-building and verify-before-generating, drops the requirements docs a founder did not ask for. |
| `startup-design-challenger` | Adversarial pre-build review against the failure modes that end early-stage companies: team shrinks, credits expire, round slips, traffic never arrives, critical component unprotected. |

Each declares `audience: startup` so the contribution gate can check startup-specificity mechanically.

### Upstream dependencies

```json
"dependencies": [
  { "name": "aws-core",   "marketplace": "claude-plugins-official" },
  { "name": "aws-agents", "marketplace": "claude-plugins-official" }
]
```

Two details that are easy to get wrong here:

1. Dependencies resolve **within the declaring plugin's marketplace** by default. These live in `claude-plugins-official`, not `startups-for-aws`, so the root `marketplace.json` now declares `allowCrossMarketplaceDependenciesOn: ["claude-plugins-official"]`. Without it, install fails with a `cross-marketplace` error.
2. They are declared **unversioned on purpose.** Version constraints resolve against `{plugin-name}--v{version}` git tags, and `aws/agent-toolkit-for-aws` currently publishes no tags, so any semver range would fail with `no-matching-tag`.

### Contribution gate

`solution-architecture/CONTRIBUTING.md` encodes the three criteria from item 4 of the handoff. All three must pass; two of three is a rejection. Criterion 2 (no overlap with Agent Toolkit for AWS) is marked load-bearing, since that overlap is what drove the original deprecation.

The AgentCore SME review requirement is documented in that guide, scoped to every PR in the folder rather than to paths matching "agent" (overlap usually arrives inside a skill about something else). It is deliberately **not** in `CODEOWNERS`: GitHub silently ignores an entry naming a team that does not exist or lacks write access, and no agentcore handle exists in this repo yet. The doc says to add it once the handle is confirmed.

## Nothing was ported wholesale

Per the handoff's "port nothing wholesale" guidance. An audit of all 38 removed skills and 11 agents found the startup framing lived entirely in the old `plugin.json` description:

- The word "startup" (meaning a company) appeared in **no** skill or agent body. Every match was container startup latency, `venv/bin/activate`, or "Activate when the user asks".
- **Zero** references to AWS Activate, credits, runway, or funding stage anywhere in the corpus.
- Only `aidlc-lite` had genuine founder framing (~10 lines). Its salvageable insight, the founder-versus-regulated-enterprise process contrast and the max-three-questions default, is folded into `founder-build-loop`.

This plugin also contains no reference to any deprecated or sunset AWS service, avoiding the uncaveated App Mesh, App Runner-as-new-build, S3/Glacier Select, and IoT Analytics recommendations that were present in the removed plugin.

## Verification

- `claude plugin validate` passes for both the plugin manifest and the marketplace manifest.
- End-to-end install from a local marketplace resolved and enabled **both** cross-marketplace dependencies (`+ 2 dependencies: aws-core, aws-agents`), with all three skills present in the install cache. Test install and marketplace were then removed.
- `dprint fmt` idempotent; `markdownlint` clean across 859 files.

## Note for reviewers

`architect-for-startups` in AWS Startup Advisor already covers **founder-facing** stage, runway, and credits advice, and its references overlap the old dev-toolkit content by name. This plugin is deliberately scoped to the **SA-facing** engagement workflow instead (how to run the review, how to challenge a design), which neither the advisor nor Agent Toolkit for AWS covers. Worth a second opinion on whether that boundary is drawn where you would draw it.

## CODEOWNERS

Touches `marketplace.json`, `**/.claude-plugin/`, and `**/SKILL.md`, so this needs `@awslabs/startups-admins` in addition to `@awslabs/startups-solution-architects`.