### PR TITLE
feat(llm-to-bedrock): accept Decide-complete as sufficient Assess handoff

### DIFF
--- a/advisor/plugins/aws-startup-advisor/skills/llm-to-bedrock/SKILL.md
+++ b/advisor/plugins/aws-startup-advisor/skills/llm-to-bedrock/SKILL.md
@@ -70,10 +70,11 @@ if you're on one of those and this fails, that is the likely cause. If the Skill
 Phase A's A1 step fails or no such mechanism exists on your agent, this skill still has no
 fallback: tell the user plainly that this agent cannot chain into `gcp-to-aws` automatically,
 and ask them to invoke `gcp-to-aws` themselves directly (e.g. "migrate my AI workload to AWS")
-to run Discover through Generate, then come back to this skill once its `generate` phase is
-`completed` (checked in A2) to continue with the SDK rewrite. This is a manual two-step
-workaround for a missing agent capability, not an automated fallback — do not present it to
-the user as this skill "handling it."
+to run Discover through Design (accepting the decision pack is enough — they do not need to
+generate infra Terraform), then come back to this skill once its Assess artifacts are ready
+(the decision pack is done, or `generate` is `completed`; checked in A2) to continue with the
+SDK rewrite. This is a manual two-step workaround for a missing agent capability, not an
+automated fallback — do not present it to the user as this skill "handling it."
 
 ---
 
@@ -130,8 +131,10 @@ Before invoking, tell the user:
 > GCP or infrastructure component, which is how it's being used here.)"
 
 After invoking the Skill tool, the `gcp-to-aws` skill instructions will load into context.
-Follow those instructions exactly — they will drive the Discover, Clarify, Design, Estimate,
-and Generate phases. The source code to scan is at `$REPO`.
+Follow those instructions exactly — they will drive the Discover, Clarify, Design, and Estimate
+phases through to the decision pack. The source code to scan is at `$REPO`. You do **not** need
+`gcp-to-aws` to run its **Generate** (infra Terraform) phase — that is opt-in and produces nothing
+this SDK rewrite reads; stopping at the decision pack is enough (A2 confirms readiness).
 
 **Important context for the gcp-to-aws skill execution:**
 
@@ -147,22 +150,72 @@ and Generate phases. The source code to scan is at `$REPO`.
 ### A2 — Wait for Assess completion
 
 The `gcp-to-aws` skill is a state machine. After each phase completes, it may stop and wait
