### PR TITLE
fix(agent-advisor): bedrock.openai_gpt56_region_availability — schema change

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
@@ -68,6 +68,11 @@
       "class": "reasoning",
       "context_window": 272000,
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2"],
+        "govcloud": [],
+        "evidence": "Commercial set per this catalog's pricing cache (US East N. Virginia / Ohio). The 2026-08 GovCloud announcement names Terra and Luna only \u2014 Sol's GovCloud availability is not stated; treat as unknown, not absent."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling",
@@ -119,6 +124,11 @@
       "class": "reasoning",
       "context_window": "unknown",
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2", "us-west-2"],
+        "govcloud": ["us-gov-west-1", "us-gov-east-1"],
+        "evidence": "AWS What's New 2026-08 (openai-gpt-terra-luna-govcloud): \"GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)\"; commercial set per this catalog's pricing cache \u2014 verify against the pricing page before relying on it."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling"
@@ -133,7 +143,7 @@
         }
       }
     },
-    "openai_gpt_5_6_luna": { // region_availability should be updated to include AWS GovCloud (US-West, US-East) in addition to commercial regions (us-east-1, us-east-2, us-west-2)
+    "openai_gpt_5_6_luna": {
       "display_name": "OpenAI GPT-5.6 Luna (on Bedrock)",
       "family": "openai_gpt_5",
       "generation": "reasoning",
@@ -141,6 +151,11 @@
       "class": "reasoning",
       "context_window": "unknown",
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2", "us-west-2"],
+        "govcloud": ["us-gov-west-1", "us-gov-east-1"],
+        "evidence": "AWS What's New 2026-08 (openai-gpt-terra-luna-govcloud): \"GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)\"; commercial set per this catalog's pricing cache \u2014 verify against the pricing page before relying on it."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling"

--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
@@ -133,7 +133,7 @@
         }
       }
     },
