### PR TITLE
Add solution-architecture/ to PR template team folder checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@
 
 - [ ] `advisor/`
 - [ ] `migrate/`
+- [ ] `solution-architecture/`
 - [ ] Other: ___
 
 ## Checklist


### PR DESCRIPTION
## Problem

The PR template's Team Folder section lists `advisor/` and `migrate/` but is missing `solution-architecture/`, which has been a top-level team folder since June 2026. SA contributors must select "Other" or skip the field.

## Solution

Add `- [ ] \`solution-architecture/\`` to the Team Folder checklist in `.github/pull_request_template.md`.

Resolves StartupEngBlend-3004.