-for the next invocation. Check progress against the LATEST run directory only (older
-`.migration/` runs may contain a stale "completed" status):
+for the next invocation. This skill only needs the **Assess artifacts** (`aws-design-ai.json`
+from Design, `ai-workload-profile.json` from Discover, `preferences.json` from Clarify) — it
+never reads anything Generate produces (Terraform, `MIGRATION_GUIDE.md`, `migration-report.html`).
+Those artifacts are all on disk once **Design** completes, so for a pure AI/SDK rewrite you do
+**not** need `gcp-to-aws` to run its infra Generate phase. The check below emits `assess-ready`
+when **any** of these hold (in this order):
+
+1. **Design done + artifact present** — `phases.design == "completed"` AND `aws-design-ai.json`
+   exists. This is the ground truth for the AI path: Design's own completion gate has passed, so
+   the model mapping is real, not mid-authoring. (Existence alone is **not** enough — `design-ai.md`
+   writes the JSON, and Discover/Clarify wrote their two files even earlier, all **before**
+   `design.md` stamps `phases.design`; so a bare "all three files exist" would fire mid-Design.
+   Requiring `phases.design == "completed"` is what closes that early-fire window.) This also
+   covers the `legacy-generate` back-compat state in `gcp-to-aws/SKILL.md`, which is only reachable
+   after Design and therefore already has `phases.design == "completed"`.
+2. **Decide-complete** — `current_phase == "complete"` AND `run_mode == "decide"` AND
+   `phases.generate == "pending"` AND `DECISION.md` on disk (the normal AI-path end state).
+3. **Generate-complete** — `phases.generate == "completed"` (the user also chose to generate infra).
+
+Check progress against the LATEST run directory only (older `.migration/` runs may contain a
+stale status):
 
 ```bash
 MIGRATION_DIR=$(ls -td "$REPO/.migration"/*/ 2>/dev/null | head -1)
 # Stdlib-only JSON read — no boto3, so bare python3 is fine here (no pinned env needed).
-python3 -c "import json,sys; print(json.load(open('$MIGRATION_DIR/.phase-status.json'))['phases'].get('generate','missing'))" 2>/dev/null || echo "no-status-file"
+# Emit one token: assess-ready / not-ready / no-status-file. Ground truth is the Assess the AI
+# path actually consumes (see the three conditions above); the phase-status tuples are fallbacks.
+python3 - "$MIGRATION_DIR" <<'PY' 2>/dev/null || echo "no-status-file"
+import json, os, sys
+d = sys.argv[1]
+if not d:
+    print("no-status-file"); sys.exit()
+def has(f): return os.path.exists(os.path.join(d, f))
+try:
+    s = json.load(open(os.path.join(d, ".phase-status.json")))
+except Exception:
+    # No readable status file, but the design artifact alone is not trusted (may be mid-Design);
+    # without the status we cannot confirm Design's gate passed.
+    print("no-status-file" if not has("aws-design-ai.json") else "not-ready"); sys.exit()
+ph = s.get("phases", {})
+# phases.design == completed means Design's completion gate passed, so aws-design-ai.json is
+# final (not mid-authoring). This also covers the legacy-generate state, which is only reachable
+# after Design. Do NOT accept a bare "all three files exist" — Discover/Clarify write their two
+# files early, and design-ai.md writes aws-design-ai.json BEFORE the gate, so three-files-present
+# fires mid-Design (the early-fire case). A3 remains the artifact-completeness backstop.
+design_done = ph.get("design") == "completed" and has("aws-design-ai.json")
+generate_done = ph.get("generate") == "completed"
+decide_done = (
+    s.get("current_phase") == "complete"
+    and s.get("run_mode") == "decide"
+    and ph.get("generate") == "pending"
+    and has("DECISION.md")
+)
+print("assess-ready" if (design_done or generate_done or decide_done) else "not-ready")
+PY
 ```
 
-- `completed` → proceed to A3.
-- Anything else (including `no-status-file`) → the skill needs to run again. Re-invoke
-  `aws-startup-advisor:gcp-to-aws` via the Skill tool — it picks up where it left off.
+- `assess-ready` → proceed to A3 (Assess is done whether or not infra Generate ran). A3 still
+  verifies the specific files before Execute reads them.
+- `not-ready` / `no-status-file` → the skill needs to run again. Re-invoke
+  `aws-startup-advisor:gcp-to-aws` via the Skill tool — it picks up where it left off. (You do
+  not need to push it all the way to Generate; stopping at the decision pack is enough.)
 
-**Cap: at most 6 re-invocations.** If `generate` is still not `completed` after 6, stop and
-show the user the last status output — the Assess skill is stuck and needs manual attention;
-looping further just burns context.
+**Cap: at most 6 re-invocations.** If it is still `not-ready` after 6, stop and show the user
+the last status output — the Assess skill is stuck and needs manual attention; looping further
+just burns context.
 
 ### A3 — Locate Assess output
 