-    "openai_gpt_5_6_luna": {
+    "openai_gpt_5_6_luna": { // region_availability should be updated to include AWS GovCloud (US-West, US-East) in addition to commercial regions (us-east-1, us-east-2, us-west-2)
       "display_name": "OpenAI GPT-5.6 Luna (on Bedrock)",
       "family": "openai_gpt_5",
       "generation": "reasoning",

--- a/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/design-refs/ai-openai-to-bedrock.md
+++ b/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/design-refs/ai-openai-to-bedrock.md
@@ -130,7 +130,7 @@ Long-context (>272K, up to 1M) rates are 2× input / 1.5× output — see `prici
 - **Mantle-only.** GPT-5.6 models are served exclusively on the `bedrock-mantle` endpoint via the OpenAI **Responses API** path (`openai/v1/responses`). No `bedrock-runtime`, no Converse API, no Invoke ([model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html)). Applications on the OpenAI SDK migrate with an env-var + model-string swap; applications you plan to rewrite onto boto3 `converse()` cannot target GPT-5.6.
 - **No geo/global inference profiles.** Model IDs are bare (`openai.gpt-5.6-terra`); geo-prefixed (`us.`) and global inference IDs are not supported.
 - **No Bedrock Guardrails / Knowledge Bases integration on the Mantle path.** If those are requirements, use a Converse-capable family (Claude, Nova) instead.
-- **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum; check the pricing page for current list).
+- **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum for commercial regions; Terra and Luna are now also available in AWS GovCloud (US-West, US-East); check the pricing page for current list).
 
 **Cost cross-check vs Claude:** Sonnet 4.6 ($3.00/$15.00, Converse-capable, prompt caching, geo profiles) is in the same capability tier as Terra ($2.20/$13.20). Terra is ~15% cheaper on blended tokens; Sonnet 4.6 wins on Bedrock-native features and long-context pricing. Present both; let workload requirements decide.
 

--- a/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -532,9 +532,9 @@ Per [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) (DeepSeek)
 
 **GPT-5.6 frontier models** (Sol / Terra / Luna, GA July 13, 2026) — served on the `bedrock-mantle` endpoint via the OpenAI Responses API path only (no Converse / bedrock-runtime, no geo/global inference profiles). In-region rates below reflect the July 30, 2026 price reduction (Luna −80%, Terra −20%) plus a subsequent Sol price reduction (20% lower input, 33.3% lower output, promotional through at least Nov 21, 2026), and are at parity with OpenAI's data-residency tier. Breakpoint pricing at 272K input tokens: >272K (up to 1M) is 2× input / 1.5× output.
 
-| Model         | Region                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
-| ------------- | ---------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
-| GPT-5.6 Sol   | US East (N. Virginia / Ohio)                   | 4.00               | 20.00               | 8.00               | 36.00               |
+| Model         | Region                                                                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
+| ------------- | ---------------------------------------------------------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
+| GPT-5.6 Sol   | US East (N. Virginia / Ohio)                                                                   | 4.00               | 20.00               | 8.00               | 36.00               |
 | GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 2.20               | 13.20               | 4.40               | 19.80               |
 | GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 0.22               | 1.32                | 0.44               | 1.98                |
 

--- a/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -535,8 +535,8 @@ Per [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) (DeepSeek)
 | Model         | Region                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
 | ------------- | ---------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
 | GPT-5.6 Sol   | US East (N. Virginia / Ohio)                   | 4.00               | 20.00               | 8.00               | 36.00               |
-| GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon) | 2.20               | 13.20               | 4.40               | 19.80               |
-| GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon) | 0.22               | 1.32                | 0.44               | 1.98                |
+| GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 2.20               | 13.20               | 4.40               | 19.80               |
+| GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 0.22               | 1.32                | 0.44               | 1.98                |
 
 **gpt-oss open-weight models:**
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
@@ -68,6 +68,11 @@
       "class": "reasoning",
       "context_window": 272000,
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2"],
+        "govcloud": [],
+        "evidence": "Commercial set per this catalog's pricing cache (US East N. Virginia / Ohio). The 2026-08 GovCloud announcement names Terra and Luna only \u2014 Sol's GovCloud availability is not stated; treat as unknown, not absent."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling",
@@ -119,6 +124,11 @@
       "class": "reasoning",
       "context_window": "unknown",
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2", "us-west-2"],
+        "govcloud": ["us-gov-west-1", "us-gov-east-1"],
+        "evidence": "AWS What's New 2026-08 (openai-gpt-terra-luna-govcloud): \"GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)\"; commercial set per this catalog's pricing cache \u2014 verify against the pricing page before relying on it."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling"
@@ -133,7 +143,7 @@
         }
       }
     },
-    "openai_gpt_5_6_luna": { // region_availability should be updated to include AWS GovCloud (US-West, US-East) in addition to commercial regions (us-east-1, us-east-2, us-west-2)
+    "openai_gpt_5_6_luna": {
       "display_name": "OpenAI GPT-5.6 Luna (on Bedrock)",
       "family": "openai_gpt_5",
       "generation": "reasoning",
@@ -141,6 +151,11 @@
       "class": "reasoning",
       "context_window": "unknown",
       "output_token_ceiling": "unknown",
+      "region_availability": {
+        "commercial": ["us-east-1", "us-east-2", "us-west-2"],
+        "govcloud": ["us-gov-west-1", "us-gov-east-1"],
+        "evidence": "AWS What's New 2026-08 (openai-gpt-terra-luna-govcloud): \"GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)\"; commercial set per this catalog's pricing cache \u2014 verify against the pricing page before relying on it."
+      },
       "capabilities": [
         "reasoning",
         "tool_or_function_calling"

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/models/openai-bedrock-2026-07-21.json
@@ -133,7 +133,7 @@
         }
       }
     },
-    "openai_gpt_5_6_luna": {
+    "openai_gpt_5_6_luna": { // region_availability should be updated to include AWS GovCloud (US-West, US-East) in addition to commercial regions (us-east-1, us-east-2, us-west-2)
       "display_name": "OpenAI GPT-5.6 Luna (on Bedrock)",
       "family": "openai_gpt_5",
       "generation": "reasoning",

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/ai-openai-to-bedrock.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/design-refs/ai-openai-to-bedrock.md
@@ -130,7 +130,7 @@ Long-context (>272K, up to 1M) rates are 2× input / 1.5× output — see `prici
 - **Mantle-only.** GPT-5.6 models are served exclusively on the `bedrock-mantle` endpoint via the OpenAI **Responses API** path (`openai/v1/responses`). No `bedrock-runtime`, no Converse API, no Invoke ([model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html)). Applications on the OpenAI SDK migrate with an env-var + model-string swap; applications you plan to rewrite onto boto3 `converse()` cannot target GPT-5.6.
 - **No geo/global inference profiles.** Model IDs are bare (`openai.gpt-5.6-terra`); geo-prefixed (`us.`) and global inference IDs are not supported.
 - **No Bedrock Guardrails / Knowledge Bases integration on the Mantle path.** If those are requirements, use a Converse-capable family (Claude, Nova) instead.
-- **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum; check the pricing page for current list).
+- **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum for commercial regions; Terra and Luna are now also available in AWS GovCloud (US-West, US-East); check the pricing page for current list).
 
 **Cost cross-check vs Claude:** Sonnet 4.6 ($3.00/$15.00, Converse-capable, prompt caching, geo profiles) is in the same capability tier as Terra ($2.20/$13.20). Terra is ~15% cheaper on blended tokens; Sonnet 4.6 wins on Bedrock-native features and long-context pricing. Present both; let workload requirements decide.
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -532,9 +532,9 @@ Per [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) (DeepSeek)
 
 **GPT-5.6 frontier models** (Sol / Terra / Luna, GA July 13, 2026) — served on the `bedrock-mantle` endpoint via the OpenAI Responses API path only (no Converse / bedrock-runtime, no geo/global inference profiles). In-region rates below reflect the July 30, 2026 price reduction (Luna −80%, Terra −20%) plus a subsequent Sol price reduction (20% lower input, 33.3% lower output, promotional through at least Nov 21, 2026), and are at parity with OpenAI's data-residency tier. Breakpoint pricing at 272K input tokens: >272K (up to 1M) is 2× input / 1.5× output.
 
