### PR TITLE
fix(agent-advisor): anthropic.model_lineup — new knowledge

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/advisor/plugins/aws-startup-advisor/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -391,7 +391,7 @@ See `shared/ai-model-lifecycle.md` for lifecycle details. **Do not recommend Leg
 
 | Model                            | Model ID                                 | Provider  | Input $/1M | Output $/1M | Context | Tier      | Status                                                       |
 | -------------------------------- | ---------------------------------------- | --------- | ---------- | ----------- | ------- | --------- | ------------------------------------------------------------ |
-| Claude Fable 5                   | anthropic.claude-fable-5                 | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
+| Claude Fable 5.1                 | anthropic.claude-fable-5-1               | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
 | Claude Sonnet 5                  | anthropic.claude-sonnet-5                | Anthropic | 2.00       | 10.00       | 1M      | flagship  | active (intro $2/$10 thru Aug 31, 2026; then $3/$15)         |
 | Claude Opus 4.8                  | anthropic.claude-opus-4-8                | Anthropic | 5.00       | 25.00       | 200K    | premium   | active                                                       |
 | Claude Sonnet 4.6                | anthropic.claude-sonnet-4-6              | Anthropic | 3.00       | 15.00       | 200K    | flagship  | active                                                       |
@@ -460,7 +460,7 @@ Per 1M tokens unless noted. See [Bedrock pricing](https://aws.amazon.com/bedrock
 
 | Model                    | Batch in | Batch out | 5m cache write | 1h cache write | Cache read |
 | ------------------------ | -------- | --------- | -------------- | -------------- | ---------- |
-| Claude Fable 5           | 5.00     | 25.00     | 12.50          | 20.00          | 1.00       |
+| Claude Fable 5.1         | 5.00     | 25.00     | 12.50          | 20.00          | 0.25       |
 | Claude Sonnet 5          | 1.00     | 5.00      | 2.50           | 4.00           | 0.20       |
 | Claude Opus 4.8          | 2.50     | 12.50     | 6.25           | 10.00          | 0.50       |
 | Claude Sonnet 4.6 (+ LC) | 1.50     | 7.50      | 3.75           | 6.00           | 0.30       |

--- a/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
+++ b/migrate/plugins/migration-to-aws/skills/gcp-to-aws/references/shared/pricing-cache.md
@@ -391,7 +391,7 @@ See `shared/ai-model-lifecycle.md` for lifecycle details. **Do not recommend Leg
 
 | Model                            | Model ID                                 | Provider  | Input $/1M | Output $/1M | Context | Tier      | Status                                                       |
 | -------------------------------- | ---------------------------------------- | --------- | ---------- | ----------- | ------- | --------- | ------------------------------------------------------------ |
-| Claude Fable 5                   | anthropic.claude-fable-5                 | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
+| Claude Fable 5.1                 | anthropic.claude-fable-5-1               | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
 | Claude Sonnet 5                  | anthropic.claude-sonnet-5                | Anthropic | 2.00       | 10.00       | 1M      | flagship  | active (intro $2/$10 thru Aug 31, 2026; then $3/$15)         |
 | Claude Opus 4.8                  | anthropic.claude-opus-4-8                | Anthropic | 5.00       | 25.00       | 200K    | premium   | active                                                       |
 | Claude Sonnet 4.6                | anthropic.claude-sonnet-4-6              | Anthropic | 3.00       | 15.00       | 200K    | flagship  | active                                                       |
@@ -460,7 +460,7 @@ Per 1M tokens unless noted. See [Bedrock pricing](https://aws.amazon.com/bedrock
 
 | Model                    | Batch in | Batch out | 5m cache write | 1h cache write | Cache read |
 | ------------------------ | -------- | --------- | -------------- | -------------- | ---------- |
-| Claude Fable 5           | 5.00     | 25.00     | 12.50          | 20.00          | 1.00       |
+| Claude Fable 5.1         | 5.00     | 25.00     | 12.50          | 20.00          | 0.25       |
 | Claude Sonnet 5          | 1.00     | 5.00      | 2.50           | 4.00           | 0.20       |
 | Claude Opus 4.8          | 2.50     | 12.50     | 6.25           | 10.00          | 0.50       |
 | Claude Sonnet 4.6 (+ LC) | 1.50     | 7.50      | 3.75           | 6.00           | 0.30       |


### PR DESCRIPTION
> Opened by the knowledge auto-update pipeline. **Draft** — a human decides.

## What changed upstream

[We've launched Claude Fable 5.1 (`claude-fable-5-1`), the successor to Claude Fable 5 for long-running agentic coding, knowledge work, and research, alongside C](https://docs.claude.com/en/release-notes/api.md)

**Verdict: `new_knowledge`** on `anthropic.model_lineup`

- was — No entry for Claude Fable 5/5.1 or Mythos 5.1 pricing/specs in the reviewed files; ai-anthropic-to-bedrock.md only mentions "Claude Fable 5" once as an explicit non-default (frontier/Mythos-class pricing, opt-in only), with no ID, price, or context window given.
- now — Claude Fable 5.1 (`claude-fable-5-1`) and Claude Mythos 5.1 (`claude-mythos-5-1`) launched: 1M token context (default), 128k max output tokens, always-on adaptive thinking, $10/$50 per MTok (same as Fable 5), cache reads $0.25/MTok. Fable 5.1 available via Claude API, Bedrock, Claude Platform on AWS, Vertex AI, and Microsoft Foundry. Mythos 5.1 is Project Glasswing participants only.

> **Still true:** The recommendation in ai-anthropic-to-bedrock.md to not default to Claude Fable 5 (opt-in only, frontier/Mythos-class pricing) still holds in spirit — Fable 5.1 is likewise a specialized/opt-in-tier model, not a default Bedrock migration target.
>
> This is why the old value is **not** simply overwritten.

## Proposed edits

Each row states its justification. No CI check can catch a badly reworded judgment, so the
"why" column is the only protection a reviewer has — please read it rather than the diff alone.

### `gcp-to-aws/references/shared/pricing-cache.md:463` — value

```diff
- | Claude Fable 5           | 5.00     | 25.00     | 12.50          | 20.00          | 1.00       |
+ | Claude Fable 5.1         | 5.00     | 25.00     | 12.50          | 20.00          | 0.25       |
```

**Why:** The announcement states cache reads for Fable 5.1 are cut to $0.25 per MTok (from the prior $1.00 rate implied for Fable 5), so this row's cache-read column must be updated for the new model.

**Evidence (verbatim from the announcement):** "with cache reads cut to $0.25 per MTok"

### `gcp-to-aws/references/shared/pricing-cache.md:394` — value

```diff
- | Claude Fable 5                   | anthropic.claude-fable-5                 | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
+ | Claude Fable 5.1                 | anthropic.claude-fable-5-1               | Anthropic | 10.00      | 50.00       | 1M      | frontier  | active                                                       |
```

**Why:** Fable 5.1 is the successor model now launched with a new model ID (claude-fable-5-1), same $10/$50 pricing and 1M context, so this pricing table row should be updated to reflect the new model/ID as current, per the announcement's explicit launch and pricing details.

**Evidence (verbatim from the announcement):** "Claude Fable 5.1** (`claude-fable-5-1`), the successor to Claude Fable 5"

## Filter false positives

The announcement scan flagged these files; the judge rejected them:

- `agent-advisor/references/decision-refs/model-selection.md`

## Mirrored to `migrate/plugins/migration-to-aws/skills`

The same edits were applied to this second copy: 2 applied.


## Known limits of this proposal

- **Blast radius is not stable between runs.** Two runs of the same input returned 9 and 13
  locations and neither was a superset of the other, so this list may be incomplete.
- Paths are relative to `advisor/plugins/aws-startup-advisor/skills`.
- The pipeline did not touch any file the judge did not name.