@@ -172,14 +225,16 @@ Find `$MIGRATION_DIR` (the `.migration/<MMDD-HHMM>/` directory that was created)
 ls -td "$REPO/.migration"/*/ 2>/dev/null | head -1
 ```
 
-Verify these files exist in `$MIGRATION_DIR`:
+Verify **all three** of these files exist in `$MIGRATION_DIR` (Phase B reads every one):
 
 - `aws-design-ai.json` (model mapping + architecture)
 - `ai-workload-profile.json` (detected workloads)
 - `preferences.json` (user preferences from Clarify)
 
-If `aws-design-ai.json` is missing, Assess did not complete the AI path correctly. Show the
-error and stop.
+If **any** of the three is missing, Assess did not complete the AI path correctly — name the
+missing file(s), show the error, and stop. (A2 can now report `assess-ready` from the design
+file + `phases.design` alone, so this step is the backstop that guarantees the other two
+artifacts Phase B needs are actually present before Execute reads them.)
 
 ---
 

--- a/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/SKILL.md
+++ b/migrate/plugins/migration-to-aws/skills/llm-to-bedrock/SKILL.md
@@ -67,10 +67,11 @@ on one of those and this fails, that is the likely cause. If the Skill tool call
 A1 step fails or no such mechanism exists on your agent, this skill still has no fallback:
 tell the user plainly that this agent cannot chain into `gcp-to-aws` automatically, and ask
 them to invoke `gcp-to-aws` themselves directly (e.g. "migrate my AI workload to AWS") to run
-Discover through Generate, then come back to this skill once its `generate` phase is
-`completed` (checked in A2) to continue with the SDK rewrite. This is a manual two-step
-workaround for a missing agent capability, not an automated fallback — do not present it to
-the user as this skill "handling it."
+Discover through Design (accepting the decision pack is enough — they do not need to generate
+infra Terraform), then come back to this skill once its Assess artifacts are ready (the
+decision pack is done, or `generate` is `completed`; checked in A2) to continue with the SDK
+rewrite. This is a manual two-step workaround for a missing agent capability, not an automated
+fallback — do not present it to the user as this skill "handling it."
 
 ---
 
@@ -127,8 +128,10 @@ Before invoking, tell the user:
 > GCP or infrastructure component, which is how it's being used here.)"
 
 After invoking the Skill tool, the `gcp-to-aws` skill instructions will load into context.
-Follow those instructions exactly — they will drive the Discover, Clarify, Design, Estimate,
-and Generate phases. The source code to scan is at `$REPO`.
+Follow those instructions exactly — they will drive the Discover, Clarify, Design, and Estimate
+phases through to the decision pack. The source code to scan is at `$REPO`. You do **not** need
+`gcp-to-aws` to run its **Generate** (infra Terraform) phase — that is opt-in and produces nothing
+this SDK rewrite reads; stopping at the decision pack is enough (A2 confirms readiness).
 
 **Important context for the gcp-to-aws skill execution:**
 
@@ -144,22 +147,72 @@ and Generate phases. The source code to scan is at `$REPO`.
 ### A2 — Wait for Assess completion
 
 The `gcp-to-aws` skill is a state machine. After each phase completes, it may stop and wait
-for the next invocation. Check progress against the LATEST run directory only (older
-`.migration/` runs may contain a stale "completed" status):
+for the next invocation. This skill only needs the **Assess artifacts** (`aws-design-ai.json`
+from Design, `ai-workload-profile.json` from Discover, `preferences.json` from Clarify) — it
+never reads anything Generate produces (Terraform, `MIGRATION_GUIDE.md`, `migration-report.html`).
+Those artifacts are all on disk once **Design** completes, so for a pure AI/SDK rewrite you do
+**not** need `gcp-to-aws` to run its infra Generate phase. The check below emits `assess-ready`
+when **any** of these hold (in this order):
+
+1. **Design done + artifact present** — `phases.design == "completed"` AND `aws-design-ai.json`
+   exists. This is the ground truth for the AI path: Design's own completion gate has passed, so
+   the model mapping is real, not mid-authoring. (Existence alone is **not** enough — `design-ai.md`
+   writes the JSON, and Discover/Clarify wrote their two files even earlier, all **before**
+   `design.md` stamps `phases.design`; so a bare "all three files exist" would fire mid-Design.
+   Requiring `phases.design == "completed"` is what closes that early-fire window.) This also
+   covers the `legacy-generate` back-compat state in `gcp-to-aws/SKILL.md`, which is only reachable
+   after Design and therefore already has `phases.design == "completed"`.
+2. **Decide-complete** — `current_phase == "complete"` AND `run_mode == "decide"` AND
+   `phases.generate == "pending"` AND `DECISION.md` on disk (the normal AI-path end state).
+3. **Generate-complete** — `phases.generate == "completed"` (the user also chose to generate infra).
+
+Check progress against the LATEST run directory only (older `.migration/` runs may contain a
+stale status):
 
 ```bash
 MIGRATION_DIR=$(ls -td "$REPO/.migration"/*/ 2>/dev/null | head -1)
 # Stdlib-only JSON read — no boto3, so bare python3 is fine here (no pinned env needed).