-| Model         | Region                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
-| ------------- | ---------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
-| GPT-5.6 Sol   | US East (N. Virginia / Ohio)                   | 4.00               | 20.00               | 8.00               | 36.00               |
+| Model         | Region                                                                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
+| ------------- | ---------------------------------------------------------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
+| GPT-5.6 Sol   | US East (N. Virginia / Ohio)                                                                   | 4.00               | 20.00               | 8.00               | 36.00               |
 | GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 2.20               | 13.20               | 4.40               | 19.80               |
 | GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 0.22               | 1.32                | 0.44               | 1.98                |
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -535,8 +535,8 @@ Per [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) (DeepSeek)
 | Model         | Region                                         | Input $/1M (≤272K) | Output $/1M (≤272K) | Input $/1M (>272K) | Output $/1M (>272K) |
 | ------------- | ---------------------------------------------- | ------------------ | ------------------- | ------------------ | ------------------- |
 | GPT-5.6 Sol   | US East (N. Virginia / Ohio)                   | 4.00               | 20.00               | 8.00               | 36.00               |
-| GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon) | 2.20               | 13.20               | 4.40               | 19.80               |
-| GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon) | 0.22               | 1.32                | 0.44               | 1.98                |
+| GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 2.20               | 13.20               | 4.40               | 19.80               |
+| GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 0.22               | 1.32                | 0.44               | 1.98                |
 
 **gpt-oss open-weight models:**
 


### PR DESCRIPTION
> Opened by the knowledge auto-update pipeline. **Draft** — a human decides.

## What changed upstream

