### PR TITLE
feat(heroku-to-aws): emit baseline.tf account security baseline in Generate

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
+++ b/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
@@ -188,7 +188,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
 
 6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
-   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `arn:aws:iam::aws:policy/service-role/AWS_ConfigRole` (note the underscore — `AWSConfigRole` without it is a deprecated policy name and fails apply)
    - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
    - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
    - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -42,12 +42,14 @@ assembler adds the cross-artifact checks that span multiple fragment outputs:
 
 The completion checks are declared in this phase's `_postconditions` frontmatter and
 enforced per `INTERPRETER.md` § Gate protocol: re-read the generated artifacts from
-disk, run the mechanical checks (`_check_file_exists` for the core terraform files +
-MIGRATION_GUIDE.md + README.md + migration-report.html) and the `_assert` judgment
-checks (valid provider / aws_region variable, a domain .tf beyond core, guide
-sections, report sections, conditional Postgres/ Redis migration scripts, conditional
-EKS terraform + kubernetes manifests, every service accounted for, no `{{VARIABLE}}`
-placeholders), then emit `GATE_FAIL` (STOP) or
+disk, run the mechanical checks (`_check_file_exists` for the core terraform files
+including `baseline.tf` + MIGRATION_GUIDE.md + README.md + migration-report.html)
+and the `_assert` judgment checks (valid provider / aws_region variable, a domain
+.tf beyond core, security-baseline resource inventory + compliance-conditional
+section + contact email variables, guide sections, report sections, conditional
+Postgres/ Redis migration scripts, conditional EKS terraform + kubernetes
+manifests, every service accounted for, no `{{VARIABLE}}` placeholders), then emit
+`GATE_FAIL` (STOP) or
 `HANDOFF_OK | phase=generate | artifacts=terraform/,MIGRATION_GUIDE.md,README.md,migration-report.html`.
 
 Optionally run
@@ -68,7 +70,7 @@ Output to user:
 Phase 5 of 6 complete (Generate). Optional remaining: Feedback.
 
 Artifacts produced:
-• terraform/ — [N] Terraform files for AWS infrastructure
+• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — delete it before apply to opt out)
 • MIGRATION_GUIDE.md — Step-by-step migration procedure
 • README.md — Artifact listing and quick start
 • migration-report.html — Stakeholder summary (costs + what-if scenarios when present)

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -70,7 +70,7 @@ Output to user:
 Phase 5 of 6 complete (Generate). Optional remaining: Feedback.
 
 Artifacts produced:
-• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — delete it before apply to opt out)
+• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — MIGRATION_GUIDE.md Phase 1 covers its contact variables and how to opt out)
 • MIGRATION_GUIDE.md — Step-by-step migration procedure
 • README.md — Artifact listing and quick start
 • migration-report.html — Stakeholder summary (costs + what-if scenarios when present)

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -167,8 +167,11 @@ baseline (account alternate contacts, IAM password policy, S3 account public
 access block, EBS default encryption, IAM Access Analyzer, IMDSv2 account
 default, CloudTrail with its log bucket, a monthly AWS Budget with alerts, and
 GuardDuty — plus AWS Config and Security Hub when compliance frameworks were
-declared). Before `terraform plan` can succeed, set the three baseline contact
-variables in `terraform/terraform.tfvars` to real inboxes:
+declared).
+
+**Security baseline contacts.** Before `terraform plan` can succeed, set the
+three baseline contact variables in `terraform/terraform.tfvars` to real
+inboxes:
 
 ```hcl
 operations_email = "ops@yourcompany.com"
@@ -176,12 +179,22 @@ billing_email    = "billing@yourcompany.com"   # also receives budget alerts
 security_email   = "security@yourcompany.com"
 ```
 
-To skip the security baseline entirely, delete `terraform/baseline.tf` before
-running `terraform apply`. To skip only the compliance-conditional section
-(Config + Security Hub), delete the block between
-`########## Compliance-Conditional ##########` and
-`########## End Compliance-Conditional ##########` in that file. If your AWS
-account already has a CloudTrail trail, a Config recorder, or Security Hub
+The alternate-contact phone numbers ship as placeholders — update them in
+`baseline.tf` (or post-apply) with real numbers.
+
+To skip the security baseline entirely, do BOTH of the following before
+`terraform plan` (the contact variables have no defaults, so deleting only the
+file still leaves plan failing on three unused required variables):
+
+1. Delete `terraform/baseline.tf`.
+2. Remove (or comment out) the `operations_email`, `billing_email`, and
+   `security_email` variable blocks in `terraform/variables.tf`, and their
+   entries in `terraform.tfvars` / `terraform.tfvars.example`.
+
+To skip only the compliance-conditional section (Config + Security Hub),
+delete the block between `########## Compliance-Conditional ##########` and
+`########## End Compliance-Conditional ##########` in `baseline.tf`. If your
+AWS account already has a CloudTrail trail, a Config recorder, or Security Hub
 enabled, review the collision-warning comments in `baseline.tf` before apply.
 
 {{IF has_beanstalk_web}}
@@ -941,7 +954,7 @@ This directory contains all artifacts needed to migrate your Heroku application(
 |------|---------|
 | `terraform/` | Terraform configurations for all AWS infrastructure |
 | `terraform/main.tf` | Provider configuration and module declarations |
-| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Delete before apply to opt out |
+| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Opt-out steps in MIGRATION_GUIDE.md Phase 1 |
 | `terraform/variables.tf` | Input variables (region, VPC, naming, baseline contact emails) |
 | `terraform/outputs.tf` | Output values (endpoints, ARNs, DNS names) |
 {{IF has_beanstalk}}

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -162,6 +162,28 @@ For detailed guidance, see your Procfile process types and match each to a Docke
 
 Apply the generated Terraform configurations to create AWS resources:
 
+The `terraform/` directory includes `baseline.tf`, an account-wide security
+baseline (account alternate contacts, IAM password policy, S3 account public
+access block, EBS default encryption, IAM Access Analyzer, IMDSv2 account
+default, CloudTrail with its log bucket, a monthly AWS Budget with alerts, and
+GuardDuty — plus AWS Config and Security Hub when compliance frameworks were
+declared). Before `terraform plan` can succeed, set the three baseline contact
+variables in `terraform/terraform.tfvars` to real inboxes:
+
+```hcl
+operations_email = "ops@yourcompany.com"
+billing_email    = "billing@yourcompany.com"   # also receives budget alerts
+security_email   = "security@yourcompany.com"
+```
+
+To skip the security baseline entirely, delete `terraform/baseline.tf` before
+running `terraform apply`. To skip only the compliance-conditional section
+(Config + Security Hub), delete the block between
+`########## Compliance-Conditional ##########` and
+`########## End Compliance-Conditional ##########` in that file. If your AWS
+account already has a CloudTrail trail, a Config recorder, or Security Hub
+enabled, review the collision-warning comments in `baseline.tf` before apply.
+
 {{IF has_beanstalk_web}}
 
 Each Elastic Beanstalk web configuration is not ready to plan until you provide
@@ -919,7 +941,8 @@ This directory contains all artifacts needed to migrate your Heroku application(
 |------|---------|
 | `terraform/` | Terraform configurations for all AWS infrastructure |
 | `terraform/main.tf` | Provider configuration and module declarations |
-| `terraform/variables.tf` | Input variables (region, VPC, naming) |
+| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Delete before apply to opt out |
+| `terraform/variables.tf` | Input variables (region, VPC, naming, baseline contact emails) |
 | `terraform/outputs.tf` | Output values (endpoints, ARNs, DNS names) |
 {{IF has_beanstalk}}
 | `terraform/beanstalk.tf` | Elastic Beanstalk applications and environments |

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -128,6 +128,15 @@ resource "aws_launch_template" "eks_nodes" {
   EOF
   )
 
+  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5 item 9).
+  # Hop limit 1 is intentionally stricter than the account default 2 in baseline.tf.
+  metadata_options {
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    http_endpoint               = "enabled"
+    instance_metadata_tags      = "enabled"
+  }
+
   network_interfaces {
     security_groups = [aws_security_group.eks_nodes.id]
   }

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -128,7 +128,7 @@ resource "aws_launch_template" "eks_nodes" {
   EOF
   )
 
-  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5 item 9).
+  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5, EKS launch-template rider).
   # Hop limit 1 is intentionally stricter than the account default 2 in baseline.tf.
   metadata_options {
     http_tokens                 = "required"

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-report.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-report.md
@@ -51,11 +51,11 @@ service count.
 Write a **self-contained** HTML file to `$MIGRATION_DIR/migration-report.html`
 (inline CSS only). Required section IDs:
 
-| Section ID         | Content                                                                                                                                                                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `decision-summary` | Typography-first verdict (see below), cost one-liner, next action                                                                                                                                                                      |
-| `exec-costs`       | Heroku-vs-AWS side-by-side when a Heroku baseline exists (`current_costs.source != "unavailable"`); otherwise the AWS three-tier table with a one-line note that no Heroku baseline was available. Estimated monthly; Balanced primary |
-| `next-steps`       | Ordered list pointing to `MIGRATION_GUIDE.md` phases (not a procedure dump)                                                                                                                                                            |
+| Section ID         | Content                                                                                                                                                                                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `decision-summary` | Typography-first verdict (see below), cost one-liner, next action                                                                                                                                                                                                                            |
+| `exec-costs`       | Heroku-vs-AWS side-by-side when a Heroku baseline exists (`current_costs.source != "unavailable"`); otherwise the AWS three-tier table with a one-line note that no Heroku baseline was available. Estimated monthly; Balanced primary                                                       |
+| `next-steps`       | Ordered list pointing to `MIGRATION_GUIDE.md` phases (not a procedure dump). Include one bullet noting the Terraform ships with `baseline.tf` (account security baseline — GuardDuty, CloudTrail, budget alerts) and that three contact emails must be set in tfvars before `terraform plan` |
 
 ### `decision-summary` content (REQUIRED)
 

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -43,7 +43,7 @@ Generate `$MIGRATION_DIR/terraform/` with the following file organization. Only 
 
 **File emission rules:**
 
-- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; users who do not want it delete the file before `terraform apply`)
+- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; opting out takes two steps — delete the file AND remove its three contact variables — documented in MIGRATION_GUIDE.md Phase 1)
 - `vpc.tf` — Emitted when `vpc_design` is present in `aws-design.json` (either existing or new VPC)
 - `compute.tf` — Emitted when `aws_service` contains "Fargate" or "ALB" entries
 - `beanstalk.tf` — Emitted when `aws_service` contains "Elastic Beanstalk" entries