-python3 -c "import json,sys; print(json.load(open('$MIGRATION_DIR/.phase-status.json'))['phases'].get('generate','missing'))" 2>/dev/null || echo "no-status-file"
+# Emit one token: assess-ready / not-ready / no-status-file. Ground truth is the Assess the AI
+# path actually consumes (see the three conditions above); the phase-status tuples are fallbacks.
+python3 - "$MIGRATION_DIR" <<'PY' 2>/dev/null || echo "no-status-file"
+import json, os, sys
+d = sys.argv[1]
+if not d:
+    print("no-status-file"); sys.exit()
+def has(f): return os.path.exists(os.path.join(d, f))
+try:
+    s = json.load(open(os.path.join(d, ".phase-status.json")))
+except Exception:
+    # No readable status file, but the design artifact alone is not trusted (may be mid-Design);
+    # without the status we cannot confirm Design's gate passed.
+    print("no-status-file" if not has("aws-design-ai.json") else "not-ready"); sys.exit()
+ph = s.get("phases", {})
+# phases.design == completed means Design's completion gate passed, so aws-design-ai.json is
+# final (not mid-authoring). This also covers the legacy-generate state, which is only reachable
+# after Design. Do NOT accept a bare "all three files exist" — Discover/Clarify write their two
+# files early, and design-ai.md writes aws-design-ai.json BEFORE the gate, so three-files-present
+# fires mid-Design (the early-fire case). A3 remains the artifact-completeness backstop.
+design_done = ph.get("design") == "completed" and has("aws-design-ai.json")
+generate_done = ph.get("generate") == "completed"
+decide_done = (
+    s.get("current_phase") == "complete"
+    and s.get("run_mode") == "decide"
+    and ph.get("generate") == "pending"
+    and has("DECISION.md")
+)
+print("assess-ready" if (design_done or generate_done or decide_done) else "not-ready")
+PY
 ```
 
-- `completed` → proceed to A3.
-- Anything else (including `no-status-file`) → the skill needs to run again. Re-invoke
-  `migration-to-aws:gcp-to-aws` via the Skill tool — it picks up where it left off.
+- `assess-ready` → proceed to A3 (Assess is done whether or not infra Generate ran). A3 still
+  verifies the specific files before Execute reads them.
+- `not-ready` / `no-status-file` → the skill needs to run again. Re-invoke
+  `migration-to-aws:gcp-to-aws` via the Skill tool — it picks up where it left off. (You do
+  not need to push it all the way to Generate; stopping at the decision pack is enough.)
 
-**Cap: at most 6 re-invocations.** If `generate` is still not `completed` after 6, stop and
-show the user the last status output — the Assess skill is stuck and needs manual attention;
-looping further just burns context.
+**Cap: at most 6 re-invocations.** If it is still `not-ready` after 6, stop and show the user
+the last status output — the Assess skill is stuck and needs manual attention; looping further
+just burns context.
 
 ### A3 — Locate Assess output
 
@@ -169,14 +222,16 @@ Find `$MIGRATION_DIR` (the `.migration/<MMDD-HHMM>/` directory that was created)
 ls -td "$REPO/.migration"/*/ 2>/dev/null | head -1
 ```
 