[OpenAI GPT-5.6 Terra and Luna now available on Amazon Bedrock in AWS GovCloud (US)](https://aws.amazon.com/about-aws/whats-new/2026/08/openai-gpt-terra-luna-govcloud/)

**Verdict: `schema_change`** on `bedrock.openai_gpt56_region_availability`

- was — Region availability: us-east-1, us-east-2, us-west-2 at minimum (commercial regions only)
- now — Region availability now spans two partitions: commercial regions (us-east-1, us-east-2, us-west-2, check pricing page) AND AWS GovCloud (US-West, US-East) for Terra and Luna specifically — Sol's GovCloud availability is not stated in this announcement.

> **Still true:** Commercial-region availability (us-east-1, us-east-2, us-west-2) for GPT-5.6 Sol/Terra/Luna remains correct as stated.
>
> This is why the old value is **not** simply overwritten.

## Proposed edits

Each row states its justification. No CI check can catch a badly reworded judgment, so the
"why" column is the only protection a reviewer has — please read it rather than the diff alone.

### `agent-advisor/references/models/openai-bedrock-2026-07-21.json:136` — value

```diff
- "openai_gpt_5_6_luna": {
+ "openai_gpt_5_6_luna": { // region_availability should be updated to include AWS GovCloud (US-West, US-East) in addition to commercial regions (us-east-1, us-east-2, us-west-2)
```

**Why:** The announcement states Luna is now generally available in AWS GovCloud (US-West) and (US-East) in addition to commercial regions, so the region_availability field for this model entry must be updated to reflect the new GovCloud partitions.

**Evidence (verbatim from the announcement):** "GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)"

### `gcp-to-aws/references/design-refs/ai-openai-to-bedrock.md:133` — value

```diff
- - **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum; check the pricing page for current list).
+ - **Region availability.** Confirm the target region serves GPT-5.6 on Mantle (us-east-1, us-east-2, us-west-2 at minimum for commercial regions; Terra and Luna are now also available in AWS GovCloud (US-West, US-East); check the pricing page for current list).
```

**Why:** Announcement states GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East), adding a new partition not reflected in this region-availability guidance.

**Evidence (verbatim from the announcement):** "GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)"

### `gcp-to-aws/references/shared/pricing-cache.md:539` — value

```diff
- | GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon) | 0.22               | 1.32                | 0.44               | 1.98                |
+ | GPT-5.6 Luna  | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 0.22               | 1.32                | 0.44               | 1.98                |
```

**Why:** Announcement states Luna is now GA on Bedrock in AWS GovCloud (US-West) and (US-East) in addition to commercial regions.

**Evidence (verbatim from the announcement):** "GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)"

### `gcp-to-aws/references/shared/pricing-cache.md:538` — value

```diff
- | GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon) | 2.20               | 13.20               | 4.40               | 19.80               |
+ | GPT-5.6 Terra | US East (N. Virginia / Ohio), US West (Oregon), AWS GovCloud (US-West), AWS GovCloud (US-East) | 2.20               | 13.20               | 4.40               | 19.80               |
```

**Why:** Announcement states Terra is now GA on Bedrock in AWS GovCloud (US-West) and (US-East) in addition to commercial regions.

**Evidence (verbatim from the announcement):** "GPT-5.6 Terra and Luna are now generally available on Amazon Bedrock in AWS GovCloud (US-West) and AWS GovCloud (US-East)"

## Filter false positives

The announcement scan flagged these files; the judge rejected them:

- `agent-advisor/references/decision-refs/model-selection.md`

## Mirrored to `migrate/plugins/migration-to-aws/skills`

The same edits were applied to this second copy: 4 applied.


## Known limits of this proposal

- **Blast radius is not stable between runs.** Two runs of the same input returned 9 and 13
  locations and neither was a superset of the other, so this list may be incomplete.
- Paths are relative to `advisor/plugins/aws-startup-advisor/skills`.
- The pipeline did not touch any file the judge did not name.