@@ -125,9 +125,9 @@ data "aws_availability_zones" "available" {
 
 ## Step 1.5: Generate `baseline.tf`
 
-Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline can delete `terraform/baseline.tf` before `terraform apply`. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
+Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline delete `terraform/baseline.tf` AND remove its three contact email variables from `variables.tf`/tfvars (they have no defaults, so plan fails on them even unreferenced) — MIGRATION_GUIDE.md Phase 1 documents both steps. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
 
-0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent or `"none"` → `[]`; scalar → single-element array; array → lowercase as-is. Every reference to `compliance` below means this normalized array.
+0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent, `"none"`, or `"unknown"` → `[]` (an absent or unconfirmed answer is not a framework); scalar → single-element array; array → lowercase as-is, dropping any `"none"`/`"unknown"` entries. Every reference to `compliance` below means this normalized array.
 
 1. **Compute retention.** Compute `cloudtrail_retention_days` from the normalized `compliance` array using this mapping, taking `max()` across all declared values (use 90 if the array is empty):
    - `[]` → 90
@@ -136,9 +136,9 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `hipaa` → 2190
    - `fedramp` → 1095
    - `gdpr` → 365
-   - unrecognized value → 365 (conservative), and record a `generation-warnings.json` entry naming the unrecognized framework
+   - unrecognized value → 365 (conservative), and note the unrecognized framework in the `baseline.tf` file-header comment (item 3) — do NOT add it to `generation-warnings.json`, whose entries are service-shaped and feed the every-service-accounted-for gate
 
-2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.breakdown.total.mid` (or the canonical equivalent). Compute `budget_limit = max(50, ceil(total_mid * 1.2))`. If `estimation-infra.json` is missing or the path is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
+2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.aws_monthly_balanced` (the Balanced-tier monthly total — the same key this skill's Estimate postconditions assert is a positive number). Compute `budget_limit = max(50, ceil(aws_monthly_balanced * 1.2))`. If `estimation-infra.json` is missing or the key is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
 
 3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
 
@@ -151,9 +151,9 @@ Always emitted. The baseline applies account-wide security controls that should 
    ```
 
 5. **Append the always-on resources**, in this order. Provider `default_tags` (Step 1) supply the standard tags; each baseline resource additionally carries `tags = { Component = "security-baseline" }` where the resource type supports tags:
-   - `aws_account_alternate_contact.operations` (ACCT.01, `email_address = var.operations_email` — fill-once variable, see Step 2)
-   - `aws_account_alternate_contact.billing` (ACCT.01, `email_address = var.billing_email`)
-   - `aws_account_alternate_contact.security` (ACCT.01, `email_address = var.security_email`)
+   - `aws_account_alternate_contact.operations` (ACCT.01; `alternate_contact_type = "OPERATIONS"`, `email_address = var.operations_email` — fill-once variable, see Step 2. `name`, `title`, and `phone_number` are ALSO required by this resource type: pin `name = "Operations Contact"`, `title = "Operations"`, and the placeholder `phone_number = "+1-555-0100"` with an inline comment telling the user to update the phone number post-apply — see the golden HCL below)
+   - `aws_account_alternate_contact.billing` (ACCT.01; `alternate_contact_type = "BILLING"`, `email_address = var.billing_email`; pinned `name = "Billing Contact"`, `title = "Billing"`, same placeholder phone pattern)
+   - `aws_account_alternate_contact.security` (ACCT.01; `alternate_contact_type = "SECURITY"`, `email_address = var.security_email`; pinned `name = "Security Contact"`, `title = "Security"`, same placeholder phone pattern)
    - `aws_iam_account_password_policy.baseline` (ACCT.06; `minimum_password_length = 14`, `password_reuse_prevention = 24`, `max_password_age = 90`, all four character-class requirements `true`, `hard_expiry = false`)
    - `aws_s3_account_public_access_block.baseline` (ACCT.08; all four flags `true`)
    - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
@@ -165,7 +165,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
 
 6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
-   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_iam_role.config` (trust policy for `config.amazonaws.com` — see the golden HCL below) + `aws_iam_role_policy_attachment` for the managed policy `arn:aws:iam::aws:policy/service-role/AWS_ConfigRole` (note the underscore — `AWSConfigRole` without it is a different, deprecated policy name and fails apply)
    - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
    - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
    - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`
@@ -181,24 +181,104 @@ Always emitted. The baseline applies account-wide security controls that should 
 8. **Attach inline HCL comments**:
    - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
    - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
-   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(total_mid * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(aws_monthly_balanced * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On each `aws_account_alternate_contact.*`: a comment noting the phone number is a placeholder to update post-apply (or in tfvars if the user prefers).
    - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
    - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
    - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
    - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
 
-9. **EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+**Golden HCL for the shapes agents get wrong.** The resource lists above name types; these four shapes have required arguments or policy documents that must not be improvised. Match them exactly (identifiers/CIDR-free values may vary):
 
-   ```hcl
-   metadata_options {
-     http_tokens                 = "required"
-     http_put_response_hop_limit = 1
-     http_endpoint               = "enabled"
-     instance_metadata_tags      = "enabled"
-   }
-   ```
+```hcl
+# Alternate contact — all four of name / title / email_address / phone_number are REQUIRED
+resource "aws_account_alternate_contact" "operations" {
+  alternate_contact_type = "OPERATIONS"
+  name                   = "Operations Contact"
+  title                  = "Operations"
+  email_address          = var.operations_email
+  phone_number           = "+1-555-0100" # placeholder — update post-apply with a real number
+}
 
-   Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
+# CloudTrail log bucket policy — service principal scoped by SourceArn
+data "aws_iam_policy_document" "cloudtrail_logs" {
+  statement {
+    sid       = "AWSCloudTrailAclCheck"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.cloudtrail_logs.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-baseline"]
+    }
+  }
+  statement {
+    sid       = "AWSCloudTrailWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+# Config role — trust policy + the CURRENT managed policy name (underscore)
+resource "aws_iam_role" "config" {
+  name = "${var.project_name}-config-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "config.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "config" {
+  role       = aws_iam_role.config.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+# Lifecycle configuration — every rule needs a filter (or prefix) block
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  rule {
+    id     = "retention"
+    status = "Enabled"
+    filter {} # applies to the whole bucket
+    expiration {
+      days = local.cloudtrail_retention_days
+    }
+    # STANDARD_IA / GLACIER transition blocks per item 7's thresholds
+  }
+}
+```
+
+**EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+
+```hcl
+metadata_options {
+  http_tokens                 = "required"
+  http_put_response_hop_limit = 1
+  http_endpoint               = "enabled"
+  instance_metadata_tags      = "enabled"
+}
+```
+
+Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
 
 **Emission conditions**:
 
@@ -241,32 +321,32 @@ variable "migration_id" {
 
 ```hcl
 variable "operations_email" {
-  description = "Operations contact for AWS account alternate contacts (fill-in checklist)"
+  description = "Operations contact for AWS account alternate contacts (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.operations_email, "TODO") && !strcontains(var.operations_email, "example.com") && strcontains(var.operations_email, "@")
-    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 
 variable "billing_email" {
-  description = "Billing contact + budget alert recipient (fill-in checklist)"
+  description = "Billing contact + budget alert recipient (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.billing_email, "TODO") && !strcontains(var.billing_email, "example.com") && strcontains(var.billing_email, "@")
-    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 
 variable "security_email" {
-  description = "Security contact for AWS account alternate contacts (fill-in checklist)"
+  description = "Security contact for AWS account alternate contacts (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.security_email, "TODO") && !strcontains(var.security_email, "example.com") && strcontains(var.security_email, "@")
-    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 ```

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -3,6 +3,7 @@ _fragment: terraform
 _of_phase: generate
 _contributes:
   - terraform/main.tf
+  - terraform/baseline.tf
   - terraform/variables.tf
   - terraform/outputs.tf
   - terraform/security.tf
@@ -25,23 +26,24 @@ Transform `aws-design.json` into review-ready Terraform HCL configurations. Prod
 
 Generate `$MIGRATION_DIR/terraform/` with the following file organization. Only emit domain files that have resources in `aws-design.json`:
 
-| File           | Domain     | Contains                                                   |
-| -------------- | ---------- | ---------------------------------------------------------- |
-| `main.tf`      | core       | Provider config, backend, data sources                     |
-| `variables.tf` | core       | All input variables with types and defaults                |
-| `outputs.tf`   | core       | Resource outputs and migration summary                     |
-| `vpc.tf`       | networking | VPC, subnets, route tables, internet gateway, NAT, peering |
-| `compute.tf`   | compute    | ECS cluster, Fargate task definitions, services, ALBs      |
-| `beanstalk.tf` | compute    | Elastic Beanstalk applications and environments            |
-| `pipeline.tf`  | deploy     | Optional CodePipeline source-to-EB deploy path             |
-| `database.tf`  | database   | RDS/Aurora instances, parameter groups, RDS Proxy          |
-| `cache.tf`     | cache      | ElastiCache replication groups, subnet groups              |
-| `messaging.tf` | messaging  | MSK clusters, configurations                               |
-| `security.tf`  | security   | Security groups, IAM roles/policies                        |
+| File           | Domain     | Contains                                                                                                                               |
+| -------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.tf`      | core       | Provider config, backend, data sources                                                                                                 |
+| `baseline.tf`  | security   | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget, IMDSv2 default; compliance-conditional Config + Security Hub) |
+| `variables.tf` | core       | All input variables with types and defaults                                                                                            |
+| `outputs.tf`   | core       | Resource outputs and migration summary                                                                                                 |
+| `vpc.tf`       | networking | VPC, subnets, route tables, internet gateway, NAT, peering                                                                             |
+| `compute.tf`   | compute    | ECS cluster, Fargate task definitions, services, ALBs                                                                                  |
+| `beanstalk.tf` | compute    | Elastic Beanstalk applications and environments                                                                                        |
+| `pipeline.tf`  | deploy     | Optional CodePipeline source-to-EB deploy path                                                                                         |
+| `database.tf`  | database   | RDS/Aurora instances, parameter groups, RDS Proxy                                                                                      |
+| `cache.tf`     | cache      | ElastiCache replication groups, subnet groups                                                                                          |
+| `messaging.tf` | messaging  | MSK clusters, configurations                                                                                                           |
+| `security.tf`  | security   | Security groups, IAM roles/policies                                                                                                    |
 
 **File emission rules:**
 
-- `main.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted
+- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; users who do not want it delete the file before `terraform apply`)
 - `vpc.tf` — Emitted when `vpc_design` is present in `aws-design.json` (either existing or new VPC)
 - `compute.tf` — Emitted when `aws_service` contains "Fargate" or "ALB" entries
 - `beanstalk.tf` — Emitted when `aws_service` contains "Elastic Beanstalk" entries
@@ -121,6 +123,90 @@ data "aws_availability_zones" "available" {
 
 ---
 
+## Step 1.5: Generate `baseline.tf`
+
+Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline can delete `terraform/baseline.tf` before `terraform apply`. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
+
+0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent or `"none"` → `[]`; scalar → single-element array; array → lowercase as-is. Every reference to `compliance` below means this normalized array.
+
+1. **Compute retention.** Compute `cloudtrail_retention_days` from the normalized `compliance` array using this mapping, taking `max()` across all declared values (use 90 if the array is empty):
+   - `[]` → 90
+   - `soc2` → 365
+   - `pci` → 365
+   - `hipaa` → 2190
+   - `fedramp` → 1095
+   - `gdpr` → 365
+   - unrecognized value → 365 (conservative), and record a `generation-warnings.json` entry naming the unrecognized framework
+
+2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.breakdown.total.mid` (or the canonical equivalent). Compute `budget_limit = max(50, ceil(total_mid * 1.2))`. If `estimation-infra.json` is missing or the path is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
+
+3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
+
+4. **Emit `baseline.tf`** starting with the file-header comment block and a `locals` block containing the resolved `cloudtrail_retention_days` integer:
+
+   ```hcl
+   locals {
+     cloudtrail_retention_days = <N>
+   }
+   ```
+
+5. **Append the always-on resources**, in this order. Provider `default_tags` (Step 1) supply the standard tags; each baseline resource additionally carries `tags = { Component = "security-baseline" }` where the resource type supports tags:
+   - `aws_account_alternate_contact.operations` (ACCT.01, `email_address = var.operations_email` — fill-once variable, see Step 2)
+   - `aws_account_alternate_contact.billing` (ACCT.01, `email_address = var.billing_email`)
+   - `aws_account_alternate_contact.security` (ACCT.01, `email_address = var.security_email`)
+   - `aws_iam_account_password_policy.baseline` (ACCT.06; `minimum_password_length = 14`, `password_reuse_prevention = 24`, `max_password_age = 90`, all four character-class requirements `true`, `hard_expiry = false`)
+   - `aws_s3_account_public_access_block.baseline` (ACCT.08; all four flags `true`)
+   - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
+   - `aws_accessanalyzer_analyzer.baseline` (ACCT.11; `type = "ACCOUNT"`)
+   - `aws_ec2_instance_metadata_defaults.baseline` (defense-in-depth; `http_tokens = "required"`, `http_put_response_hop_limit = 2`)
+   - `aws_cloudtrail.baseline` (ACCT.07; multi-region, management events only, `enable_log_file_validation = true`)
+   - `aws_s3_bucket.cloudtrail_logs` plus `aws_s3_bucket_public_access_block`, `aws_s3_bucket_server_side_encryption_configuration`, `aws_s3_bucket_versioning`, `aws_s3_bucket_lifecycle_configuration` (transitions driven by `local.cloudtrail_retention_days` per item 7), and `aws_s3_bucket_policy` restricting the CloudTrail service principal by `aws:SourceArn`
+   - `aws_budgets_budget.monthly_spend` (ACCT.10; `limit_amount = "<budget_limit>"` from item 2; three `notification` blocks at 50/80/100% `ACTUAL`; `subscriber_email_addresses = [var.billing_email]` — same fill-once variable as the alternate contact, entered exactly once in tfvars)
+   - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
+
+6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
+   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
+   - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
+   - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`
+   - `aws_s3_bucket.config_logs` plus PAB, SSE, versioning, lifecycle (same `local.cloudtrail_retention_days`), and a bucket policy allowing the `config.amazonaws.com` service principal
+   - `aws_securityhub_account.baseline`
+   - `aws_securityhub_standards_subscription.fsbp` (always emitted in this section)
+   - `aws_securityhub_standards_subscription.pci_dss` (only if `compliance` contains `pci`)
+
+   Do NOT emit an NIST 800-53 standards subscription, even if `compliance` contains `hipaa` or `fedramp`. Security Hub does not provide a HIPAA-specific standard; FedRAMP attestation is out-of-band.
+
+7. **Lifecycle rule adjustment.** Omit the `STANDARD_IA` transition block when the resolved retention is less than 90 days. Omit the `GLACIER` transition block when retention is less than 365 days. Both rules apply to both the CloudTrail log bucket and (when emitted) the Config log bucket.
+
+8. **Attach inline HCL comments**:
+   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
+   - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
+   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(total_mid * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
+   - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
+   - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
+   - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
+
+9. **EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+
+   ```hcl
+   metadata_options {
+     http_tokens                 = "required"
+     http_put_response_hop_limit = 1
+     http_endpoint               = "enabled"
+     instance_metadata_tags      = "enabled"
+   }
+   ```
+
+   Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
+
+**Emission conditions**:
+
+- Emit `baseline.tf` for every design, including EB-only, Fargate-only, and EKS designs. The baseline is workload-independent.
+- Do NOT probe for existing account resources (CloudTrail trails, Config recorders, Security Hub enrollment). Collision risk is surfaced by the inline comments listed in item 8.
+
+---
+
 ## Step 2: Generate `variables.tf`
 
 **Always include these global variables:**
@@ -148,6 +234,40 @@ variable "migration_id" {
   description = "Migration run identifier"
   type        = string
   default     = "<migration_id from .phase-status.json>"
+}
+```
+
+**Baseline contact variables (always include — `baseline.tf` depends on them):** the three fill-once contact emails referenced by `baseline.tf`'s alternate contacts and budget alerts. They intentionally have no `default` — `terraform plan` must fail until the customer supplies real values — and each carries a `validation` block rejecting placeholder tokens, so a copied-through `TODO-ops@example.com` fails loudly at `terraform plan` instead of silently becoming the account's security contact:
+
+```hcl
+variable "operations_email" {
+  description = "Operations contact for AWS account alternate contacts (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.operations_email, "TODO") && !strcontains(var.operations_email, "example.com") && strcontains(var.operations_email, "@")
+    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
+}
+
+variable "billing_email" {
+  description = "Billing contact + budget alert recipient (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.billing_email, "TODO") && !strcontains(var.billing_email, "example.com") && strcontains(var.billing_email, "@")
+    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
+}
+
+variable "security_email" {
+  description = "Security contact for AWS account alternate contacts (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.security_email, "TODO") && !strcontains(var.security_email, "example.com") && strcontains(var.security_email, "@")
+    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
 }
 ```
 
@@ -1944,6 +2064,11 @@ project_name = "<project_name>"
 environment  = "<environment>"
 migration_id = "<migration_id>"
 
+# Security baseline contacts (always required — plan fails until all three are real inboxes)
+operations_email = "TODO-ops@example.com"      # AWS account operations alternate contact
+billing_email    = "TODO-billing@example.com"  # billing alternate contact + budget alert recipient
+security_email   = "TODO-security@example.com" # security alternate contact
+
 # Database credentials (required if RDS/Aurora is in the design)
 # db_username = "app_user"
 # db_password = "CHANGE_ME"
@@ -1992,7 +2117,8 @@ After all files are written:
 3. **Variable completeness**: Every `var.*` reference has a corresponding `variable` block in `variables.tf`
 4. **Output references**: Every `output` references a declared resource attribute
 5. **Tag consistency**: Every resource has the default tags (applied via provider `default_tags`)
-6. **Elastic Beanstalk web runtime inputs**: For every EB web service, verify its per-app `eb_application_port_<app>_web` and `eb_health_check_path_<app>_web` variables are declared without defaults, include the required validation blocks, and are referenced directly by that app's `PORT` and `HealthCheckPath` settings. Verify non-web EB services do not require these variables. Do not report an EB web configuration as ready to plan until the customer has supplied both values for every web app.
+6. **Security baseline**: `baseline.tf` exists and contains the full always-on resource list from Step 1.5 (three `aws_account_alternate_contact`, password policy, S3 account PAB, EBS default encryption, Access Analyzer, IMDSv2 account default, CloudTrail + log bucket, budget, GuardDuty); its `locals.cloudtrail_retention_days` is a positive integer; the compliance-conditional section is present exactly when the normalized `compliance` array contains soc2/pci/hipaa/fedramp; the three contact email variables are declared without defaults and with placeholder-rejecting validation blocks
+7. **Elastic Beanstalk web runtime inputs**: For every EB web service, verify its per-app `eb_application_port_<app>_web` and `eb_health_check_path_<app>_web` variables are declared without defaults, include the required validation blocks, and are referenced directly by that app's `PORT` and `HealthCheckPath` settings. Verify non-web EB services do not require these variables. Do not report an EB web configuration as ready to plan until the customer has supplied both values for every web app.
 
 **Note:** Full `terraform validate` requires `terraform init` (provider download). The generated configuration SHOULD pass `terraform validate` when run with network access. If validation cannot run (no Terraform binary, no network), log a note but do NOT block generation.
 

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -140,7 +140,7 @@ Always emitted. The baseline applies account-wide security controls that should 
 
 2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.aws_monthly_balanced` (the Balanced-tier monthly total — the same key this skill's Estimate postconditions assert is a positive number). Compute `budget_limit = max(50, ceil(aws_monthly_balanced * 1.2))`. If `estimation-infra.json` is missing or the key is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
 
-3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
+3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header. When item 1 encountered an unrecognized compliance value, append one header line naming it and the conservative 365-day retention applied (e.g. `# Unrecognized compliance framework "iso27001" — applied conservative 365-day CloudTrail retention`).
 
 4. **Emit `baseline.tf`** starting with the file-header comment block and a `locals` block containing the resolved `cloudtrail_retention_days` integer:
 
@@ -159,7 +159,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
    - `aws_accessanalyzer_analyzer.baseline` (ACCT.11; `type = "ACCOUNT"`)
    - `aws_ec2_instance_metadata_defaults.baseline` (defense-in-depth; `http_tokens = "required"`, `http_put_response_hop_limit = 2`)
-   - `aws_cloudtrail.baseline` (ACCT.07; multi-region, management events only, `enable_log_file_validation = true`)
+   - `aws_cloudtrail.baseline` (ACCT.07; `name = "${var.project_name}-baseline"` — MUST match the `aws:SourceArn` in the bucket policy exactly, see the golden HCL; multi-region, management events only, `enable_log_file_validation = true`, `depends_on = [aws_s3_bucket_policy.cloudtrail_logs]` — CloudTrail validates the bucket policy at create time)
    - `aws_s3_bucket.cloudtrail_logs` plus `aws_s3_bucket_public_access_block`, `aws_s3_bucket_server_side_encryption_configuration`, `aws_s3_bucket_versioning`, `aws_s3_bucket_lifecycle_configuration` (transitions driven by `local.cloudtrail_retention_days` per item 7), and `aws_s3_bucket_policy` restricting the CloudTrail service principal by `aws:SourceArn`
    - `aws_budgets_budget.monthly_spend` (ACCT.10; `limit_amount = "<budget_limit>"` from item 2; three `notification` blocks at 50/80/100% `ACTUAL`; `subscriber_email_addresses = [var.billing_email]` — same fill-once variable as the alternate contact, entered exactly once in tfvars)
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
@@ -179,16 +179,15 @@ Always emitted. The baseline applies account-wide security controls that should 
 7. **Lifecycle rule adjustment.** Omit the `STANDARD_IA` transition block when the resolved retention is less than 90 days. Omit the `GLACIER` transition block when retention is less than 365 days. Both rules apply to both the CloudTrail log bucket and (when emitted) the Config log bucket.
 
 8. **Attach inline HCL comments**:
-   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
+   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`) and noting the phone number is a placeholder to update post-apply.
    - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
    - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(aws_monthly_balanced * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
-   - On each `aws_account_alternate_contact.*`: a comment noting the phone number is a placeholder to update post-apply (or in tfvars if the user prefers).
    - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
    - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
    - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
    - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
 
-**Golden HCL for the shapes agents get wrong.** The resource lists above name types; these four shapes have required arguments or policy documents that must not be improvised. Match them exactly (identifiers/CIDR-free values may vary):
+**Golden HCL for the shapes agents get wrong.** The resource lists above name types; the shapes below have required arguments, policy documents, or cross-resource name/ordering couplings that must not be improvised. Match them exactly (identifiers/region values may vary, but the trail name and the `aws:SourceArn` conditions must agree):
 
 ```hcl
 # Alternate contact — all four of name / title / email_address / phone_number are REQUIRED
@@ -231,7 +230,31 @@ data "aws_iam_policy_document" "cloudtrail_logs" {
       variable = "s3:x-amz-acl"
       values   = ["bucket-owner-full-control"]
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-baseline"]
+    }
   }
+}
+
+# The policy document must be ATTACHED, and the trail name must match the
+# SourceArn above exactly — CloudTrail validates the bucket policy at create
+# time, so the trail depends_on the attachment.
+resource "aws_s3_bucket_policy" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  policy = data.aws_iam_policy_document.cloudtrail_logs.json
+}
+
+resource "aws_cloudtrail" "baseline" {
+  # Trail already in this region? See the collision warning in item 8.
+  name                          = "${var.project_name}-baseline" # MUST match the SourceArn conditions above
+  s3_bucket_name                = aws_s3_bucket.cloudtrail_logs.id
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  include_global_service_events = true
+
+  depends_on = [aws_s3_bucket_policy.cloudtrail_logs]
 }
 
 # Config role — trust policy + the CURRENT managed policy name (underscore)

--- a/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/advisor/plugins/aws-startup-advisor/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -24,6 +24,7 @@ _assemble:
   _file: phases/generate/generate-assemble.md
 _produces:
   - terraform/main.tf
+  - terraform/baseline.tf
   - terraform/variables.tf
   - terraform/outputs.tf
   - terraform/security.tf
@@ -47,9 +48,15 @@ _preconditions:
   - _validate_json: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
     _on_failure: _unrecoverable
 _postconditions:
-  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md, migration-report.html, generation-warnings.json]
+  - _check_file_exists: [terraform/main.tf, terraform/baseline.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md, migration-report.html, generation-warnings.json]
     _on_failure: _halt_and_inform
   - _assert: "terraform/main.tf has valid provider configuration; terraform/variables.tf declares at least an aws_region variable"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/baseline.tf contains a locals block with cloudtrail_retention_days set to a positive integer, plus aws_account_alternate_contact resources for each of operations, billing, and security, aws_iam_account_password_policy, aws_s3_account_public_access_block, aws_ebs_encryption_by_default, aws_accessanalyzer_analyzer, aws_ec2_instance_metadata_defaults, aws_cloudtrail with its log bucket, aws_budgets_budget, and aws_guardduty_detector"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/baseline.tf has the Compliance-Conditional section (aws_config_* recorder/delivery/status, aws_securityhub_account, FSBP standards subscription) exactly when the normalized preferences compliance array contains soc2, pci, hipaa, or fedramp; a PCI DSS standards subscription exists only when it contains pci; no NIST 800-53 standards subscription exists regardless of compliance values"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/variables.tf declares operations_email, billing_email, and security_email with no defaults and placeholder-rejecting validation blocks, and terraform/terraform.tfvars.example lists all three with TODO placeholders"
     _on_failure: _halt_and_inform
   - _assert: "at least one domain .tf file exists beyond the core files"
     _on_failure: _halt_and_inform

--- a/migrate/README.md
+++ b/migrate/README.md
@@ -109,13 +109,13 @@ GCP/Heroku migrations write a `.migration/<session>/` directory; agent-advisor w
 
 **Infrastructure:**
 
-| Capability                 | Base LLM          | This Plugin                                                                                                                   |
-| -------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Terraform generation       | Generic templates | Your actual GCP config translated — instance classes, storage sizes, region, VPC CIDRs, security groups                       |
-| Security baseline          | Not included      | `baseline.tf` always emitted: GuardDuty, CloudTrail, IMDSv2, ECR scanning, EBS encryption, budget alerts                      |
-| Database migration tooling | "Use DMS"         | Selects pg_dump / pgcopydb / DMS based on your actual database size; generates the right script                               |
-| Cost estimation            | Stale guesses     | Estimated monthly costs across three tiers (Premium/Balanced/Optimized) using live AWS Pricing API, compared to your GCP bill |
-| Migration plan             | Generic checklist | Phased timeline with Go/No-Go gates, rollback procedures, and data integrity checks                                           |
+| Capability                 | Base LLM          | This Plugin                                                                                                                                                                                         |
+| -------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Terraform generation       | Generic templates | Your actual GCP config translated — instance classes, storage sizes, region, VPC CIDRs, security groups                                                                                             |
+| Security baseline          | Not included      | `baseline.tf` always emitted by both `gcp-to-aws` and `heroku-to-aws` Generate: GuardDuty, CloudTrail, IMDSv2, EBS encryption, budget alerts; ECR scan-on-push where ECR repositories are generated |
+| Database migration tooling | "Use DMS"         | Selects pg_dump / pgcopydb / DMS based on your actual database size; generates the right script                                                                                                     |
+| Cost estimation            | Stale guesses     | Estimated monthly costs across three tiers (Premium/Balanced/Optimized) using live AWS Pricing API, compared to your GCP bill                                                                       |
+| Migration plan             | Generic checklist | Phased timeline with Go/No-Go gates, rollback procedures, and data integrity checks                                                                                                                 |
 
 **AI/Agentic:**
 

--- a/migrate/plugins/migration-to-aws/README.md
+++ b/migrate/plugins/migration-to-aws/README.md
@@ -30,14 +30,14 @@ Point this plugin at your Heroku account (via your authenticated Heroku CLI, rea
 
 **Infrastructure:**
 
-| Capability                 | Base LLM                          | This Plugin                                                                                                                                        |
-| -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Terraform generation       | Generic templates                 | Your actual config translated — instance classes, storage sizes, region, VPC CIDRs, security groups                                                |
-| Security baseline          | Not included                      | `baseline.tf` always emitted: GuardDuty, CloudTrail, IMDSv2, ECR scanning, EBS encryption, budget alerts                                           |
-| Database migration tooling | "Use DMS"                         | Selects pg_dump / pgcopydb / DMS based on your actual database size; generates the right script                                                    |
-| Cost estimation            | Stale guesses                     | Three-tier pricing (Premium/Balanced/Optimized) using live AWS Pricing API, compared to your current bill                                          |
-| Migration plan             | Generic checklist                 | Phased timeline with Go/No-Go gates, rollback procedures, and data integrity checks                                                                |
-| Migration report           | Generic summary or missing detail | `migration-report.html` with cost tiers, security baseline (GuardDuty, etc.), combined TCO, and appendices — validated for structural completeness |
+| Capability                 | Base LLM                          | This Plugin                                                                                                                                                                                         |
+| -------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Terraform generation       | Generic templates                 | Your actual config translated — instance classes, storage sizes, region, VPC CIDRs, security groups                                                                                                 |
+| Security baseline          | Not included                      | `baseline.tf` always emitted by both `gcp-to-aws` and `heroku-to-aws` Generate: GuardDuty, CloudTrail, IMDSv2, EBS encryption, budget alerts; ECR scan-on-push where ECR repositories are generated |
+| Database migration tooling | "Use DMS"                         | Selects pg_dump / pgcopydb / DMS based on your actual database size; generates the right script                                                                                                     |
+| Cost estimation            | Stale guesses                     | Three-tier pricing (Premium/Balanced/Optimized) using live AWS Pricing API, compared to your current bill                                                                                           |
+| Migration plan             | Generic checklist                 | Phased timeline with Go/No-Go gates, rollback procedures, and data integrity checks                                                                                                                 |
+| Migration report           | Generic summary or missing detail | `migration-report.html` with cost tiers, security baseline (GuardDuty, etc.), combined TCO, and appendices — validated for structural completeness                                                  |
 
 **AI/Agentic:**
 

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/phases/generate/generate-artifacts-infra.md
@@ -188,7 +188,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
 
 6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
-   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `arn:aws:iam::aws:policy/service-role/AWS_ConfigRole` (note the underscore — `AWSConfigRole` without it is a deprecated policy name and fails apply)
    - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
    - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
    - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -42,12 +42,14 @@ assembler adds the cross-artifact checks that span multiple fragment outputs:
 
 The completion checks are declared in this phase's `_postconditions` frontmatter and
 enforced per `INTERPRETER.md` § Gate protocol: re-read the generated artifacts from
-disk, run the mechanical checks (`_check_file_exists` for the core terraform files +
-MIGRATION_GUIDE.md + README.md + migration-report.html) and the `_assert` judgment
-checks (valid provider / aws_region variable, a domain .tf beyond core, guide
-sections, report sections, conditional Postgres/ Redis migration scripts, conditional
-EKS terraform + kubernetes manifests, every service accounted for, no `{{VARIABLE}}`
-placeholders), then emit `GATE_FAIL` (STOP) or
+disk, run the mechanical checks (`_check_file_exists` for the core terraform files
+including `baseline.tf` + MIGRATION_GUIDE.md + README.md + migration-report.html)
+and the `_assert` judgment checks (valid provider / aws_region variable, a domain
+.tf beyond core, security-baseline resource inventory + compliance-conditional
+section + contact email variables, guide sections, report sections, conditional
+Postgres/ Redis migration scripts, conditional EKS terraform + kubernetes
+manifests, every service accounted for, no `{{VARIABLE}}` placeholders), then emit
+`GATE_FAIL` (STOP) or
 `HANDOFF_OK | phase=generate | artifacts=terraform/,MIGRATION_GUIDE.md,README.md,migration-report.html`.
 
 Optionally run
@@ -68,7 +70,7 @@ Output to user:
 Phase 5 of 6 complete (Generate). Optional remaining: Feedback.
 
 Artifacts produced:
-• terraform/ — [N] Terraform files for AWS infrastructure
+• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — delete it before apply to opt out)
 • MIGRATION_GUIDE.md — Step-by-step migration procedure
 • README.md — Artifact listing and quick start
 • migration-report.html — Stakeholder summary (costs + what-if scenarios when present)

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-assemble.md
@@ -70,7 +70,7 @@ Output to user:
 Phase 5 of 6 complete (Generate). Optional remaining: Feedback.
 
 Artifacts produced:
-• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — delete it before apply to opt out)
+• terraform/ — [N] Terraform files for AWS infrastructure (includes baseline.tf, the account security baseline — MIGRATION_GUIDE.md Phase 1 covers its contact variables and how to opt out)
 • MIGRATION_GUIDE.md — Step-by-step migration procedure
 • README.md — Artifact listing and quick start
 • migration-report.html — Stakeholder summary (costs + what-if scenarios when present)

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -167,8 +167,11 @@ baseline (account alternate contacts, IAM password policy, S3 account public
 access block, EBS default encryption, IAM Access Analyzer, IMDSv2 account
 default, CloudTrail with its log bucket, a monthly AWS Budget with alerts, and
 GuardDuty — plus AWS Config and Security Hub when compliance frameworks were
-declared). Before `terraform plan` can succeed, set the three baseline contact
-variables in `terraform/terraform.tfvars` to real inboxes:
+declared).
+
+**Security baseline contacts.** Before `terraform plan` can succeed, set the
+three baseline contact variables in `terraform/terraform.tfvars` to real
+inboxes:
 
 ```hcl
 operations_email = "ops@yourcompany.com"
@@ -176,12 +179,22 @@ billing_email    = "billing@yourcompany.com"   # also receives budget alerts
 security_email   = "security@yourcompany.com"
 ```
 