-Verify these files exist in `$MIGRATION_DIR`:
+Verify **all three** of these files exist in `$MIGRATION_DIR` (Phase B reads every one):
 
 - `aws-design-ai.json` (model mapping + architecture)
 - `ai-workload-profile.json` (detected workloads)
 - `preferences.json` (user preferences from Clarify)
 
-If `aws-design-ai.json` is missing, Assess did not complete the AI path correctly. Show the
-error and stop.
+If **any** of the three is missing, Assess did not complete the AI path correctly — name the
+missing file(s), show the error, and stop. (A2 can now report `assess-ready` from the design
+file + `phases.design` alone, so this step is the backstop that guarantees the other two
+artifacts Phase B needs are actually present before Execute reads them.)
 
 ---
 


### PR DESCRIPTION
## Problem

`llm-to-bedrock` handles a narrow job: rewrite an app's OpenAI/Gemini/Anthropic calls to use Amazon Bedrock. It doesn't do its own analysis of the codebase — it hands that "assess the app" step to the `gcp-to-aws` skill, waits for it to finish, then reads a few files it produced and starts rewriting.

The problem was in *how it decided the assess step was finished*. It waited for `gcp-to-aws` to fully **generate infrastructure** (all the Terraform) — but generating infrastructure is optional in `gcp-to-aws`, and it's completely irrelevant to an SDK rewrite. A normal assessment run stops earlier, at the point where it has produced its recommendation, without generating any infrastructure.

Two things went wrong as a result:

1. **It demanded a step that isn't needed.** Everything `llm-to-bedrock` actually reads is ready as soon as the design work is done — none of it comes from the infrastructure-generation step. So insisting on that step forced users through infra generation they'd never use for a pure code rewrite.
2. **It looped pointlessly.** A run that correctly stopped at the recommendation looked "not finished" to `llm-to-bedrock`, so it kept re-invoking `gcp-to-aws` (up to 6 times) trying to reach a state that run was never going to reach.

