### PR TITLE
Add .codex-plugin/ to CODEOWNERS protected-metadata block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@ dprint.json              @awslabs/startups-admins
 **/OWNERS.yml            @awslabs/startups-admins
 **/.claude-plugin/       @awslabs/startups-admins
 **/.cursor-plugin/       @awslabs/startups-admins
+**/.codex-plugin/        @awslabs/startups-admins
 **/SKILL.md              @awslabs/startups-admins
 
 # Team folders


### PR DESCRIPTION
Adds `**/.codex-plugin/` to the protected-metadata block in CODEOWNERS, requiring `@awslabs/startups-admins` approval for changes to Codex plugin manifests — consistent with the existing `.claude-plugin/` and `.cursor-plugin/` entries.

Resolves StartupEngBlend-3005.