### PR TITLE
docs(agent-advisor): complete OpenAI Agents API awareness guidance

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/decision-refs/managed-alternatives.md
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/decision-refs/managed-alternatives.md
@@ -11,6 +11,8 @@ Surface these as awareness with tradeoffs when the user is committed to a single
 
 ## Bedrock Managed Agents (OpenAI-committed)
 
+## OpenAI Agents API (public beta)
+
 - Available in us-east-1 and expanding.
 - If the customer needs model flexibility, governance, or code export → AgentCore wins.
 

--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/decision-refs/managed-alternatives.md
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/decision-refs/managed-alternatives.md
@@ -11,10 +11,35 @@ Surface these as awareness with tradeoffs when the user is committed to a single
 
 ## Bedrock Managed Agents (OpenAI-committed)
 
-## OpenAI Agents API (public beta)
-
 - Available in us-east-1 and expanding.
 - If the customer needs model flexibility, governance, or code export → AgentCore wins.
+
+## OpenAI Agents API (public beta)
+
+Public beta announced 2026-09-10; this entry verified 2026-09-11.
+
+- OpenAI manages the Codex harness, session orchestration, context compaction, and recovery.
+  Durable sessions retain progress across turns; tools can include application functions and MCP
+  servers. Surface this option when an OpenAI-committed customer wants managed agent execution.
+- Execution can use an OpenAI-hosted sandbox or a self-hosted sandbox on the customer's
+  infrastructure. OpenAI still runs the harness with a self-hosted executor; this is a separate
+  OpenAI service, not Bedrock Managed Agents or an agent loop deployed through the Agents SDK.
+- Data boundary: currently supports data residency only in the United States and does not support
+  Zero Data Retention (ZDR). A self-hosted sandbox does not remove these limits. If either limit
+  conflicts with the customer's requirements, explain the mismatch rather than presenting this
+  option as suitable. Recheck the overview before relying on these beta constraints.
+- Operational responsibilities: for self-hosted execution, the customer manages workload isolation,
+  network restrictions, and executor credentials. Review these controls against the required
+  governance model; do not assume sandbox ownership puts OpenAI-managed sessions inside AWS.
+- Portability: session state and orchestration use the Agents API contract. Moving to another
+  runtime requires validating session and tool behavior; do not promise a drop-in migration or
+  assume that all state is non-exportable.
+
+Sources: [launch announcement](https://platform.openai.com/docs/changelog),
+[Agents API overview](https://developers.openai.com/api/docs/guides/agents-api/overview),
+[runtime comparison](https://developers.openai.com/api/docs/guides/agents),
+[self-hosted sandboxes](https://developers.openai.com/api/docs/guides/agents-api/environments/self-hosted),
+[sandbox security](https://developers.openai.com/api/docs/guides/agents-api/environments/security).
 
 ## Rule
 

--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/design/design.md
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/design/design.md
@@ -26,6 +26,8 @@ _postconditions:
     _on_failure: _halt_and_inform
   - _validate_json: design.json
     _on_failure: _halt_and_inform
+  - _assert: "design.json records managed_alternatives and the legacy managed_alternative using the source/current-provider mapping in Step 4; awareness options do not change scores, eliminations, or the chosen runtime"
+    _on_failure: _halt_and_inform
   - _assert: "design.json has one units[] entry per inventory unit, a platform block consistent with confirm.platform_decision, and top-level legacy fields mirroring the primary unit; design.json has top-level verdict, chosen_runtime, deployment_model, agentcore_compute_type, agentcore_services, model_recommendation, and carries scores + eliminated (and blocking_constraints when present) copied verbatim from scoring-result.json; every agentcore-verdict unit carries agentcore_compute_type (microvms or instances) verbatim from its scoring result and every non-agentcore unit carries null — the compute type is never re-derived in Design; every model-bearing unit's model_recommendation is derived from the matching model-recommendation.json workload entry and accepted confirm.model_decision, including model_identity, model, api_path, invocation_model_id, source, source_analysis, feature_assessment, compatibility, architecture_impacts, additional_targets (separate-modality target contracts, carried verbatim when present), blocks, tuning, migration_deltas, evaluation, rollout, provisional verification, and live_verification when model-verification.json exists; no model was independently selected from scoring-result.json; handoff_required is true iff ANY unit's effective_runtime needs a compute handoff — one of ecs, eks, fargate, or batch (not just the primary/winning runtime; AgentCore/Lambda/Lambda MicroVMs are self-contained); when temporal units exist, design.json has a temporal block recording the Way, per-queue Tier 1 rule ids, and Serverless Workers labeled Public Preview regardless of any docs label; Workflow orchestration code is never rewritten; every unit carries a key_change line derived from its runtime's service card; every non-agent unit's verdict equals the runtime its workload-classes rule maps to (W1→eks/ecs; W2→batch; W3/W4→lambda; W5/W6→fargate) — verdict and workload_class are never contradictory; every unit carries an effective_runtime equal to platform.runtime when platform.mode is consolidated, else its own resolved runtime (a co_recommend unit resolves to its confirm chosen_runtime) — effective_runtime is always a concrete runtime enum, never the literal co_recommend"
     _on_failure: _halt_and_inform
 ---
@@ -68,11 +70,24 @@ values on failure. Record which succeeded vs fell back (for the freshness footer
 
 ## Step 4 — Provider lock-in check
 
-Determine the managed alternative from the source/current model provider: Claude-committed →
-`claude_managed`; OpenAI-committed → `bedrock_managed`; multi-provider or undecided → `none`.
-If a managed alternative applies, surface it **as awareness only** (per `managed-alternatives.md`)
-with its tradeoffs — do NOT present it as the recommendation. Otherwise note AgentCore supports
-all models.
+Determine the managed alternatives from the source/current model provider, not the recommended
+target model. Record both fields using this table:
+
+| Source/current provider     | `managed_alternatives`                     | Legacy `managed_alternative` |
+| --------------------------- | ------------------------------------------ | ---------------------------- |
+| Claude-committed            | `["claude_managed"]`                       | `claude_managed`             |
+| OpenAI-committed            | `["bedrock_managed", "openai_agents_api"]` | `bedrock_managed`            |
+| Multi-provider or undecided | `[]`                                       | `none`                       |
+
+The array records all awareness options; the singular field preserves the existing artifact
+contract. Map the IDs to the Claude Managed Agents, Bedrock Managed Agents, and OpenAI Agents API
+sections in `managed-alternatives.md`. Carry both fields into `design.json` for Generate.
+
+Surface each listed option **as awareness only**, with the reference's status and tradeoffs.
+For OpenAI Agents API, include the public-beta status and US-only data residency / no-ZDR limits,
+including with self-hosted execution; flag any conflict with the customer's requirements.
+Do not score these options or change the chosen runtime. For an empty array, omit the awareness
+note.
 
 ## Step 4b — I/O-wait TCO differentiator (surface proactively)
 
@@ -336,6 +351,7 @@ considered" and the "Eliminated" line (Generate reads design.json, not scoring-r
   "volatile_facts": {"microvms_session_cap": {"value": "8h", "source": "mcp|cached"},
                      "instances_session_cap": {"value": "14d", "source": "mcp|cached"}},
   "managed_alternative": "claude_managed | bedrock_managed | none",
+  "managed_alternatives": [...],
   "io_wait_tco_note": true|false,
   "fedramp_note": true|false,
   "region_availability_note": "... | null",

--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/generate/generate-report.md
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/generate/generate-report.md
@@ -72,6 +72,11 @@ rules below.
 
 ## Step R1 — Section spec
 
+Set `MANAGED_ALTERNATIVES_HTML` to the HTML rendered from recommendation.md §5's
+"Managed alternatives (awareness only)" subsection, excluding its heading. Preserve the product
+names, beta status, requirement conflicts, data-boundary caveats, and source links. Use an empty
+string when the subsection is absent.
+
 The v3 report mirrors the reference HTML structure (report-v3-reference-multi-agent.html)
 exactly:
 
@@ -87,6 +92,8 @@ exactly:
   - considered-and-rejected; each unit with a non-null `model_recommendation` additionally
     gets the **"Why this model" card** — rationale visible, full model/migration detail in a
     collapsed `<details>`, all values from `unit.model_recommendation`)
+- After the §3 unit cards, include the managed-alternatives awareness note when present. It has
+  no scores and does not add a numbered top-level section.
 - **§4 Target architecture** (figure w/ per-unit entry points from `trigger` + figcap; **4.1
   component detail** table [Entry point from trigger / Compute / Model access / Supporting
   services]; **4.2 Security & networking** table [from the runtime cards' Serving & security
@@ -385,6 +392,11 @@ that element entirely (use `display:none` or omit the HTML block).
   </div>
 </div>
 {{ END FOR }}
+
+{{ IF MANAGED_ALTERNATIVES_HTML }}
+<h3>Managed alternatives (awareness only)</h3>
+<div class="callout">{{ MANAGED_ALTERNATIVES_HTML }}</div>
+{{ END IF }}
 
 <!-- ═══ 4. TARGET ARCHITECTURE ═══ -->
 <h2><span class="no">4.</span>Target architecture</h2>

--- a/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/generate/generate.md
+++ b/advisor/plugins/aws-startup-advisor/skills/agent-advisor/references/phases/generate/generate.md
@@ -27,6 +27,8 @@ _preconditions:
 _postconditions:
   - _check_file_exists: [diagram.md, recommendation.md, mini-brief.md, recommendation-report.html]
     _on_failure: _halt_and_inform
+  - _assert: "when the awareness IDs resolved in Step 1 are non-empty, recommendation.md, mini-brief.md, and recommendation-report.html include every managed alternative with its status and requirement conflicts; openai_agents_api retains the public-beta, US-only, and no-ZDR caveats including self-hosted execution; awareness does not add scored runtimes"
+    _on_failure: _halt_and_inform
   - _assert: "recommendation.md fills all 12 sections (business summary first, technical detail after) with the freshness footer; mini-brief.md carries the recommendation, top-3 signals, eliminated, model, and any io_wait/fedramp/region/cris notes set in design.json (a non-agent unit in a mixed system may show 'no model' when its model_recommendation is null); recommendation-report.html was generated (Step 5 is not optional); when design.json has >1 unit, recommendation.md contains the System topology section and the report one unit card per unit; every unit card whose design.json unit has a non-null model_recommendation contains the 'Why this model' card (rationale paragraph + collapsed 'Full model & migration detail' details block) rendered from unit.model_recommendation values, not invented"
     _on_failure: _halt_and_inform
   - _assert: "recommendation.md's architecture-diagram section carries diagram.md's content INLINE — the Mermaid fenced block itself (and the ASCII fallback when build_diagram.py produced one), copied verbatim. A pointer such as 'see diagram.md' does not satisfy it: the recommendation doc is read on its own, often as the only artifact a reader opens, and the diagram is the section's whole content"
@@ -49,6 +51,11 @@ winning runtime's service card and
 (Same exception as Design Step 2: a `serverless_workers` unit has NO `<verdict>.md` card — do not
 attempt to load one; derive its content from `temporal.md` + `poc-shapes.md`.)
 
+Read `design.json.managed_alternatives` as the awareness option IDs. Only when the array is absent,
+use `[design.json.managed_alternative]` if the legacy value is present and not `none`, otherwise
+use `[]`. An explicitly empty array stays empty. When IDs are present, also load
+`references/decision-refs/managed-alternatives.md`.
+
 ## Step 2 — Build the architecture diagram
 
 Load `references/diagram/build-diagram.md` and follow it to produce `$RUN_DIR/diagram.md`
@@ -70,6 +77,14 @@ For `migrate`: also fill Section 9 (Bedrock model) with the **coarse family mapp
 migration plugins — no dollar figures. Section 10 (cost magnitude) presents the per-unit
 target-state bands from estimate.json and notes that the migration TCO comparison and
 current-spend delta are produced by the migration plugins.
+
+**Section 5 — Managed alternatives:** when awareness IDs are present, append a subsection titled
+"Managed alternatives (awareness only)" after the scored alternatives. For each ID, use its
+reference section's product name, status, tradeoffs, and available source links. Include OpenAI
+Agents API's public-beta status, US-only data residency, and no-ZDR limit even for a self-hosted
+sandbox; identify any conflict with the customer's requirements. Keep this an awareness note:
+do not add these options to scores or the runtime ranking. Omit the subsection when the list is
+empty.
 
 **Section 3c — Temporal migration** (conditional: only if ANY
 `design.json.units[].workload_class == "temporal_worker_poll"` — the `temporal` block has no
@@ -114,6 +129,9 @@ TO `$RUN_DIR/mini-brief.md` (a file, not just chat text; Step 5.5 re-reads it):
   `[BLOCKS]`, evaluation mode, and live verification status. Never describe model access as
   runnable unless `live_verification.status == "passed"`.
 - Any `warnings` from the scoring result (e.g. 5 TPS).
+- When awareness IDs are present, summarize the managed alternatives from recommendation.md §5,
+  including any requirement conflict; retain the OpenAI public-beta, US-only, and no-ZDR caveats
+  when `openai_agents_api` is listed.
 - If `design.json` has `io_wait_tco_note == true`: the I/O-wait TCO point (AgentCore bills $0
   during model/human waits — a cost edge for spiky/HITL traffic; no dollar figures).
 - When set: `fedramp_note` (FedRAMP WIP — verify + GovCloud fallback),

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/decision-refs/managed-alternatives.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/decision-refs/managed-alternatives.md
@@ -11,6 +11,8 @@ Surface these as awareness with tradeoffs when the user is committed to a single
 
 ## Bedrock Managed Agents (OpenAI-committed)
 
+## OpenAI Agents API (public beta)
+
 - Available in us-east-1 and expanding.
 - If the customer needs model flexibility, governance, or code export → AgentCore wins.
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/decision-refs/managed-alternatives.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/decision-refs/managed-alternatives.md
@@ -11,10 +11,35 @@ Surface these as awareness with tradeoffs when the user is committed to a single
 
 ## Bedrock Managed Agents (OpenAI-committed)
 
-## OpenAI Agents API (public beta)
-
 - Available in us-east-1 and expanding.
 - If the customer needs model flexibility, governance, or code export → AgentCore wins.
+
+## OpenAI Agents API (public beta)
+
+Public beta announced 2026-09-10; this entry verified 2026-09-11.
+
+- OpenAI manages the Codex harness, session orchestration, context compaction, and recovery.
+  Durable sessions retain progress across turns; tools can include application functions and MCP
+  servers. Surface this option when an OpenAI-committed customer wants managed agent execution.
+- Execution can use an OpenAI-hosted sandbox or a self-hosted sandbox on the customer's
+  infrastructure. OpenAI still runs the harness with a self-hosted executor; this is a separate
+  OpenAI service, not Bedrock Managed Agents or an agent loop deployed through the Agents SDK.
+- Data boundary: currently supports data residency only in the United States and does not support
+  Zero Data Retention (ZDR). A self-hosted sandbox does not remove these limits. If either limit
+  conflicts with the customer's requirements, explain the mismatch rather than presenting this
+  option as suitable. Recheck the overview before relying on these beta constraints.
+- Operational responsibilities: for self-hosted execution, the customer manages workload isolation,
+  network restrictions, and executor credentials. Review these controls against the required
+  governance model; do not assume sandbox ownership puts OpenAI-managed sessions inside AWS.
+- Portability: session state and orchestration use the Agents API contract. Moving to another
+  runtime requires validating session and tool behavior; do not promise a drop-in migration or
+  assume that all state is non-exportable.
+
+Sources: [launch announcement](https://platform.openai.com/docs/changelog),
+[Agents API overview](https://developers.openai.com/api/docs/guides/agents-api/overview),
+[runtime comparison](https://developers.openai.com/api/docs/guides/agents),
+[self-hosted sandboxes](https://developers.openai.com/api/docs/guides/agents-api/environments/self-hosted),
+[sandbox security](https://developers.openai.com/api/docs/guides/agents-api/environments/security).
 
 ## Rule
 

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/design/design.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/design/design.md
@@ -26,6 +26,8 @@ _postconditions:
     _on_failure: _halt_and_inform
   - _validate_json: design.json
     _on_failure: _halt_and_inform
+  - _assert: "design.json records managed_alternatives and the legacy managed_alternative using the source/current-provider mapping in Step 4; awareness options do not change scores, eliminations, or the chosen runtime"
+    _on_failure: _halt_and_inform
   - _assert: "design.json has one units[] entry per inventory unit, a platform block consistent with confirm.platform_decision, and top-level legacy fields mirroring the primary unit; design.json has top-level verdict, chosen_runtime, deployment_model, agentcore_compute_type, agentcore_services, model_recommendation, and carries scores + eliminated (and blocking_constraints when present) copied verbatim from scoring-result.json; every agentcore-verdict unit carries agentcore_compute_type (microvms or instances) verbatim from its scoring result and every non-agentcore unit carries null — the compute type is never re-derived in Design; every model-bearing unit's model_recommendation is derived from the matching model-recommendation.json workload entry and accepted confirm.model_decision, including model_identity, model, api_path, invocation_model_id, source, source_analysis, feature_assessment, compatibility, architecture_impacts, additional_targets (separate-modality target contracts, carried verbatim when present), blocks, tuning, migration_deltas, evaluation, rollout, provisional verification, and live_verification when model-verification.json exists; no model was independently selected from scoring-result.json; handoff_required is true iff ANY unit's effective_runtime needs a compute handoff — one of ecs, eks, fargate, or batch (not just the primary/winning runtime; AgentCore/Lambda/Lambda MicroVMs are self-contained); when temporal units exist, design.json has a temporal block recording the Way, per-queue Tier 1 rule ids, and Serverless Workers labeled Public Preview regardless of any docs label; Workflow orchestration code is never rewritten; every unit carries a key_change line derived from its runtime's service card; every non-agent unit's verdict equals the runtime its workload-classes rule maps to (W1→eks/ecs; W2→batch; W3/W4→lambda; W5/W6→fargate) — verdict and workload_class are never contradictory; every unit carries an effective_runtime equal to platform.runtime when platform.mode is consolidated, else its own resolved runtime (a co_recommend unit resolves to its confirm chosen_runtime) — effective_runtime is always a concrete runtime enum, never the literal co_recommend"
     _on_failure: _halt_and_inform
 ---
@@ -68,11 +70,24 @@ values on failure. Record which succeeded vs fell back (for the freshness footer
 
 ## Step 4 — Provider lock-in check
 
-Determine the managed alternative from the source/current model provider: Claude-committed →
-`claude_managed`; OpenAI-committed → `bedrock_managed`; multi-provider or undecided → `none`.
-If a managed alternative applies, surface it **as awareness only** (per `managed-alternatives.md`)
-with its tradeoffs — do NOT present it as the recommendation. Otherwise note AgentCore supports
-all models.
+Determine the managed alternatives from the source/current model provider, not the recommended
+target model. Record both fields using this table:
+
+| Source/current provider     | `managed_alternatives`                     | Legacy `managed_alternative` |
+| --------------------------- | ------------------------------------------ | ---------------------------- |
+| Claude-committed            | `["claude_managed"]`                       | `claude_managed`             |
+| OpenAI-committed            | `["bedrock_managed", "openai_agents_api"]` | `bedrock_managed`            |
+| Multi-provider or undecided | `[]`                                       | `none`                       |
+
+The array records all awareness options; the singular field preserves the existing artifact
+contract. Map the IDs to the Claude Managed Agents, Bedrock Managed Agents, and OpenAI Agents API
+sections in `managed-alternatives.md`. Carry both fields into `design.json` for Generate.
+
+Surface each listed option **as awareness only**, with the reference's status and tradeoffs.
+For OpenAI Agents API, include the public-beta status and US-only data residency / no-ZDR limits,
+including with self-hosted execution; flag any conflict with the customer's requirements.
+Do not score these options or change the chosen runtime. For an empty array, omit the awareness
+note.
 
 ## Step 4b — I/O-wait TCO differentiator (surface proactively)
 
@@ -336,6 +351,7 @@ considered" and the "Eliminated" line (Generate reads design.json, not scoring-r
   "volatile_facts": {"microvms_session_cap": {"value": "8h", "source": "mcp|cached"},
                      "instances_session_cap": {"value": "14d", "source": "mcp|cached"}},
   "managed_alternative": "claude_managed | bedrock_managed | none",
+  "managed_alternatives": [...],
   "io_wait_tco_note": true|false,
   "fedramp_note": true|false,
   "region_availability_note": "... | null",

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate-report.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate-report.md
@@ -72,6 +72,11 @@ rules below.
 
 ## Step R1 — Section spec
 
+Set `MANAGED_ALTERNATIVES_HTML` to the HTML rendered from recommendation.md §5's
+"Managed alternatives (awareness only)" subsection, excluding its heading. Preserve the product
+names, beta status, requirement conflicts, data-boundary caveats, and source links. Use an empty
+string when the subsection is absent.
+
 The v3 report mirrors the reference HTML structure (report-v3-reference-multi-agent.html)
 exactly:
 
@@ -87,6 +92,8 @@ exactly:
   - considered-and-rejected; each unit with a non-null `model_recommendation` additionally
     gets the **"Why this model" card** — rationale visible, full model/migration detail in a
     collapsed `<details>`, all values from `unit.model_recommendation`)
+- After the §3 unit cards, include the managed-alternatives awareness note when present. It has
+  no scores and does not add a numbered top-level section.
 - **§4 Target architecture** (figure w/ per-unit entry points from `trigger` + figcap; **4.1
   component detail** table [Entry point from trigger / Compute / Model access / Supporting
   services]; **4.2 Security & networking** table [from the runtime cards' Serving & security
@@ -385,6 +392,11 @@ that element entirely (use `display:none` or omit the HTML block).
   </div>
 </div>
 {{ END FOR }}
+
+{{ IF MANAGED_ALTERNATIVES_HTML }}
+<h3>Managed alternatives (awareness only)</h3>
+<div class="callout">{{ MANAGED_ALTERNATIVES_HTML }}</div>
+{{ END IF }}
 
 <!-- ═══ 4. TARGET ARCHITECTURE ═══ -->
 <h2><span class="no">4.</span>Target architecture</h2>

--- a/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate.md
+++ b/migrate/plugins/migration-to-aws/skills/agent-advisor/references/phases/generate/generate.md
@@ -27,6 +27,8 @@ _preconditions:
 _postconditions:
   - _check_file_exists: [diagram.md, recommendation.md, mini-brief.md, recommendation-report.html]
     _on_failure: _halt_and_inform
+  - _assert: "when the awareness IDs resolved in Step 1 are non-empty, recommendation.md, mini-brief.md, and recommendation-report.html include every managed alternative with its status and requirement conflicts; openai_agents_api retains the public-beta, US-only, and no-ZDR caveats including self-hosted execution; awareness does not add scored runtimes"
+    _on_failure: _halt_and_inform
   - _assert: "recommendation.md fills all 12 sections (business summary first, technical detail after) with the freshness footer; mini-brief.md carries the recommendation, top-3 signals, eliminated, model, and any io_wait/fedramp/region/cris notes set in design.json (a non-agent unit in a mixed system may show 'no model' when its model_recommendation is null); recommendation-report.html was generated (Step 5 is not optional); when design.json has >1 unit, recommendation.md contains the System topology section and the report one unit card per unit; every unit card whose design.json unit has a non-null model_recommendation contains the 'Why this model' card (rationale paragraph + collapsed 'Full model & migration detail' details block) rendered from unit.model_recommendation values, not invented"
     _on_failure: _halt_and_inform
   - _assert: "recommendation.md's architecture-diagram section carries diagram.md's content INLINE — the Mermaid fenced block itself (and the ASCII fallback when build_diagram.py produced one), copied verbatim. A pointer such as 'see diagram.md' does not satisfy it: the recommendation doc is read on its own, often as the only artifact a reader opens, and the diagram is the section's whole content"
@@ -49,6 +51,11 @@ winning runtime's service card and
 (Same exception as Design Step 2: a `serverless_workers` unit has NO `<verdict>.md` card — do not
 attempt to load one; derive its content from `temporal.md` + `poc-shapes.md`.)
 
+Read `design.json.managed_alternatives` as the awareness option IDs. Only when the array is absent,
+use `[design.json.managed_alternative]` if the legacy value is present and not `none`, otherwise
+use `[]`. An explicitly empty array stays empty. When IDs are present, also load
+`references/decision-refs/managed-alternatives.md`.
+
 ## Step 2 — Build the architecture diagram
 
 Load `references/diagram/build-diagram.md` and follow it to produce `$RUN_DIR/diagram.md`
@@ -70,6 +77,14 @@ For `migrate`: also fill Section 9 (Bedrock model) with the **coarse family mapp
 migration plugins — no dollar figures. Section 10 (cost magnitude) presents the per-unit
 target-state bands from estimate.json and notes that the migration TCO comparison and
 current-spend delta are produced by the migration plugins.
+
+**Section 5 — Managed alternatives:** when awareness IDs are present, append a subsection titled
+"Managed alternatives (awareness only)" after the scored alternatives. For each ID, use its
+reference section's product name, status, tradeoffs, and available source links. Include OpenAI
+Agents API's public-beta status, US-only data residency, and no-ZDR limit even for a self-hosted
+sandbox; identify any conflict with the customer's requirements. Keep this an awareness note:
+do not add these options to scores or the runtime ranking. Omit the subsection when the list is
+empty.
 
 **Section 3c — Temporal migration** (conditional: only if ANY
 `design.json.units[].workload_class == "temporal_worker_poll"` — the `temporal` block has no
@@ -114,6 +129,9 @@ TO `$RUN_DIR/mini-brief.md` (a file, not just chat text; Step 5.5 re-reads it):
   `[BLOCKS]`, evaluation mode, and live verification status. Never describe model access as
   runnable unless `live_verification.status == "passed"`.
 - Any `warnings` from the scoring result (e.g. 5 TPS).
+- When awareness IDs are present, summarize the managed alternatives from recommendation.md §5,
+  including any requirement conflict; retain the OpenAI public-beta, US-only, and no-ZDR caveats
+  when `openai_agents_api` is listed.
 - If `design.json` has `io_wait_tco_note == true`: the I/O-wait TCO point (AgentCore bills $0
   during model/human waits — a cost edge for spiky/HITL traffic; no dollar figures).
 - When set: `fedramp_note` (FedRAMP WIP — verify + GovCloud fallback),

--- a/mise.toml
+++ b/mise.toml
@@ -68,6 +68,7 @@ run = [
   "node --test migrate/plugins/migration-to-aws/tests/tools/frontmatter-validator.test.ts",
   "node --test advisor/plugins/aws-startup-advisor/tests/tools/frontmatter-validator.test.ts",
   "node --test tests/heroku-eb-runtime-settings.test.ts",
+  "node --test tests/agent-managed-alternatives.test.ts",
 ]
 
 [tasks."lint:model-ids"]

--- a/tests/agent-managed-alternatives.test.ts
+++ b/tests/agent-managed-alternatives.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const PLUGINS = [
+  "migrate/plugins/migration-to-aws",
+  "advisor/plugins/aws-startup-advisor",
+];
+
+function read(plugin: string, file: string): string {
+  return readFileSync(
+    join(plugin, "skills/agent-advisor/references", file),
+    "utf8",
+  );
+}
+
+function section(text: string, heading: string): string {
+  const start = text.indexOf(`## ${heading}\n`);
+  assert.notEqual(start, -1, `missing section: ${heading}`);
+  const bodyStart = start + `## ${heading}\n`.length;
+  const end = text.indexOf("\n## ", bodyStart);
+  return text.slice(bodyStart, end === -1 ? undefined : end).trim();
+}
+
+for (const plugin of PLUGINS) {
+  describe(`${plugin}: managed agent alternatives`, () => {
+    const card = read(plugin, "decision-refs/managed-alternatives.md");
+    const design = read(plugin, "phases/design/design.md");
+    const generate = read(plugin, "phases/generate/generate.md");
+    const report = read(plugin, "phases/generate/generate-report.md");
+
+    it("keeps the Bedrock region and recommendation in the Bedrock section", () => {
+      const bedrock = section(card, "Bedrock Managed Agents (OpenAI-committed)");
+      const openai = section(card, "OpenAI Agents API (public beta)");
+      assert.match(bedrock, /Available in us-east-1 and expanding/);
+      assert.match(bedrock, /model flexibility, governance, or code export/);
+      assert.doesNotMatch(openai, /us-east-1|AgentCore wins/);
+    });
+
+    it("grounds the new offering's boundary in current vendor documentation", () => {
+      const openai = section(card, "OpenAI Agents API (public beta)").replace(/\s+/g, " ");
+      assert.match(openai, /2026-09-10/);
+      assert.match(openai, /United States/);
+      assert.match(openai, /does not support Zero Data Retention/);
+      assert.match(openai, /self-hosted sandbox does not remove these limits/);
+      assert.match(openai, /OpenAI still runs the harness/);
+      assert.match(openai, /developers\.openai\.com\/api\/docs\/guides\/agents-api\/overview/);
+      assert.match(openai, /developers\.openai\.com\/api\/docs\/guides\/agents-api\/environments\/security/);
+    });
+
+    it("records both OpenAI options without changing the legacy provider mapping", () => {
+      const lockIn = section(design, "Step 4 — Provider lock-in check");
+      const rows = lockIn.split("\n").filter((line) => line.startsWith("| "));
+      const expected = [
+        ["Claude-committed", ["claude_managed"], "claude_managed"],
+        ["OpenAI-committed", ["bedrock_managed", "openai_agents_api"], "bedrock_managed"],
+        ["Multi-provider or undecided", [], "none"],
+      ] as const;
+      for (const [provider, ids, legacy] of expected) {
+        const row = rows.find((line) => line.split("|")[1].trim() === provider);
+        assert.ok(row, `missing provider row: ${provider}`);
+        const cells = row.split("|").slice(1, -1).map((cell) => cell.trim().replaceAll("`", ""));
+        assert.deepEqual(JSON.parse(cells[1]), ids);
+        assert.equal(cells[2], legacy);
+      }
+      assert.match(design, /"managed_alternatives":/);
+      assert.match(design, /"managed_alternative": "claude_managed \| bedrock_managed \| none"/);
+    });
+
+    it("carries awareness into the document and report without treating it as scoring", () => {
+      assert.match(generate, /managed_alternatives/);
+      assert.match(generate, /Only when the array is absent/);
+      assert.match(generate, /An explicitly empty array stays empty/);
+      assert.match(generate, /decision-refs\/managed-alternatives\.md/);
+      assert.match(generate, /Section 5 — Managed alternatives/);
+      assert.match(generate, /do not add these options to scores or the runtime ranking/);
+      const brief = section(
+        generate,
+        "Step 4.5 — Write the mini-brief to `$RUN_DIR/mini-brief.md` (delivered by the Step 5.5 sidebar)",
+      );
+      assert.match(brief, /managed alternatives/);
+      assert.match(brief, /public-beta, US-only, and no-ZDR/);
+      assert.match(report, /MANAGED_ALTERNATIVES_HTML[\s\S]*recommendation\.md §5/);
+      assert.match(report, /IF MANAGED_ALTERNATIVES_HTML/);
+      assert.match(report, /Managed alternatives \(awareness only\)/);
+    });
+  });
+}


### PR DESCRIPTION
The original patch inserted an empty OpenAI Agents API heading above the existing Bedrock bullets, assigning Bedrock's region and selection guidance to the wrong product. This change restores the Bedrock section and adds sourced OpenAI Agents API guidance covering its public beta, managed harness, sandbox options, data residency, retention, operational responsibilities, and portability considerations.

Design records both managed options for OpenAI-committed users in `managed_alternatives`, while preserving the existing singular field for compatibility. Generate carries the awareness note into the recommendation, mini-brief, and HTML report, including requirement conflicts. These options do not participate in runtime scoring.

Both plugin copies are updated. Official sources and the verification date are recorded in the reference.

Validation:

- 144 local Node tests passed, including 8 new regressions covering section ownership, provider mappings, and output contracts.
- The new regression suite fails against the original PR content and passes with this patch.
- Markdown lint passed for 891 files; formatting, agent-advisor frontmatter validation, cross-plugin drift, and `git diff --check` passed.
- Validation covers reference and generation contracts. A live Agents API call and an end-to-end advisor generation run were not performed.