An earlier PR (#260) fixed the surrounding wiring; this PR is the remaining piece — letting "the recommendation is done" count as a finished assessment.

<details><summary>In code, for reviewers</summary>

`llm-to-bedrock` delegates Assess to `gcp-to-aws` and waits at its **A2 gate**. A2 required `phases.generate == "completed"`, but `gcp-to-aws`'s Generate is opt-in; a normal AI-path run ends at the decision pack (`run_mode: "decide"`, `current_phase: "complete"`, `phases.generate: "pending"`). The three artifacts Execute consumes — `aws-design-ai.json` (Design), `ai-workload-profile.json` (Discover), `preferences.json` (Clarify) — are all present once Design completes; nothing it reads comes from Generate. So the gate over-required, and an AI-path run that stopped at the decision pack read as "not done," re-invoking `gcp-to-aws` up to its 6× cap. #260 landed the explanation + presence-check + manual-handoff; this PR is the decoupling — accept Decide-complete as a sufficient handoff.
</details>

## Solution

Make A2 key on **the Assess the AI path actually consumes** as ground truth, with the phase-status tuples as fallbacks. The gate emits one token — `assess-ready` / `not-ready` / `no-status-file` — and is `assess-ready` when **any** of these hold, in order:

1. **Design done + artifact present** — `phases.design == "completed"` AND `aws-design-ai.json` exists. Design's own completion gate has passed, so the model mapping is real. (Existence *alone* is not trusted: `design-ai.md` writes the JSON — and Discover/Clarify wrote their two files even earlier — all **before** `design.md` stamps `phases.design`, so a bare "all three files exist" check would fire mid-Design. Requiring `phases.design == "completed"` is what closes that early-fire window.) This also covers the `legacy-generate` back-compat state, which is only reachable after Design and so already has `phases.design == "completed"`.
2. **Decide-complete** — `current_phase == "complete"` AND `run_mode == "decide"` AND `phases.generate == "pending"` AND `DECISION.md` on disk (the normal AI-path end state).
3. **Generate-complete** — `phases.generate == "completed"` (user also chose to generate infra).

Genuinely incomplete runs (no design yet) stay `not-ready`; a design file **without** a readable status (can't confirm the gate passed) is `not-ready`. Stdlib-only `python3` heredoc — no new dependencies.

Two supporting fixes so the whole path is consistent:
- **A1** no longer tells the agent to drive `gcp-to-aws` through **Generate** — it drives Discover→Design/decision pack; Generate is opt-in and not needed for the SDK rewrite.
- **A3** now fails closed if **any** of the three Assess artifacts is missing (not just `aws-design-ai.json`) — the backstop now that A2 can report ready on the design file + `phases.design` alone. Phase B reads all three.

The manual-handoff prose (for agents without the Skill tool) is updated to match: run Discover through **Design**, the decision pack is enough, no infra Generate needed.

**Verified the gate matches the emitter:** `gcp-to-aws` `estimate.md` (decision gate) writes `DECISION.md`/`decision-report.html` and then sets `run_mode: "decide"`, `current_phase: "complete"` with `phases.generate` staying `"pending"` — exactly the tuple A2 now recognizes. The SSOT state table (`gcp-to-aws/SKILL.md`) defines decide-complete as that same tuple.

**Unchanged:** the hard `gcp-to-aws` dependency and the Step 0b presence-check (#260); Execute still verifies its required Assess artifacts in A3 before reading them; the 6-invocation cap; `uv` prereq wording.

## Type of Change
- [ ] New plugin/power/tool
- [ ] Bug fix
- [x] Enhancement to existing content
- [ ] Guardrail/CI update

## Team Folder
- [x] `advisor/`
- [x] `migrate/`
- [ ] `solution-architecture/`
- [ ] Other: ___

## Verification
- `cross-plugin-drift.ts`: **OK** (273 identical, 25 allowlisted — no new drift; the two SKILL.md twins differ only by the allowlisted namespace/install strings, and the A2 logic is byte-identical after namespace normalization)
- A2 gate logic probed against eight `.phase-status.json` states: design-done+artifact → `assess-ready`; **early-fire (design mid-flight, all three files present) → `not-ready`**; legacy-generate (design done) → `assess-ready`; decide-complete → `assess-ready`; generate-complete → `assess-ready`; mid-clarify (two files, design in progress) → `not-ready`; design file with no readable status → `not-ready`; missing dir → `no-status-file`
- Gate-vs-emitter agreement: A2's decide-complete tuple matches what `gcp-to-aws` `estimate.md` writes at the decision gate and the `gcp-to-aws/SKILL.md` state table
- `frontmatter-validator` / `markdownlint` / `dprint`: clean (both trees)
- `mise run build` (full composite incl. `bandit`/`semgrep`/`gitleaks`/`checkov`/`grype`): **PASS, exit 0** — run against a fresh detached worktree at this branch's commit. checkov 276/0; gitleaks no leaks; grype no vulnerabilities.

Not run locally: no live cross-skill run (no end-to-end `gcp-to-aws` → `llm-to-bedrock` invocation) — the change is prose + a stdlib status read; behavior verified by probing the gate logic against constructed `.phase-status.json` fixtures.

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] My changes do not include hardcoded secrets, credentials, or internal-only content
- [x] I have run `mise run build` locally and it passes — verified against a fresh worktree at this branch's commit (see Verification)
- [x] I have updated documentation if needed (the change is in the skill instructions themselves)
- [x] My changes are scoped to my team's folder only (`advisor/` + `migrate/` migration skills)