-To skip the security baseline entirely, delete `terraform/baseline.tf` before
-running `terraform apply`. To skip only the compliance-conditional section
-(Config + Security Hub), delete the block between
-`########## Compliance-Conditional ##########` and
-`########## End Compliance-Conditional ##########` in that file. If your AWS
-account already has a CloudTrail trail, a Config recorder, or Security Hub
+The alternate-contact phone numbers ship as placeholders — update them in
+`baseline.tf` (or post-apply) with real numbers.
+
+To skip the security baseline entirely, do BOTH of the following before
+`terraform plan` (the contact variables have no defaults, so deleting only the
+file still leaves plan failing on three unused required variables):
+
+1. Delete `terraform/baseline.tf`.
+2. Remove (or comment out) the `operations_email`, `billing_email`, and
+   `security_email` variable blocks in `terraform/variables.tf`, and their
+   entries in `terraform.tfvars` / `terraform.tfvars.example`.
+
+To skip only the compliance-conditional section (Config + Security Hub),
+delete the block between `########## Compliance-Conditional ##########` and
+`########## End Compliance-Conditional ##########` in `baseline.tf`. If your
+AWS account already has a CloudTrail trail, a Config recorder, or Security Hub
 enabled, review the collision-warning comments in `baseline.tf` before apply.
 
 {{IF has_beanstalk_web}}
