### PR TITLE
fix: remove dangling ai-to-aws entry from migrate Cursor marketplace.json

### DIFF
--- a/migrate/plugins/.cursor-plugin/marketplace.json
+++ b/migrate/plugins/.cursor-plugin/marketplace.json
@@ -12,11 +12,6 @@
       "name": "migration-to-aws",
       "source": "./migration-to-aws",
       "description": "Migrate from GCP to AWS — including your entire AI stack. Moves infrastructure (Cloud Run → Fargate, Cloud SQL → Aurora, GKE → EKS), OpenAI/Gemini workloads to Amazon Bedrock, and agentic systems (LangChain, CrewAI, AutoGen, OpenAI Agents SDK) to AWS-native frameworks. Generates runnable Terraform, migration scripts, provider adapters, and deployment artifacts. Gives honest model-by-model pricing comparisons so you know exactly when Bedrock saves money and when it doesn't."
-    },
-    {
-      "name": "ai-to-aws",
-      "source": "./ai-to-aws",
-      "description": "End-to-end AI migration to Amazon Bedrock: assess your codebase, rewrite SDK calls, evaluate quality, and deliver a ready-to-merge git branch. Requires migration-to-aws (powers the Assess phase)."
     }
   ]
 }


### PR DESCRIPTION
Addresses StartupEngBlend-3003.

## Problem

`migrate/plugins/.cursor-plugin/marketplace.json` lists a plugin `ai-to-aws` with `"source": "./ai-to-aws"`, but no such directory exists. `migrate/plugins/` contains only `migration-to-aws/`. Cursor users resolving that entry hit a dangling reference.

## Fix

Removed the `ai-to-aws` entry from the plugins array. The `migration-to-aws` entry (which points at an existing directory) is retained.

## Verification
- `markdownlint-cli2`: 0 errors
- `git secrets --scan`: clean
- 1 file changed, 5 deletions