@@ -941,7 +954,7 @@ This directory contains all artifacts needed to migrate your Heroku application(
 |------|---------|
 | `terraform/` | Terraform configurations for all AWS infrastructure |
 | `terraform/main.tf` | Provider configuration and module declarations |
-| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Delete before apply to opt out |
+| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Opt-out steps in MIGRATION_GUIDE.md Phase 1 |
 | `terraform/variables.tf` | Input variables (region, VPC, naming, baseline contact emails) |
 | `terraform/outputs.tf` | Output values (endpoints, ARNs, DNS names) |
 {{IF has_beanstalk}}

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-docs.md
@@ -162,6 +162,28 @@ For detailed guidance, see your Procfile process types and match each to a Docke
 
 Apply the generated Terraform configurations to create AWS resources:
 
+The `terraform/` directory includes `baseline.tf`, an account-wide security
+baseline (account alternate contacts, IAM password policy, S3 account public
+access block, EBS default encryption, IAM Access Analyzer, IMDSv2 account
+default, CloudTrail with its log bucket, a monthly AWS Budget with alerts, and
+GuardDuty — plus AWS Config and Security Hub when compliance frameworks were
+declared). Before `terraform plan` can succeed, set the three baseline contact
+variables in `terraform/terraform.tfvars` to real inboxes:
+
+```hcl
+operations_email = "ops@yourcompany.com"
+billing_email    = "billing@yourcompany.com"   # also receives budget alerts
+security_email   = "security@yourcompany.com"
+```
+
+To skip the security baseline entirely, delete `terraform/baseline.tf` before
+running `terraform apply`. To skip only the compliance-conditional section
+(Config + Security Hub), delete the block between
+`########## Compliance-Conditional ##########` and
+`########## End Compliance-Conditional ##########` in that file. If your AWS
+account already has a CloudTrail trail, a Config recorder, or Security Hub
+enabled, review the collision-warning comments in `baseline.tf` before apply.
+
 {{IF has_beanstalk_web}}
 
 Each Elastic Beanstalk web configuration is not ready to plan until you provide
@@ -919,7 +941,8 @@ This directory contains all artifacts needed to migrate your Heroku application(
 |------|---------|
 | `terraform/` | Terraform configurations for all AWS infrastructure |
 | `terraform/main.tf` | Provider configuration and module declarations |
-| `terraform/variables.tf` | Input variables (region, VPC, naming) |
+| `terraform/baseline.tf` | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget alerts; Config + Security Hub when compliance declared). Delete before apply to opt out |
+| `terraform/variables.tf` | Input variables (region, VPC, naming, baseline contact emails) |
 | `terraform/outputs.tf` | Output values (endpoints, ARNs, DNS names) |
 {{IF has_beanstalk}}
 | `terraform/beanstalk.tf` | Elastic Beanstalk applications and environments |

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -128,6 +128,15 @@ resource "aws_launch_template" "eks_nodes" {
   EOF
   )
 
+  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5 item 9).
+  # Hop limit 1 is intentionally stricter than the account default 2 in baseline.tf.
+  metadata_options {
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    http_endpoint               = "enabled"
+    instance_metadata_tags      = "enabled"
+  }
+
   network_interfaces {
     security_groups = [aws_security_group.eks_nodes.id]
   }

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-eks.md
@@ -128,7 +128,7 @@ resource "aws_launch_template" "eks_nodes" {
   EOF
   )
 
-  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5 item 9).
+  # IMDSv2 enforcement — security baseline, always applied (generate-terraform.md Step 1.5, EKS launch-template rider).
   # Hop limit 1 is intentionally stricter than the account default 2 in baseline.tf.
   metadata_options {
     http_tokens                 = "required"

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-report.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-report.md
@@ -51,11 +51,11 @@ service count.
 Write a **self-contained** HTML file to `$MIGRATION_DIR/migration-report.html`
 (inline CSS only). Required section IDs:
 
-| Section ID         | Content                                                                                                                                                                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `decision-summary` | Typography-first verdict (see below), cost one-liner, next action                                                                                                                                                                      |
-| `exec-costs`       | Heroku-vs-AWS side-by-side when a Heroku baseline exists (`current_costs.source != "unavailable"`); otherwise the AWS three-tier table with a one-line note that no Heroku baseline was available. Estimated monthly; Balanced primary |
-| `next-steps`       | Ordered list pointing to `MIGRATION_GUIDE.md` phases (not a procedure dump)                                                                                                                                                            |
+| Section ID         | Content                                                                                                                                                                                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `decision-summary` | Typography-first verdict (see below), cost one-liner, next action                                                                                                                                                                                                                            |
+| `exec-costs`       | Heroku-vs-AWS side-by-side when a Heroku baseline exists (`current_costs.source != "unavailable"`); otherwise the AWS three-tier table with a one-line note that no Heroku baseline was available. Estimated monthly; Balanced primary                                                       |
+| `next-steps`       | Ordered list pointing to `MIGRATION_GUIDE.md` phases (not a procedure dump). Include one bullet noting the Terraform ships with `baseline.tf` (account security baseline — GuardDuty, CloudTrail, budget alerts) and that three contact emails must be set in tfvars before `terraform plan` |
 
 ### `decision-summary` content (REQUIRED)
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -43,7 +43,7 @@ Generate `$MIGRATION_DIR/terraform/` with the following file organization. Only 
 
 **File emission rules:**
 
-- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; users who do not want it delete the file before `terraform apply`)
+- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; opting out takes two steps — delete the file AND remove its three contact variables — documented in MIGRATION_GUIDE.md Phase 1)
 - `vpc.tf` — Emitted when `vpc_design` is present in `aws-design.json` (either existing or new VPC)
 - `compute.tf` — Emitted when `aws_service` contains "Fargate" or "ALB" entries
 - `beanstalk.tf` — Emitted when `aws_service` contains "Elastic Beanstalk" entries
@@ -125,9 +125,9 @@ data "aws_availability_zones" "available" {
 
 ## Step 1.5: Generate `baseline.tf`
 
-Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline can delete `terraform/baseline.tf` before `terraform apply`. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
+Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline delete `terraform/baseline.tf` AND remove its three contact email variables from `variables.tf`/tfvars (they have no defaults, so plan fails on them even unreferenced) — MIGRATION_GUIDE.md Phase 1 documents both steps. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
 
-0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent or `"none"` → `[]`; scalar → single-element array; array → lowercase as-is. Every reference to `compliance` below means this normalized array.
+0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent, `"none"`, or `"unknown"` → `[]` (an absent or unconfirmed answer is not a framework); scalar → single-element array; array → lowercase as-is, dropping any `"none"`/`"unknown"` entries. Every reference to `compliance` below means this normalized array.
 
 1. **Compute retention.** Compute `cloudtrail_retention_days` from the normalized `compliance` array using this mapping, taking `max()` across all declared values (use 90 if the array is empty):
    - `[]` → 90
@@ -136,9 +136,9 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `hipaa` → 2190
    - `fedramp` → 1095
    - `gdpr` → 365
-   - unrecognized value → 365 (conservative), and record a `generation-warnings.json` entry naming the unrecognized framework
+   - unrecognized value → 365 (conservative), and note the unrecognized framework in the `baseline.tf` file-header comment (item 3) — do NOT add it to `generation-warnings.json`, whose entries are service-shaped and feed the every-service-accounted-for gate
 
-2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.breakdown.total.mid` (or the canonical equivalent). Compute `budget_limit = max(50, ceil(total_mid * 1.2))`. If `estimation-infra.json` is missing or the path is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
+2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.aws_monthly_balanced` (the Balanced-tier monthly total — the same key this skill's Estimate postconditions assert is a positive number). Compute `budget_limit = max(50, ceil(aws_monthly_balanced * 1.2))`. If `estimation-infra.json` is missing or the key is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
 
 3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
 
@@ -151,9 +151,9 @@ Always emitted. The baseline applies account-wide security controls that should 
    ```
 
 5. **Append the always-on resources**, in this order. Provider `default_tags` (Step 1) supply the standard tags; each baseline resource additionally carries `tags = { Component = "security-baseline" }` where the resource type supports tags:
-   - `aws_account_alternate_contact.operations` (ACCT.01, `email_address = var.operations_email` — fill-once variable, see Step 2)
-   - `aws_account_alternate_contact.billing` (ACCT.01, `email_address = var.billing_email`)
-   - `aws_account_alternate_contact.security` (ACCT.01, `email_address = var.security_email`)
+   - `aws_account_alternate_contact.operations` (ACCT.01; `alternate_contact_type = "OPERATIONS"`, `email_address = var.operations_email` — fill-once variable, see Step 2. `name`, `title`, and `phone_number` are ALSO required by this resource type: pin `name = "Operations Contact"`, `title = "Operations"`, and the placeholder `phone_number = "+1-555-0100"` with an inline comment telling the user to update the phone number post-apply — see the golden HCL below)
+   - `aws_account_alternate_contact.billing` (ACCT.01; `alternate_contact_type = "BILLING"`, `email_address = var.billing_email`; pinned `name = "Billing Contact"`, `title = "Billing"`, same placeholder phone pattern)
+   - `aws_account_alternate_contact.security` (ACCT.01; `alternate_contact_type = "SECURITY"`, `email_address = var.security_email`; pinned `name = "Security Contact"`, `title = "Security"`, same placeholder phone pattern)
    - `aws_iam_account_password_policy.baseline` (ACCT.06; `minimum_password_length = 14`, `password_reuse_prevention = 24`, `max_password_age = 90`, all four character-class requirements `true`, `hard_expiry = false`)
    - `aws_s3_account_public_access_block.baseline` (ACCT.08; all four flags `true`)
    - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
@@ -165,7 +165,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
 
 6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
-   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_iam_role.config` (trust policy for `config.amazonaws.com` — see the golden HCL below) + `aws_iam_role_policy_attachment` for the managed policy `arn:aws:iam::aws:policy/service-role/AWS_ConfigRole` (note the underscore — `AWSConfigRole` without it is a different, deprecated policy name and fails apply)
    - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
    - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
    - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`
@@ -181,24 +181,104 @@ Always emitted. The baseline applies account-wide security controls that should 
 8. **Attach inline HCL comments**:
    - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
    - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
-   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(total_mid * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(aws_monthly_balanced * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On each `aws_account_alternate_contact.*`: a comment noting the phone number is a placeholder to update post-apply (or in tfvars if the user prefers).
    - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
    - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
    - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
    - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
 
-9. **EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+**Golden HCL for the shapes agents get wrong.** The resource lists above name types; these four shapes have required arguments or policy documents that must not be improvised. Match them exactly (identifiers/CIDR-free values may vary):
 
-   ```hcl
-   metadata_options {
-     http_tokens                 = "required"
-     http_put_response_hop_limit = 1
-     http_endpoint               = "enabled"
-     instance_metadata_tags      = "enabled"
-   }
-   ```
+```hcl
+# Alternate contact — all four of name / title / email_address / phone_number are REQUIRED
+resource "aws_account_alternate_contact" "operations" {
+  alternate_contact_type = "OPERATIONS"
+  name                   = "Operations Contact"
+  title                  = "Operations"
+  email_address          = var.operations_email
+  phone_number           = "+1-555-0100" # placeholder — update post-apply with a real number
+}
 
-   Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
+# CloudTrail log bucket policy — service principal scoped by SourceArn
+data "aws_iam_policy_document" "cloudtrail_logs" {
+  statement {
+    sid       = "AWSCloudTrailAclCheck"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.cloudtrail_logs.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-baseline"]
+    }
+  }
+  statement {
+    sid       = "AWSCloudTrailWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+# Config role — trust policy + the CURRENT managed policy name (underscore)
+resource "aws_iam_role" "config" {
+  name = "${var.project_name}-config-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "config.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "config" {
+  role       = aws_iam_role.config.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+# Lifecycle configuration — every rule needs a filter (or prefix) block
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  rule {
+    id     = "retention"
+    status = "Enabled"
+    filter {} # applies to the whole bucket
+    expiration {
+      days = local.cloudtrail_retention_days
+    }
+    # STANDARD_IA / GLACIER transition blocks per item 7's thresholds
+  }
+}
+```
+
+**EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+
+```hcl
+metadata_options {
+  http_tokens                 = "required"
+  http_put_response_hop_limit = 1
+  http_endpoint               = "enabled"
+  instance_metadata_tags      = "enabled"
+}
+```
+
+Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
 
 **Emission conditions**:
 
@@ -241,32 +321,32 @@ variable "migration_id" {
 
 ```hcl
 variable "operations_email" {
-  description = "Operations contact for AWS account alternate contacts (fill-in checklist)"
+  description = "Operations contact for AWS account alternate contacts (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.operations_email, "TODO") && !strcontains(var.operations_email, "example.com") && strcontains(var.operations_email, "@")
-    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 
 variable "billing_email" {
-  description = "Billing contact + budget alert recipient (fill-in checklist)"
+  description = "Billing contact + budget alert recipient (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.billing_email, "TODO") && !strcontains(var.billing_email, "example.com") && strcontains(var.billing_email, "@")
-    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 
 variable "security_email" {
-  description = "Security contact for AWS account alternate contacts (fill-in checklist)"
+  description = "Security contact for AWS account alternate contacts (MIGRATION_GUIDE.md Phase 1)"
   type        = string
 
   validation {
     condition     = !strcontains(var.security_email, "TODO") && !strcontains(var.security_email, "example.com") && strcontains(var.security_email, "@")
-    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md Phase 1, Security baseline contacts)."
   }
 }
 ```

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -3,6 +3,7 @@ _fragment: terraform
 _of_phase: generate
 _contributes:
   - terraform/main.tf
+  - terraform/baseline.tf
   - terraform/variables.tf
   - terraform/outputs.tf
   - terraform/security.tf
@@ -25,23 +26,24 @@ Transform `aws-design.json` into review-ready Terraform HCL configurations. Prod
 
 Generate `$MIGRATION_DIR/terraform/` with the following file organization. Only emit domain files that have resources in `aws-design.json`:
 
-| File           | Domain     | Contains                                                   |
-| -------------- | ---------- | ---------------------------------------------------------- |
-| `main.tf`      | core       | Provider config, backend, data sources                     |
-| `variables.tf` | core       | All input variables with types and defaults                |
-| `outputs.tf`   | core       | Resource outputs and migration summary                     |
-| `vpc.tf`       | networking | VPC, subnets, route tables, internet gateway, NAT, peering |
-| `compute.tf`   | compute    | ECS cluster, Fargate task definitions, services, ALBs      |
-| `beanstalk.tf` | compute    | Elastic Beanstalk applications and environments            |
-| `pipeline.tf`  | deploy     | Optional CodePipeline source-to-EB deploy path             |
-| `database.tf`  | database   | RDS/Aurora instances, parameter groups, RDS Proxy          |
-| `cache.tf`     | cache      | ElastiCache replication groups, subnet groups              |
-| `messaging.tf` | messaging  | MSK clusters, configurations                               |
-| `security.tf`  | security   | Security groups, IAM roles/policies                        |
+| File           | Domain     | Contains                                                                                                                               |
+| -------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.tf`      | core       | Provider config, backend, data sources                                                                                                 |
+| `baseline.tf`  | security   | Account-wide security baseline (contacts, CloudTrail, GuardDuty, budget, IMDSv2 default; compliance-conditional Config + Security Hub) |
+| `variables.tf` | core       | All input variables with types and defaults                                                                                            |
+| `outputs.tf`   | core       | Resource outputs and migration summary                                                                                                 |
+| `vpc.tf`       | networking | VPC, subnets, route tables, internet gateway, NAT, peering                                                                             |
+| `compute.tf`   | compute    | ECS cluster, Fargate task definitions, services, ALBs                                                                                  |
+| `beanstalk.tf` | compute    | Elastic Beanstalk applications and environments                                                                                        |
+| `pipeline.tf`  | deploy     | Optional CodePipeline source-to-EB deploy path                                                                                         |
+| `database.tf`  | database   | RDS/Aurora instances, parameter groups, RDS Proxy                                                                                      |
+| `cache.tf`     | cache      | ElastiCache replication groups, subnet groups                                                                                          |
+| `messaging.tf` | messaging  | MSK clusters, configurations                                                                                                           |
+| `security.tf`  | security   | Security groups, IAM roles/policies                                                                                                    |
 
 **File emission rules:**
 
-- `main.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted
+- `main.tf`, `baseline.tf`, `variables.tf`, `outputs.tf` — ALWAYS emitted (`baseline.tf` is workload-independent; users who do not want it delete the file before `terraform apply`)
 - `vpc.tf` — Emitted when `vpc_design` is present in `aws-design.json` (either existing or new VPC)
 - `compute.tf` — Emitted when `aws_service` contains "Fargate" or "ALB" entries
 - `beanstalk.tf` — Emitted when `aws_service` contains "Elastic Beanstalk" entries
@@ -121,6 +123,90 @@ data "aws_availability_zones" "available" {
 
 ---
 
+## Step 1.5: Generate `baseline.tf`
+
+Always emitted. The baseline applies account-wide security controls that should be in place on any new AWS account. Users who do not want the baseline can delete `terraform/baseline.tf` before `terraform apply`. It is workload-independent: emit it regardless of which services `aws-design.json` contains.
+
+0. **Normalize compliance.** Read `preferences.json.global.compliance`. It is a scalar string (`"none"`, `"soc2"`, `"hipaa"`, `"pci"`) or, when the user specified multiple frameworks in Clarify Q2 option E, an array of strings. Normalize to an array: absent or `"none"` → `[]`; scalar → single-element array; array → lowercase as-is. Every reference to `compliance` below means this normalized array.
+
+1. **Compute retention.** Compute `cloudtrail_retention_days` from the normalized `compliance` array using this mapping, taking `max()` across all declared values (use 90 if the array is empty):
+   - `[]` → 90
+   - `soc2` → 365
+   - `pci` → 365
+   - `hipaa` → 2190
+   - `fedramp` → 1095
+   - `gdpr` → 365
+   - unrecognized value → 365 (conservative), and record a `generation-warnings.json` entry naming the unrecognized framework
+
+2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.breakdown.total.mid` (or the canonical equivalent). Compute `budget_limit = max(50, ceil(total_mid * 1.2))`. If `estimation-infra.json` is missing or the path is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
+
+3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
+
+4. **Emit `baseline.tf`** starting with the file-header comment block and a `locals` block containing the resolved `cloudtrail_retention_days` integer:
+
+   ```hcl
+   locals {
+     cloudtrail_retention_days = <N>
+   }
+   ```
+
+5. **Append the always-on resources**, in this order. Provider `default_tags` (Step 1) supply the standard tags; each baseline resource additionally carries `tags = { Component = "security-baseline" }` where the resource type supports tags:
+   - `aws_account_alternate_contact.operations` (ACCT.01, `email_address = var.operations_email` — fill-once variable, see Step 2)
+   - `aws_account_alternate_contact.billing` (ACCT.01, `email_address = var.billing_email`)
+   - `aws_account_alternate_contact.security` (ACCT.01, `email_address = var.security_email`)
+   - `aws_iam_account_password_policy.baseline` (ACCT.06; `minimum_password_length = 14`, `password_reuse_prevention = 24`, `max_password_age = 90`, all four character-class requirements `true`, `hard_expiry = false`)
+   - `aws_s3_account_public_access_block.baseline` (ACCT.08; all four flags `true`)
+   - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
+   - `aws_accessanalyzer_analyzer.baseline` (ACCT.11; `type = "ACCOUNT"`)
+   - `aws_ec2_instance_metadata_defaults.baseline` (defense-in-depth; `http_tokens = "required"`, `http_put_response_hop_limit = 2`)
+   - `aws_cloudtrail.baseline` (ACCT.07; multi-region, management events only, `enable_log_file_validation = true`)
+   - `aws_s3_bucket.cloudtrail_logs` plus `aws_s3_bucket_public_access_block`, `aws_s3_bucket_server_side_encryption_configuration`, `aws_s3_bucket_versioning`, `aws_s3_bucket_lifecycle_configuration` (transitions driven by `local.cloudtrail_retention_days` per item 7), and `aws_s3_bucket_policy` restricting the CloudTrail service principal by `aws:SourceArn`
+   - `aws_budgets_budget.monthly_spend` (ACCT.10; `limit_amount = "<budget_limit>"` from item 2; three `notification` blocks at 50/80/100% `ACTUAL`; `subscriber_email_addresses = [var.billing_email]` — same fill-once variable as the alternate contact, entered exactly once in tfvars)
+   - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
+
+6. **If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, append the compliance-conditional section**, wrapped in `########## Compliance-Conditional ##########` / `########## End Compliance-Conditional ##########` dividers:
+   - `aws_iam_role.config` + `aws_iam_role_policy_attachment` for the managed policy `AWSConfigRole`
+   - `aws_config_configuration_recorder.baseline` with `recording_group { all_supported = true, include_global_resource_types = true }`
+   - `aws_config_delivery_channel.baseline` pointing at the Config S3 bucket
+   - `aws_config_configuration_recorder_status.baseline` with `is_enabled = true`
+   - `aws_s3_bucket.config_logs` plus PAB, SSE, versioning, lifecycle (same `local.cloudtrail_retention_days`), and a bucket policy allowing the `config.amazonaws.com` service principal
+   - `aws_securityhub_account.baseline`
+   - `aws_securityhub_standards_subscription.fsbp` (always emitted in this section)
+   - `aws_securityhub_standards_subscription.pci_dss` (only if `compliance` contains `pci`)
+
+   Do NOT emit an NIST 800-53 standards subscription, even if `compliance` contains `hipaa` or `fedramp`. Security Hub does not provide a HIPAA-specific standard; FedRAMP attestation is out-of-band.
+
+7. **Lifecycle rule adjustment.** Omit the `STANDARD_IA` transition block when the resolved retention is less than 90 days. Omit the `GLACIER` transition block when retention is less than 365 days. Both rules apply to both the CloudTrail log bucket and (when emitted) the Config log bucket.
+
+8. **Attach inline HCL comments**:
+   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
+   - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
+   - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(total_mid * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
+   - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
+   - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
+   - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
+   - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
+
+9. **EKS launch-template rider (runs in the eks-generate fragment, not here):** when the design routes compute to EKS with self-managed node groups, the `aws_launch_template` emitted by `generate-eks.md` receives IMDSv2 enforcement unconditionally:
+
+   ```hcl
+   metadata_options {
+     http_tokens                 = "required"
+     http_put_response_hop_limit = 1
+     http_endpoint               = "enabled"
+     instance_metadata_tags      = "enabled"
+   }
+   ```
+
+   Fargate and Elastic Beanstalk do not emit launch templates in this skill and are unaffected (no synthetic launch template is created). Hop limit `1` here is intentionally different from the account-level default `2` in `aws_ec2_instance_metadata_defaults.baseline` — strict on templates the plugin owns, permissive at the account default.
+
+**Emission conditions**:
+
+- Emit `baseline.tf` for every design, including EB-only, Fargate-only, and EKS designs. The baseline is workload-independent.
+- Do NOT probe for existing account resources (CloudTrail trails, Config recorders, Security Hub enrollment). Collision risk is surfaced by the inline comments listed in item 8.
+
+---
+
 ## Step 2: Generate `variables.tf`
 
 **Always include these global variables:**
@@ -148,6 +234,40 @@ variable "migration_id" {
   description = "Migration run identifier"
   type        = string
   default     = "<migration_id from .phase-status.json>"
+}
+```
+
+**Baseline contact variables (always include — `baseline.tf` depends on them):** the three fill-once contact emails referenced by `baseline.tf`'s alternate contacts and budget alerts. They intentionally have no `default` — `terraform plan` must fail until the customer supplies real values — and each carries a `validation` block rejecting placeholder tokens, so a copied-through `TODO-ops@example.com` fails loudly at `terraform plan` instead of silently becoming the account's security contact:
+
+```hcl
+variable "operations_email" {
+  description = "Operations contact for AWS account alternate contacts (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.operations_email, "TODO") && !strcontains(var.operations_email, "example.com") && strcontains(var.operations_email, "@")
+    error_message = "Set operations_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
+}
+
+variable "billing_email" {
+  description = "Billing contact + budget alert recipient (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.billing_email, "TODO") && !strcontains(var.billing_email, "example.com") && strcontains(var.billing_email, "@")
+    error_message = "Set billing_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
+}
+
+variable "security_email" {
+  description = "Security contact for AWS account alternate contacts (fill-in checklist)"
+  type        = string
+
+  validation {
+    condition     = !strcontains(var.security_email, "TODO") && !strcontains(var.security_email, "example.com") && strcontains(var.security_email, "@")
+    error_message = "Set security_email in terraform.tfvars to a real inbox (see MIGRATION_GUIDE.md fill-in checklist)."
+  }
 }
 ```
 
@@ -1944,6 +2064,11 @@ project_name = "<project_name>"
 environment  = "<environment>"
 migration_id = "<migration_id>"
 
+# Security baseline contacts (always required — plan fails until all three are real inboxes)
+operations_email = "TODO-ops@example.com"      # AWS account operations alternate contact
+billing_email    = "TODO-billing@example.com"  # billing alternate contact + budget alert recipient
+security_email   = "TODO-security@example.com" # security alternate contact
+
 # Database credentials (required if RDS/Aurora is in the design)
 # db_username = "app_user"
 # db_password = "CHANGE_ME"
@@ -1992,7 +2117,8 @@ After all files are written:
 3. **Variable completeness**: Every `var.*` reference has a corresponding `variable` block in `variables.tf`
 4. **Output references**: Every `output` references a declared resource attribute
 5. **Tag consistency**: Every resource has the default tags (applied via provider `default_tags`)
-6. **Elastic Beanstalk web runtime inputs**: For every EB web service, verify its per-app `eb_application_port_<app>_web` and `eb_health_check_path_<app>_web` variables are declared without defaults, include the required validation blocks, and are referenced directly by that app's `PORT` and `HealthCheckPath` settings. Verify non-web EB services do not require these variables. Do not report an EB web configuration as ready to plan until the customer has supplied both values for every web app.
+6. **Security baseline**: `baseline.tf` exists and contains the full always-on resource list from Step 1.5 (three `aws_account_alternate_contact`, password policy, S3 account PAB, EBS default encryption, Access Analyzer, IMDSv2 account default, CloudTrail + log bucket, budget, GuardDuty); its `locals.cloudtrail_retention_days` is a positive integer; the compliance-conditional section is present exactly when the normalized `compliance` array contains soc2/pci/hipaa/fedramp; the three contact email variables are declared without defaults and with placeholder-rejecting validation blocks
+7. **Elastic Beanstalk web runtime inputs**: For every EB web service, verify its per-app `eb_application_port_<app>_web` and `eb_health_check_path_<app>_web` variables are declared without defaults, include the required validation blocks, and are referenced directly by that app's `PORT` and `HealthCheckPath` settings. Verify non-web EB services do not require these variables. Do not report an EB web configuration as ready to plan until the customer has supplied both values for every web app.
 
 **Note:** Full `terraform validate` requires `terraform init` (provider download). The generated configuration SHOULD pass `terraform validate` when run with network access. If validation cannot run (no Terraform binary, no network), log a note but do NOT block generation.
 

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate-terraform.md
@@ -140,7 +140,7 @@ Always emitted. The baseline applies account-wide security controls that should 
 
 2. **Compute budget limit.** Read `estimation-infra.json.projected_costs.aws_monthly_balanced` (the Balanced-tier monthly total — the same key this skill's Estimate postconditions assert is a positive number). Compute `budget_limit = max(50, ceil(aws_monthly_balanced * 1.2))`. If `estimation-infra.json` is missing or the key is unreadable, use `50` and emit an inline comment noting that the projection was unavailable.
 
-3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header.
+3. **Choose file-header variant.** If `compliance` contains any of `soc2`, `pci`, `hipaa`, `fedramp`, emit the compliance-expansion header. Otherwise emit the base header. Both variants include a two-sentence provenance note stating per-unit rates in the cost-disclosure comments were verified against the AWS Pricing API for us-east-1 on 2026-05-04. Substitute the resolved `cloudtrail_retention_days` value into the header. When item 1 encountered an unrecognized compliance value, append one header line naming it and the conservative 365-day retention applied (e.g. `# Unrecognized compliance framework "iso27001" — applied conservative 365-day CloudTrail retention`).
 
 4. **Emit `baseline.tf`** starting with the file-header comment block and a `locals` block containing the resolved `cloudtrail_retention_days` integer:
 
@@ -159,7 +159,7 @@ Always emitted. The baseline applies account-wide security controls that should 
    - `aws_ebs_encryption_by_default.baseline` (defense-in-depth; `enabled = true`)
    - `aws_accessanalyzer_analyzer.baseline` (ACCT.11; `type = "ACCOUNT"`)
    - `aws_ec2_instance_metadata_defaults.baseline` (defense-in-depth; `http_tokens = "required"`, `http_put_response_hop_limit = 2`)
-   - `aws_cloudtrail.baseline` (ACCT.07; multi-region, management events only, `enable_log_file_validation = true`)
+   - `aws_cloudtrail.baseline` (ACCT.07; `name = "${var.project_name}-baseline"` — MUST match the `aws:SourceArn` in the bucket policy exactly, see the golden HCL; multi-region, management events only, `enable_log_file_validation = true`, `depends_on = [aws_s3_bucket_policy.cloudtrail_logs]` — CloudTrail validates the bucket policy at create time)
    - `aws_s3_bucket.cloudtrail_logs` plus `aws_s3_bucket_public_access_block`, `aws_s3_bucket_server_side_encryption_configuration`, `aws_s3_bucket_versioning`, `aws_s3_bucket_lifecycle_configuration` (transitions driven by `local.cloudtrail_retention_days` per item 7), and `aws_s3_bucket_policy` restricting the CloudTrail service principal by `aws:SourceArn`
    - `aws_budgets_budget.monthly_spend` (ACCT.10; `limit_amount = "<budget_limit>"` from item 2; three `notification` blocks at 50/80/100% `ACTUAL`; `subscriber_email_addresses = [var.billing_email]` — same fill-once variable as the alternate contact, entered exactly once in tfvars)
    - `aws_guardduty_detector.baseline` (defense-in-depth; `enable = true`, `finding_publishing_frequency = "FIFTEEN_MINUTES"`)
@@ -179,16 +179,15 @@ Always emitted. The baseline applies account-wide security controls that should 
 7. **Lifecycle rule adjustment.** Omit the `STANDARD_IA` transition block when the resolved retention is less than 90 days. Omit the `GLACIER` transition block when retention is less than 365 days. Both rules apply to both the CloudTrail log bucket and (when emitted) the Config log bucket.
 
 8. **Attach inline HCL comments**:
-   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`).
+   - On each `aws_account_alternate_contact.*`: a comment pointing at the tfvars fill-once variable (`# set var.operations_email in terraform.tfvars — plan fails until you do`) and noting the phone number is a placeholder to update post-apply.
    - On `aws_cloudtrail.baseline`: a collision warning for users who already have a trail in the region.
    - On `aws_budgets_budget.monthly_spend`: the limit-rationale comment (`max(50, ceil(aws_monthly_balanced * 1.2))`; $50 floor prevents alert noise; users may edit `limit_amount` directly post-apply).
-   - On each `aws_account_alternate_contact.*`: a comment noting the phone number is a placeholder to update post-apply (or in tfvars if the user prefers).
    - On `aws_guardduty_detector.baseline`: a cost disclosure noting the 30-day free trial and ~$2–25/mo post-trial.
    - On `aws_config_configuration_recorder.baseline`: a cost disclosure ($0.003/CI continuous; $0.012/daily-CI as an opt-in for cost-sensitive users).
    - On `aws_securityhub_account.baseline`: a cost disclosure noting the 30-day free trial and ~$1–15/mo post-trial.
    - On every defense-in-depth resource (EBS encryption, IMDSv2 account default, GuardDuty, Config, Security Hub): the literal token `defense-in-depth` in the inline comment.
 
-**Golden HCL for the shapes agents get wrong.** The resource lists above name types; these four shapes have required arguments or policy documents that must not be improvised. Match them exactly (identifiers/CIDR-free values may vary):
+**Golden HCL for the shapes agents get wrong.** The resource lists above name types; the shapes below have required arguments, policy documents, or cross-resource name/ordering couplings that must not be improvised. Match them exactly (identifiers/region values may vary, but the trail name and the `aws:SourceArn` conditions must agree):
 
 ```hcl
 # Alternate contact — all four of name / title / email_address / phone_number are REQUIRED
@@ -231,7 +230,31 @@ data "aws_iam_policy_document" "cloudtrail_logs" {
       variable = "s3:x-amz-acl"
       values   = ["bucket-owner-full-control"]
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.project_name}-baseline"]
+    }
   }
+}
+
+# The policy document must be ATTACHED, and the trail name must match the
+# SourceArn above exactly — CloudTrail validates the bucket policy at create
+# time, so the trail depends_on the attachment.
+resource "aws_s3_bucket_policy" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  policy = data.aws_iam_policy_document.cloudtrail_logs.json
+}
+
+resource "aws_cloudtrail" "baseline" {
+  # Trail already in this region? See the collision warning in item 8.
+  name                          = "${var.project_name}-baseline" # MUST match the SourceArn conditions above
+  s3_bucket_name                = aws_s3_bucket.cloudtrail_logs.id
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  include_global_service_events = true
+
+  depends_on = [aws_s3_bucket_policy.cloudtrail_logs]
 }
 
 # Config role — trust policy + the CURRENT managed policy name (underscore)

--- a/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/heroku-to-aws/references/phases/generate/generate.md
@@ -24,6 +24,7 @@ _assemble:
   _file: phases/generate/generate-assemble.md
 _produces:
   - terraform/main.tf
+  - terraform/baseline.tf
   - terraform/variables.tf
   - terraform/outputs.tf
   - terraform/security.tf
@@ -47,9 +48,15 @@ _preconditions:
   - _validate_json: [aws-design.json, estimation-infra.json, preferences.json, heroku-resource-inventory.json]
     _on_failure: _unrecoverable
 _postconditions:
-  - _check_file_exists: [terraform/main.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md, migration-report.html, generation-warnings.json]
+  - _check_file_exists: [terraform/main.tf, terraform/baseline.tf, terraform/variables.tf, terraform/outputs.tf, terraform/security.tf, terraform/.gitignore, terraform/terraform.tfvars.example, MIGRATION_GUIDE.md, README.md, migration-report.html, generation-warnings.json]
     _on_failure: _halt_and_inform
   - _assert: "terraform/main.tf has valid provider configuration; terraform/variables.tf declares at least an aws_region variable"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/baseline.tf contains a locals block with cloudtrail_retention_days set to a positive integer, plus aws_account_alternate_contact resources for each of operations, billing, and security, aws_iam_account_password_policy, aws_s3_account_public_access_block, aws_ebs_encryption_by_default, aws_accessanalyzer_analyzer, aws_ec2_instance_metadata_defaults, aws_cloudtrail with its log bucket, aws_budgets_budget, and aws_guardduty_detector"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/baseline.tf has the Compliance-Conditional section (aws_config_* recorder/delivery/status, aws_securityhub_account, FSBP standards subscription) exactly when the normalized preferences compliance array contains soc2, pci, hipaa, or fedramp; a PCI DSS standards subscription exists only when it contains pci; no NIST 800-53 standards subscription exists regardless of compliance values"
+    _on_failure: _halt_and_inform
+  - _assert: "terraform/variables.tf declares operations_email, billing_email, and security_email with no defaults and placeholder-rejecting validation blocks, and terraform/terraform.tfvars.example lists all three with TODO placeholders"
     _on_failure: _halt_and_inform
   - _assert: "at least one domain .tf file exists beyond the core files"
     _on_failure: _halt_and_inform


### PR DESCRIPTION
## Problem

`gcp-to-aws` Generate has always emitted `baseline.tf` — account-wide security controls (alternate contacts, IAM password policy, S3 account public access block, EBS default encryption, Access Analyzer, IMDSv2 account default, CloudTrail with a hardened log bucket, a monthly AWS Budget with alerts, GuardDuty, plus compliance-conditional Config + Security Hub). `heroku-to-aws` never has: a Heroku user today gets Terraform with none of those controls. This is the largest security-parity gap between the two migration paths, and it's the gap the READMEs have had to caveat since #229.

## What this does

Ports the `gcp-to-aws` Step 1.5 baseline spec into `heroku-to-aws`'s Generate phase — **translated into the DSL's native idiom**, not pasted as prose. The two skills are architected differently: gcp-to-aws is prose-orchestrated (imperative steps the agent follows), heroku-to-aws is DSL-based (frontmatter contracts enforced fail-closed by the vendored interpreter + assembler gates). So the port lands in three layers:

| gcp-to-aws (prose) | heroku-to-aws (this PR) |
|---|---|
| Step 1.5 emission spec in `generate-artifacts-infra.md` | New Step 1.5 in `generate-terraform.md` + `_contributes` entry |
| Step 5 prose checklist (~12 baseline assertions) | Three `_assert` postconditions in `generate.md` frontmatter, enforced by the assembler per `INTERPRETER.md` gate protocol |
| Phase Completion prose gate ("baseline.tf MUST exist") | `terraform/baseline.tf` in `_produces` + `_check_file_exists` |
| compute.tf IMDSv2 launch-template rider | `metadata_options` on the EKS self-managed launch template in `generate-eks.md` (Fargate/EB emit no launch templates) |

Because the checks are interpreter-enforced postconditions rather than prose the agent is trusted to follow, the ported version is fail-closed where the original is advisory.

## Adaptations (not blind copies)

- **Compliance shape**: heroku stores `preferences.global.compliance` as a scalar (`"none"|"soc2"|"hipaa"|"pci"`) or user-specified array (Clarify Q2 option E); gcp uses an array. New item 0 normalizes to an array before the retention mapping, treating `"unknown"` like `"none"` (an unconfirmed answer is not a framework). Unrecognized frameworks (possible via option E) get conservative 365-day retention plus a named note in the `baseline.tf` header comment (not `generation-warnings.json`, whose entries are service-shaped and feed the every-service-accounted-for gate).
- **Contact variables**: `operations_email`/`billing_email`/`security_email` didn't exist in heroku's `variables.tf` step. Added with no defaults and placeholder-rejecting `validation` blocks (the gcp pattern — `terraform plan` fails loudly on `TODO`/`example.com` instead of silently making them the account's security contacts), plus `terraform.tfvars.example` entries.
- **Docs**: MIGRATION_GUIDE Phase 1 template ("Security baseline contacts" — the target of the validation error messages) explains the baseline, the three contact tfvars, both opt-outs, and the CloudTrail/Config/Security Hub collision warnings. Full opt-out is two steps — delete `baseline.tf` AND remove the three contact variables, which have no defaults and fail `plan` even unreferenced; partial opt-out deletes just the compliance-conditional block. README artifact table lists `baseline.tf`; the report next-steps spec gains a one-bullet baseline mention.
- **Golden HCL**: a reference block for the shapes agents invent wrong — full `aws_account_alternate_contact` required fields (name/title/phone_number, not just email), the SourceArn-scoped CloudTrail bucket policy with its `aws_s3_bucket_policy` attachment and the `aws_cloudtrail` resource itself (trail name pinned to match the SourceArn; `depends_on` the attachment since CloudTrail validates the bucket policy at create time), the Config trust policy with the current `AWS_ConfigRole` managed-policy ARN, and the lifecycle `filter {}`.
- **Budget source**: pinned to `projected_costs.aws_monthly_balanced` — the key heroku's own Estimate postconditions assert — with a $50 floor fallback.
- **README accuracy fix**: the security-baseline capability row claimed "ECR scanning" unconditionally — `heroku-to-aws` generates no ECR repositories. Now reads "ECR scan-on-push where ECR repositories are generated," and covers both paths.

## Scope

**In**: baseline.tf emission, contact variables, DSL postconditions, EKS IMDSv2 rider, golden HCL, docs. Both plugin trees updated byte-identically (`advisor/` + `migrate/`). Also fixes the deprecated `AWSConfigRole` managed-policy name at its source in `gcp-to-aws`'s spec (both trees) — this PR inherited the bug from there, and it is the same apply failure on gcp's compliance path.
**Out (follow-up PR)**: `tf-best-practices` authoring-posture invocation and the policy gate with `validation-report.json` — the "Consumers (v1): gcp-to-aws only" note in `tf-best-practices/SKILL.md` is intentionally untouched until that lands.

**Interaction with #229**: that open PR hedges the README security-baseline row with "not yet emitted by heroku-to-aws (planned)". This PR makes the unhedged claim true. Whichever merges second will have a trivial README conflict to resolve in favor of this PR's wording.

## Verification

- `markdownlint-cli2`: 0 errors (repo config)
- `dprint check`: clean
- `cross-plugin-drift.ts`: OK — all five touched generate files byte-identical across both plugin trees (none are drift-allowlisted, so CI enforces this permanently)
- frontmatter validator: OK on both `heroku-to-aws` trees (7 phase files each)
- `tests/heroku-eb-runtime-settings.test.ts`: 11/12 pass; the 1 failure is a pre-existing environmental Terraform version-pin assertion (expects 1.13.x, machine has 1.15.2) and fails identically on a clean checkout — not introduced by this change
